### PR TITLE
v0.5.50: Migration Safety & Correctness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ opsdesk/
 
 # Internal security matrix — keep private; see security/security_matrix.example.yml
 security/security_matrix.yml
+
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,78 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## Unreleased — v0.5.50 Migration Safety & Correctness
+
+Migrations apply safely and consistently across every entry point, the integrity
+of already-applied migrations is verified, and the SQL the framework generates is
+hardened. The migration file format is unchanged and no action is required on
+existing projects.
+
+### Migration execution safety
+
+- Python migrations are transactional — every operation and the recording of the
+  migration run in one transaction and roll back together on failure.
+- SQL migrations execute statement-by-statement inside that same transaction, so
+  multi-statement files apply completely.
+- Applying migrations acquires a PostgreSQL advisory lock so two processes cannot
+  migrate at the same time; the lock is always released.
+- The migration dependency graph detects circular dependencies and reports the
+  cycle clearly.
+
+### Migration integrity
+
+- Python and SQL migrations store a checksum when applied.
+- Already-applied migrations are verified against their stored checksum before new
+  migrations run; a mismatch fails with the migration name and next steps.
+- Historical rows with no stored checksum remain valid and produce a warning, not
+  an error.
+- Generated migrations that add a non-null field without a default include a
+  warning comment pointing to a safe rollout (temporary default, backfill, or a
+  nullable-first data migration). Primary keys are exempt.
+
+### Failure reporting
+
+- Migration graph loading is strict by default — a file that cannot be loaded
+  raises a clear error instead of being silently skipped.
+- When a migration fails, the pending migrations that were skipped are reported,
+  and the CLI shows them.
+
+### SQL-generation guardrails
+
+- Many-to-many join-table constraint names are deterministic, quoted, and bounded
+  to PostgreSQL's identifier length limit; source/target columns are quoted.
+- Partial-index `where` predicates are validated for obvious unsafe patterns.
+- Array field SQL types are validated against an allowlist and normalised.
+  `ArrayField(sql_type="text[]")` now normalises to `"TEXT[]"`.
+
+### Unified execution path
+
+- `aksara migrate` and the testing helpers apply migrations through the same
+  canonical executor, so CLI and test runs get the same transactions, advisory
+  lock, SQL splitting, checksum recording, and checksum verification. The dry-run
+  preview path is unchanged.
+
+### Compatibility notes
+
+- The migration file format is unchanged; existing migrations are not
+  re-generated or altered.
+- Legacy CLI helpers (`MIGRATION_TABLE_SQL`, `compute_checksum`,
+  `ensure_migrations_table`, `get_applied_migrations`, `record_migration`) remain
+  importable from `aksara.cli.main` as compatibility shims; new code should import
+  from `aksara.migrations.executor`.
+
+### Deferred work
+
+These migration-metadata items are intentionally not part of this patch:
+
+- Migration metadata schema versioning (`schema_version` column).
+- App-label / name identity split (`app_label` column and `UNIQUE(app_label, name)`).
+- Automatic checksum backfill for historical rows (unsafe to automate — it would
+  bless already-edited files and defeat tamper detection).
+- A dedicated migration verify/backfill command.
+
+---
+
 ## v0.5.49 — Security Hardening & Release Trust
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,11 @@ existing projects.
 ### Unified execution path
 
 - `aksara migrate` and the testing helpers apply migrations through the same
-  canonical executor, so CLI and test runs get the same transactions, advisory
-  lock, SQL splitting, checksum recording, and checksum verification. The dry-run
-  preview path is unchanged.
+  canonical executor, so file-based CLI and test runs get the same transactions,
+  advisory lock, SQL splitting, checksum recording, and checksum verification.
+  The legacy model-based CLI fallback remains for bootstrap scenarios and does
+  not provide the full file-based migration integrity model. The dry-run preview
+  path is unchanged.
 
 ### Compatibility notes
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,19 @@ for the current posture and known limitations.
 
 ---
 
+## Migration Safety
+
+Aksara migrations are applied through a single canonical executor that uses
+PostgreSQL advisory locks, per-migration transactions, checksum verification, SQL
+statement splitting, cycle detection, and clearer failure reporting. The CLI and
+the testing helpers use the same executor path, so local, CI, and production runs
+get the same guarantees.
+
+See the [Migration Safety guide](https://nagarjuna-tella.github.io/Aksara/orm/migration-safety/)
+for details.
+
+---
+
 ## Patterns & Examples
 
 The bundled examples are the golden paths for learning and launch validation:
@@ -309,9 +322,10 @@ Next planned milestones:
 
 | Version | Focus |
 | ------- | ----- |
-| v0.5.50 | Durable AI Session Store |
-| v0.5.51 | AI Memory Foundation |
-| v0.5.52 | AI System Radar |
+| v0.5.50 | Migration Safety & Correctness |
+| v0.5.51 | Durable AI Session Store |
+| v0.5.52 | AI Memory Foundation |
+| v0.5.53 | AI System Radar |
 | v0.6.0  | Production Mode |
 
 See the [Roadmap](https://nagarjuna-tella.github.io/Aksara/roadmap/) for the full release path.

--- a/README.md
+++ b/README.md
@@ -263,11 +263,14 @@ for the current posture and known limitations.
 
 ## Migration Safety
 
-Aksara migrations are applied through a single canonical executor that uses
+File-based Aksara migrations are applied through a canonical executor that uses
 PostgreSQL advisory locks, per-migration transactions, checksum verification, SQL
 statement splitting, cycle detection, and clearer failure reporting. The CLI and
-the testing helpers use the same executor path, so local, CI, and production runs
-get the same guarantees.
+the testing helpers share that executor for file-based runs, so local, CI, and
+production file-based runs get the same guarantees. When no migration files
+exist, `aksara migrate` can still use a legacy model-based bootstrap fallback;
+that path is intended for initial/simple setup and does not provide the full
+file-based migration integrity model.
 
 See the [Migration Safety guide](https://nagarjuna-tella.github.io/Aksara/orm/migration-safety/)
 for details.

--- a/aksara/cli/main.py
+++ b/aksara/cli/main.py
@@ -159,13 +159,20 @@ async def get_applied_migrations(db) -> List[str]:
     return [row['name'] for row in rows]
 
 
-# NOTE: This is a legacy module-level helper kept for any external caller that
-# may import `aksara.cli.main.record_migration`. The canonical implementation
-# now lives in `aksara.migrations.executor.record_migration` (Optional checksum)
-# and is what the migrate command uses via a function-local import that shadows
-# this name. Do not call this helper from new code.
+# ---------------------------------------------------------------------------
+# Legacy CLI-level helpers
+#
+# MIGRATION_TABLE_SQL, compute_checksum, ensure_migrations_table,
+# get_applied_migrations, and record_migration below are compatibility
+# shims kept so that external code importing them from aksara.cli.main
+# continues to work.
+#
+# The canonical implementations live in aksara.migrations.executor and are
+# what the `aksara migrate` command now uses internally.  Do not call these
+# CLI-level helpers from new code.
+# ---------------------------------------------------------------------------
 async def record_migration(db, name: str, checksum: str) -> None:
-    """Record a migration as applied (legacy — see note above)."""
+    """Legacy shim — canonical implementation is aksara.migrations.executor.record_migration."""
     await db.execute(
         "INSERT INTO aksara_migrations (name, checksum) VALUES ($1, $2)",
         name, checksum
@@ -1331,85 +1338,69 @@ def migrate(
                         ui.text("Migration aborted. Resolve conflicts first.")
                         return
                 
-                pending = get_pending_migrations(migration_files, applied)
-                
-                if not pending:
+                if dry_run:
+                    # Dry-run: preview what would be applied, nothing is executed or recorded.
+                    pending = get_pending_migrations(migration_files, applied)
+                    if not pending:
+                        ui.blank()
+                        ui.success("All migrations already applied!")
+                        return
                     ui.blank()
-                    ui.success("All migrations already applied!")
-                    return
-                
-                ui.blank()
-                ui.info(f"{len(pending)} pending migration(s):")
-
-                with ui.progress(len(pending), "Applying migrations") as progress:
-                    for i, (name, path) in enumerate(pending):
+                    ui.info(f"{len(pending)} pending migration(s) [DRY RUN]:")
+                    for name, path in pending:
+                        ui.blank()
                         if path.suffix == ".py":
-                            if dry_run:
-                                ui.blank()
-                                ui.info(f"[DRY RUN] Would apply: {name}")
-                                try:
-                                    migration_class = load_migration_module(path)
-                                    migration = migration_class()
-                                    for op in migration.operations:
-                                        ui.text(f"    > {op.describe()}")
-                                except Exception as e:
-                                    ui.warning(f"Error loading: {e}")
-                                progress.advance(description=f"Scanned {name}")
-                            elif fake:
-                                ui.blank()
-                                ui.info(f"Marking as applied: {name}")
-                                await record_migration(db, name)
-                                ui.success("Marked (not executed)")
-                                progress.advance(description=f"Marked {name}")
-                            else:
-                                ui.blank()
-                                ui.info(f"Applying {name}")
-                                try:
-                                    migration_class = load_migration_module(path)
-                                    migration = migration_class()
-                                    for op in migration.operations:
-                                        ui.text(f"    > {op.describe()}")
-                                        await op.apply(db)
-                                    await record_migration(db, name)
-                                    ui.success("Applied successfully")
-                                    progress.advance(description=f"Applied {name}")
-                                except Exception as e:
-                                    ui.error(f"Error: {e}")
-                                    _display_pending_skipped(ui, pending, i)
-                                    return
+                            ui.info(f"[DRY RUN] Would apply: {name}")
+                            try:
+                                migration_class = load_migration_module(path)
+                                migration = migration_class()
+                                for op in migration.operations:
+                                    ui.text(f"    > {op.describe()}")
+                            except Exception as e:
+                                ui.warning(f"Error loading: {e}")
                         elif path.suffix == ".sql":
+                            ui.info(f"[DRY RUN] Would apply SQL: {name}")
                             sql = path.read_text()
-                            checksum = compute_checksum(sql)
+                            lines = sql.strip().split('\n')[:5]
+                            for line in lines:
+                                ui.text(f"    {line}")
+                            if len(sql.strip().split('\n')) > 5:
+                                ui.text(
+                                    f"    ... ({len(sql.strip().split(chr(10)))} lines)"
+                                )
+                    return
+                else:
+                    # Canonical executor path: advisory lock per run, transaction per
+                    # migration, SQL statement splitting, checksum recording and
+                    # verification.  This is the same path used by apply_migrations().
+                    results = await apply_migrations(
+                        db, mig_dir, fake=fake, verbose=False, include_internal=True,
+                    )
 
-                            if dry_run:
-                                ui.blank()
-                                ui.info(f"[DRY RUN] Would apply SQL: {name}")
-                                lines = sql.strip().split('\n')[:5]
-                                for line in lines:
-                                    ui.text(f"    {line}")
-                                if len(sql.strip().split('\n')) > 5:
-                                    ui.text(
-                                        f"    ... ({len(sql.strip().split(chr(10)))} lines)"
-                                    )
-                                progress.advance(description=f"Scanned {name}")
-                            elif fake:
-                                ui.blank()
-                                ui.info(f"Marking as applied: {name}")
-                                await record_migration(db, name, checksum)
-                                ui.success("Marked (not executed)")
-                                progress.advance(description=f"Marked {name}")
-                            else:
-                                ui.blank()
-                                ui.info(f"Applying SQL: {name}")
-                                try:
-                                    await db.execute(sql)
-                                    await record_migration(db, name, checksum)
-                                    ui.success("Applied successfully")
-                                    progress.advance(description=f"Applied {name}")
-                                except Exception as e:
-                                    ui.error(f"Error: {e}")
-                                    _display_pending_skipped(ui, pending, i)
-                                    return
+                    if not results["applied"] and not results["errors"]:
+                        ui.blank()
+                        ui.success("All migrations already applied!")
+                        return
+
+                    if results["applied"]:
+                        ui.blank()
+                        action = "marked as applied" if fake else "applied successfully"
+                        for name in results["applied"]:
+                            ui.success(f"  ✓ {name} — {action}")
+
+                    if results["errors"]:
+                        ui.blank()
+                        for name, err in results["errors"]:
+                            ui.error(f"  ✗ {name}: {err}")
+                        if results["pending_skipped"]:
+                            ui.blank()
+                            ui.warning(
+                                f"Skipped {len(results['pending_skipped'])} pending "
+                                f"migration(s) after failure:"
+                            )
+                            for skipped_name in results["pending_skipped"]:
+                                ui.text(f"  - {skipped_name}")
+                        sys.exit(1)
             else:
                 # Model-based migrations (v0.1 behavior - fallback)
                 models = ModelRegistry.all()

--- a/aksara/cli/main.py
+++ b/aksara/cli/main.py
@@ -1289,8 +1289,12 @@ def migrate(
         ui.info(f"Found {len(migration_files)} migration file(s) in {mig_dir}")
         
         # v0.3.16: Build migration graph and check for conflicts
-        with ui.status("Building migration graph", animate=False):
-            graph = build_migration_graph(migrations_list=migration_files)
+        try:
+            with ui.status("Building migration graph", animate=False):
+                graph = build_migration_graph(migrations_list=migration_files)
+        except ValueError as e:
+            ui.error(f"Could not build migration graph: {e}")
+            sys.exit(1)
         
     else:
         # Fall back to model-based migration (v0.1 behavior)

--- a/aksara/cli/main.py
+++ b/aksara/cli/main.py
@@ -1221,6 +1221,16 @@ class Migration(Migration):
         ui.command("aksara migrate")
 
 
+def _display_pending_skipped(ui, pending, failed_index: int) -> None:
+    """Display the migrations that were not attempted because of a prior failure."""
+    remaining = [n for n, _ in pending[failed_index + 1:]]
+    if remaining:
+        ui.blank()
+        ui.warning(f"Skipped {len(remaining)} pending migration(s) after failure:")
+        for name in remaining:
+            ui.text(f"  - {name}")
+
+
 @cli.command()
 @click.option("--app", "-a", help="Path to application models module")
 @click.option("--database-url", "-d", envvar="DATABASE_URL",
@@ -1332,7 +1342,7 @@ def migrate(
                 ui.info(f"{len(pending)} pending migration(s):")
 
                 with ui.progress(len(pending), "Applying migrations") as progress:
-                    for name, path in pending:
+                    for i, (name, path) in enumerate(pending):
                         if path.suffix == ".py":
                             if dry_run:
                                 ui.blank()
@@ -1365,6 +1375,7 @@ def migrate(
                                     progress.advance(description=f"Applied {name}")
                                 except Exception as e:
                                     ui.error(f"Error: {e}")
+                                    _display_pending_skipped(ui, pending, i)
                                     return
                         elif path.suffix == ".sql":
                             sql = path.read_text()
@@ -1397,6 +1408,7 @@ def migrate(
                                     progress.advance(description=f"Applied {name}")
                                 except Exception as e:
                                     ui.error(f"Error: {e}")
+                                    _display_pending_skipped(ui, pending, i)
                                     return
             else:
                 # Model-based migrations (v0.1 behavior - fallback)

--- a/aksara/cli/main.py
+++ b/aksara/cli/main.py
@@ -1373,9 +1373,18 @@ def migrate(
                     # Canonical executor path: advisory lock per run, transaction per
                     # migration, SQL statement splitting, checksum recording and
                     # verification.  This is the same path used by apply_migrations().
-                    results = await apply_migrations(
-                        db, mig_dir, fake=fake, verbose=False, include_internal=True,
-                    )
+                    try:
+                        results = await apply_migrations(
+                            db, mig_dir, fake=fake, verbose=False, include_internal=True,
+                        )
+                    except (RuntimeError, ValueError) as e:
+                        ui.blank()
+                        ui.error(f"Migration failed: {e}")
+                        sys.exit(1)
+                    except Exception as e:
+                        ui.blank()
+                        ui.error(f"Migration failed unexpectedly: {e}")
+                        sys.exit(1)
 
                     if not results["applied"] and not results["errors"]:
                         ui.blank()

--- a/aksara/cli/main.py
+++ b/aksara/cli/main.py
@@ -1228,13 +1228,14 @@ class Migration(Migration):
         ui.command("aksara migrate")
 
 
-def _display_pending_skipped(ui, pending, failed_index: int) -> None:
+def _display_pending_skipped(ui, pending_skipped: list[str]) -> None:
     """Display the migrations that were not attempted because of a prior failure."""
-    remaining = [n for n, _ in pending[failed_index + 1:]]
-    if remaining:
+    if pending_skipped:
         ui.blank()
-        ui.warning(f"Skipped {len(remaining)} pending migration(s) after failure:")
-        for name in remaining:
+        ui.warning(
+            f"Skipped {len(pending_skipped)} pending migration(s) after failure:"
+        )
+        for name in pending_skipped:
             ui.text(f"  - {name}")
 
 
@@ -1260,7 +1261,6 @@ def migrate(
         apply_migrations,
         discover_migrations,
         get_pending_migrations,
-        ensure_migrations_table,
         get_applied_migrations as get_applied_migs,
         record_migration,
         load_migration_module,
@@ -1317,10 +1317,6 @@ def migrate(
             with ui.status("Connecting to database"):
                 await db.connect()
             ui.success("Connected to database")
-            
-            # Ensure migrations table exists
-            with ui.status("Ensuring migrations table", animate=False):
-                await ensure_migrations_table(db)
             
             if migration_files:
                 # File-based migrations (v0.3.3 path)
@@ -1401,14 +1397,7 @@ def migrate(
                         ui.blank()
                         for name, err in results["errors"]:
                             ui.error(f"  ✗ {name}: {err}")
-                        if results["pending_skipped"]:
-                            ui.blank()
-                            ui.warning(
-                                f"Skipped {len(results['pending_skipped'])} pending "
-                                f"migration(s) after failure:"
-                            )
-                            for skipped_name in results["pending_skipped"]:
-                                ui.text(f"  - {skipped_name}")
+                        _display_pending_skipped(ui, results["pending_skipped"])
                         sys.exit(1)
             else:
                 # Model-based migrations (v0.1 behavior - fallback)

--- a/aksara/cli/main.py
+++ b/aksara/cli/main.py
@@ -171,7 +171,7 @@ async def get_applied_migrations(db) -> List[str]:
 # what the `aksara migrate` command now uses internally.  Do not call these
 # CLI-level helpers from new code.
 # ---------------------------------------------------------------------------
-async def record_migration(db, name: str, checksum: str) -> None:
+async def record_migration(db, name: str, checksum: str | None = None) -> None:
     """Legacy shim — canonical implementation is aksara.migrations.executor.record_migration."""
     await db.execute(
         "INSERT INTO aksara_migrations (name, checksum) VALUES ($1, $2)",

--- a/aksara/migrations/autodetector.py
+++ b/aksara/migrations/autodetector.py
@@ -1087,8 +1087,15 @@ def operations_to_code(operations: list) -> str:
             f = operation.field
             is_primary_key = getattr(f, "primary_key", False)
             is_nullable = getattr(f, "nullable", True)
-            has_default = getattr(f, "default", None) is not None
-            if not is_primary_key and not is_nullable and not has_default:
+            has_python_default = getattr(f, "default", None) is not None
+            field_sql = f.to_sql()
+            has_db_default = " DEFAULT " in f" {field_sql.upper()} "
+            if (
+                not is_primary_key
+                and not is_nullable
+                and not has_python_default
+                and not has_db_default
+            ):
                 warning = (
                     f'        # WARNING: Adding non-null field "{operation.name}" without a default '
                     f'may fail on non-empty table "{operation.table}".\n'

--- a/aksara/migrations/autodetector.py
+++ b/aksara/migrations/autodetector.py
@@ -1086,6 +1086,18 @@ def operations_to_code(operations: list) -> str:
 
         elif isinstance(operation, op.AddField):
             field_code = _field_op_to_code(operation.field)
+            f = operation.field
+            is_primary_key = getattr(f, "primary_key", False)
+            is_nullable = getattr(f, "nullable", True)
+            has_default = getattr(f, "default", None) is not None
+            if not is_primary_key and not is_nullable and not has_default:
+                warning = (
+                    f'        # WARNING: Adding non-null field "{operation.name}" without a default '
+                    f'may fail on non-empty table "{operation.table}".\n'
+                    f'        # Add a temporary default, backfill existing rows, or split this into '
+                    f'a nullable field + data migration + nullability change.'
+                )
+                code_parts.append(warning)
             code_parts.append(
                 f'        op.AddField(\n'
                 f'            table="{operation.table}",\n'

--- a/aksara/migrations/autodetector.py
+++ b/aksara/migrations/autodetector.py
@@ -314,10 +314,8 @@ def _model_field_to_state(field_name: str, field) -> FieldState:
         field_type = "EmailField"
     elif isinstance(field, URL):
         field_type = "URLField"
-    elif isinstance(field, type(None)):
-        field_type = "StringField"
     else:
-        field_type = "StringField"  # default fallback
+        field_type = "StringField"  # default fallback for unknown field types
         for cls, name in type_map.items():
             if isinstance(field, cls):
                 field_type = name

--- a/aksara/migrations/base.py
+++ b/aksara/migrations/base.py
@@ -43,11 +43,5 @@ class Migration:
     # List of operations to apply in this migration
     operations: List["Operation"] = []
     
-    def __init__(self):
-        """Initialize the migration instance."""
-        # Ensure operations is a copy to avoid shared state
-        if not hasattr(self, '_initialized'):
-            self._initialized = True
-    
     def __repr__(self) -> str:
         return f"<Migration operations={len(self.operations)}>"

--- a/aksara/migrations/executor.py
+++ b/aksara/migrations/executor.py
@@ -54,22 +54,42 @@ async def ensure_migrations_table(connection) -> None:
         pass  # Column already nullable or doesn't exist
 
 
+def _compute_file_checksum(path: Path) -> str:
+    """SHA-256 checksum of a migration file, truncated to 16 hex chars."""
+    import hashlib
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
 async def get_applied_migrations(connection) -> List[str]:
     """
     Get list of applied migration names from the database.
-    
+
     Args:
         connection: Database connection
-        
+
     Returns:
         List of migration names that have been applied
     """
     await ensure_migrations_table(connection)
-    
+
     rows = await connection.fetch(
         "SELECT name FROM aksara_migrations ORDER BY applied_at, id"
     )
     return [row['name'] for row in rows]
+
+
+async def get_applied_migration_records(connection) -> Dict[str, Optional[str]]:
+    """
+    Get applied migrations with their stored checksums.
+
+    Returns:
+        Dict mapping migration name → stored checksum (or None if not stored).
+    """
+    await ensure_migrations_table(connection)
+    rows = await connection.fetch(
+        "SELECT name, checksum FROM aksara_migrations ORDER BY applied_at, id"
+    )
+    return {row["name"]: row["checksum"] for row in rows}
 
 
 async def record_migration(
@@ -315,6 +335,7 @@ def build_migration_graph(
     migrations_path: Optional[Path] = None,
     include_internal: bool = True,
     migrations_list: Optional[List[Tuple[str, Path]]] = None,
+    strict: bool = True,
 ) -> MigrationGraph:
     """
     Build a migration graph from discovered migrations.
@@ -383,9 +404,13 @@ def build_migration_graph(
             graph.add_node(node)
             
         except Exception as e:
-            logger.warning(f"Could not load migration {name}: {e}")
-            # Still add the node without dependencies
             app_label = extract_app_label_from_name(name, path)
+            if strict:
+                raise ValueError(
+                    f"Could not load migration {app_label}.{name} from {path}: {e}"
+                ) from e
+            # Non-strict: warn and continue without dependencies (best-effort graph).
+            logger.warning(f"Could not load migration {app_label}.{name} from {path}: {e}")
             node = MigrationNode(app_label=app_label, name=name)
             graph.add_node(node)
     
@@ -517,6 +542,7 @@ async def apply_migration(
                 # so a partial failure leaves the DB unchanged and the migration unrecorded.
                 migration_class = load_migration_module(file_path)
                 migration = migration_class()
+                checksum = _compute_file_checksum(file_path)
 
                 if not fake:
                     async with conn.transaction():
@@ -524,9 +550,9 @@ async def apply_migration(
                             if verbose:
                                 logger.info(f"  → {op.describe()}")
                             await op.apply(conn)
-                        await record_migration(conn, name)
+                        await record_migration(conn, name, checksum)
                 else:
-                    await record_migration(conn, name)
+                    await record_migration(conn, name, checksum)
 
             elif file_path.suffix == ".sql":
                 # SQL migration: split on statement boundaries so every statement runs,
@@ -624,8 +650,9 @@ async def _apply_migrations_on_conn(
         # Ensure migrations table exists
         await ensure_migrations_table(conn)
 
-        # Get applied migrations
-        applied = await get_applied_migrations(conn)
+        # Get applied migrations with checksums for integrity verification
+        applied_records = await get_applied_migration_records(conn)
+        applied = list(applied_records.keys())
 
         # Discover all migrations (internal + user)
         all_migrations = discover_all_migrations(
@@ -633,12 +660,34 @@ async def _apply_migrations_on_conn(
             include_internal=include_internal,
         )
 
+        # Verify checksums of already-applied migrations whose files are still present.
+        # A mismatch means an applied migration file was edited, which is unsafe.
+        applied_by_name = {name: path for name, path in all_migrations if name in applied_records}
+        for mig_name, mig_path in applied_by_name.items():
+            stored = applied_records.get(mig_name)
+            if stored is None:
+                # Migrated before checksums were introduced — allow but warn.
+                if verbose:
+                    logger.warning(
+                        f"Checksum unavailable for previously applied migration {mig_name!r}. "
+                        "It will not be verified."
+                    )
+                continue
+            current = _compute_file_checksum(mig_path)
+            if current != stored:
+                raise ValueError(
+                    f"Migration checksum mismatch for {mig_name!r}.\n"
+                    "The migration has already been applied but the file contents have changed.\n"
+                    "Do not edit applied migrations. Create a new migration instead."
+                )
+
         # Get pending migrations
         pending = get_pending_migrations(all_migrations, applied)
 
-        results = {
+        results: Dict[str, Any] = {
             "applied": [],
             "skipped": applied,
+            "pending_skipped": [],
             "errors": [],
             "total_discovered": len(all_migrations),
         }
@@ -663,7 +712,7 @@ async def _apply_migrations_on_conn(
         if verbose:
             logger.info(f"Found {len(pending)} pending migration(s).")
 
-        for name, path in ordered_pending:
+        for i, (name, path) in enumerate(ordered_pending):
             try:
                 if verbose:
                     action = "Marking" if fake else "Applying"
@@ -687,6 +736,16 @@ async def _apply_migrations_on_conn(
                 results["errors"].append((name, str(e)))
                 if verbose:
                     logger.error(f"  ✗ Error: {e}")
+                # Collect remaining pending migrations that will not be attempted
+                skipped_remaining = [n for n, _ in ordered_pending[i + 1:]]
+                results["pending_skipped"] = skipped_remaining
+                if verbose and skipped_remaining:
+                    logger.warning(
+                        f"Skipping {len(skipped_remaining)} pending migration(s) "
+                        f"because {name!r} failed:"
+                    )
+                    for skipped_name in skipped_remaining:
+                        logger.warning(f"  - {skipped_name}")
                 # Stop on first error
                 break
 

--- a/aksara/migrations/executor.py
+++ b/aksara/migrations/executor.py
@@ -515,6 +515,7 @@ def _split_sql_statements(sql: str) -> list[str]:
             single-quoted string, double-quoted identifier, or dollar-quoted
             block.
     """
+    sql = sql.replace("\r\n", "\n").replace("\r", "\n")
     statements: list[str] = []
     current: list[str] = []
     i = 0

--- a/aksara/migrations/executor.py
+++ b/aksara/migrations/executor.py
@@ -348,9 +348,15 @@ def build_migration_graph(
         include_internal: Whether to include internal migrations
         migrations_list: Optional pre-discovered list of migrations.
                         If provided, migrations_path is ignored.
+        strict: When True, raise ValueError if a Python migration file
+                cannot be loaded. When False, keep legacy best-effort
+                behavior and add a dependency-less node.
         
     Returns:
         A MigrationGraph with all discovered migrations
+
+    Raises:
+        ValueError: If strict=True and a Python migration file cannot be loaded.
         
     Example:
         graph = build_migration_graph(Path("./migrations"))
@@ -682,9 +688,13 @@ async def apply_migrations(
         
     Returns:
         Dict with results:
-            - applied: List of applied migration names
-            - skipped: List of already-applied migrations
-            - errors: List of (name, error) tuples if any
+            - applied: List of migrations applied in this run.
+            - skipped: List of migrations already applied before this run.
+            - pending_skipped: List of pending migrations not attempted
+              because an earlier pending migration failed.
+            - errors: List of (name, error) tuples.
+            - total_discovered: Total number of migrations discovered before
+              filtering applied/pending.
     """
     migrations_path = Path(migrations_path)
 

--- a/aksara/migrations/executor.py
+++ b/aksara/migrations/executor.py
@@ -513,6 +513,7 @@ def _split_sql_statements(sql: str) -> list[str]:
 
         # Block comment: skip /* ... */
         if ch == "/" and i + 1 < n and sql[i + 1] == "*":
+            current.append(" ")
             i += 2
             while i < n:
                 if sql[i] == "*" and i + 1 < n and sql[i + 1] == "/":
@@ -762,11 +763,10 @@ async def _apply_migrations_on_conn(
             stored = applied_records.get(mig_name)
             if stored is None:
                 # Migrated before checksums were introduced — allow but warn.
-                if verbose:
-                    logger.warning(
-                        f"Checksum unavailable for previously applied migration {mig_name!r}. "
-                        "It will not be verified."
-                    )
+                logger.warning(
+                    f"Checksum unavailable for previously applied migration {mig_name!r}. "
+                    "It will not be verified."
+                )
                 continue
             current = _compute_file_checksum(mig_path)
             if current != stored:
@@ -1183,8 +1183,10 @@ def model_to_create_table(model_class) -> str:
         elif isinstance(field, Array):
             sql_type = Array.TYPE_MAP.get(field.item_type, "TEXT[]")
             parts = [f"sql_type={sql_type!r}"]
-            if field.nullable:
-                parts.append("nullable=True")
+            if not field.nullable:
+                parts.append("nullable=False")
+            if field.default is not None and not callable(field.default):
+                parts.append(f"default={field.default!r}")
             field_code = f"op.ArrayField({', '.join(parts)})"
         
         elif isinstance(field, ForeignKey):

--- a/aksara/migrations/executor.py
+++ b/aksara/migrations/executor.py
@@ -57,7 +57,14 @@ async def ensure_migrations_table(connection) -> None:
 def _compute_file_checksum(path: Path) -> str:
     """SHA-256 checksum of a migration file, truncated to 16 hex chars."""
     import hashlib
-    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+    data = _normalize_checksum_bytes(path.read_bytes())
+    return hashlib.sha256(data).hexdigest()[:16]
+
+
+def _normalize_checksum_bytes(data: bytes) -> bytes:
+    """Normalise migration file line endings before checksum hashing."""
+    return data.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
 
 
 async def get_applied_migrations(connection) -> List[str]:

--- a/aksara/migrations/executor.py
+++ b/aksara/migrations/executor.py
@@ -491,26 +491,106 @@ def _split_sql_statements(sql: str) -> list[str]:
     """Split a SQL script into individual statements on ';' boundaries.
 
     asyncpg's connection.execute() only runs the first statement in a
-    multi-statement string.  This helper strips comments and blank lines,
-    then splits on ';' so every statement is executed.
+    multi-statement string.  This helper uses a character-level scanner that
+    respects single-quoted strings, double-quoted identifiers, dollar-quoted
+    blocks, line comments (--), and block comments (/* ... */) so that
+    semicolons inside any of those constructs are never treated as statement
+    delimiters.
     """
-    statements = []
+    statements: list[str] = []
     current: list[str] = []
-    for line in sql.splitlines():
-        stripped = line.strip()
-        # Skip line comments and blank lines
-        if stripped.startswith("--") or not stripped:
+    i = 0
+    n = len(sql)
+
+    while i < n:
+        ch = sql[i]
+
+        # Line comment: skip to end of line (do not add to current statement)
+        if ch == "-" and i + 1 < n and sql[i + 1] == "-":
+            while i < n and sql[i] != "\n":
+                i += 1
             continue
-        current.append(line)
-        if stripped.endswith(";"):
-            stmt = "\n".join(current).strip()
+
+        # Block comment: skip /* ... */
+        if ch == "/" and i + 1 < n and sql[i + 1] == "*":
+            i += 2
+            while i < n:
+                if sql[i] == "*" and i + 1 < n and sql[i + 1] == "/":
+                    i += 2
+                    break
+                i += 1
+            continue
+
+        # Single-quoted string literal — copy verbatim, handling '' escape
+        if ch == "'":
+            current.append(ch)
+            i += 1
+            while i < n:
+                c = sql[i]
+                current.append(c)
+                i += 1
+                if c == "'":
+                    if i < n and sql[i] == "'":
+                        # Escaped quote inside string
+                        current.append(sql[i])
+                        i += 1
+                    else:
+                        break
+            continue
+
+        # Double-quoted identifier — copy verbatim, handling "" escape
+        if ch == '"':
+            current.append(ch)
+            i += 1
+            while i < n:
+                c = sql[i]
+                current.append(c)
+                i += 1
+                if c == '"':
+                    if i < n and sql[i] == '"':
+                        current.append(sql[i])
+                        i += 1
+                    else:
+                        break
+            continue
+
+        # Dollar-quoting: $$...$$  or  $tag$...$tag$
+        if ch == "$":
+            j = i + 1
+            while j < n and sql[j] != "$":
+                if not (sql[j].isalnum() or sql[j] == "_"):
+                    break
+                j += 1
+            if j < n and sql[j] == "$":
+                tag = sql[i : j + 1]
+                current.extend(tag)
+                i = j + 1
+                while i < n:
+                    if sql[i : i + len(tag)] == tag:
+                        current.extend(tag)
+                        i += len(tag)
+                        break
+                    current.append(sql[i])
+                    i += 1
+                continue
+
+        # Statement delimiter
+        if ch == ";":
+            stmt = "".join(current).strip()
             if stmt:
                 statements.append(stmt)
             current = []
+            i += 1
+            continue
+
+        current.append(ch)
+        i += 1
+
     # Trailing statement without a terminating semicolon
-    remainder = "\n".join(current).strip()
+    remainder = "".join(current).strip()
     if remainder:
         statements.append(remainder)
+
     return statements
 
 
@@ -557,9 +637,10 @@ async def apply_migration(
             elif file_path.suffix == ".sql":
                 # SQL migration: split on statement boundaries so every statement runs,
                 # then record_migration in the same transaction.
-                import hashlib
+                # Use _compute_file_checksum so the checksum matches what integrity
+                # verification will recompute from the file on disk.
+                checksum = _compute_file_checksum(file_path)
                 sql = file_path.read_text()
-                checksum = hashlib.sha256(sql.encode()).hexdigest()[:16]
 
                 if not fake:
                     statements = _split_sql_statements(sql)
@@ -659,6 +740,20 @@ async def _apply_migrations_on_conn(
             user_migrations_path=migrations_path,
             include_internal=include_internal,
         )
+
+        # Warn about applied migration records that no longer have a file on disk.
+        # This is advisory: the migration ran successfully in the past, but the
+        # file has since been deleted.  We warn rather than fail so that teams
+        # can clean up tracking rows deliberately.
+        discovered_names = {name for name, _ in all_migrations}
+        for applied_name in applied_records:
+            if applied_name not in discovered_names:
+                logger.warning(
+                    f"Applied migration {applied_name!r} is recorded in the database "
+                    "but its file was not found on disk. "
+                    "If you intentionally deleted the file, remove the tracking row "
+                    f"manually: DELETE FROM aksara_migrations WHERE name = '{applied_name}';"
+                )
 
         # Verify checksums of already-applied migrations whose files are still present.
         # A mismatch means an applied migration file was edited, which is unsafe.

--- a/aksara/migrations/executor.py
+++ b/aksara/migrations/executor.py
@@ -608,6 +608,7 @@ async def apply_migration(
     *,
     fake: bool = False,
     verbose: bool = True,
+    ensure_table: bool = True,
 ) -> bool:
     """
     Apply a single migration.
@@ -618,6 +619,7 @@ async def apply_migration(
         file_path: Path to migration file
         fake: If True, record as applied without executing
         verbose: If True, print progress messages
+        ensure_table: If True, ensure the migration tracking table exists
         
     Returns:
         True if successful, False otherwise
@@ -626,7 +628,8 @@ async def apply_migration(
         async with _raw_connection(connection) as conn:
             # ensure_migrations_table() is idempotent, and direct apply_migration()
             # calls need the tracking table before recording the migration.
-            await ensure_migrations_table(conn)
+            if ensure_table:
+                await ensure_migrations_table(conn)
 
             if file_path.suffix == ".py":
                 # Python migration: all operations + record_migration in one transaction
@@ -751,14 +754,14 @@ async def _apply_migrations_on_conn(
         applied_records = await get_applied_migration_records(conn)
         applied = list(applied_records.keys())
 
-        # Discover all migrations (internal + user)
-        all_migrations = discover_all_migrations(
+        # Discover migrations used for this execution run.
+        execution_migrations = discover_all_migrations(
             user_migrations_path=migrations_path,
             include_internal=include_internal,
         )
-        warning_migrations = all_migrations
+        known_migrations = execution_migrations
         if not include_internal:
-            warning_migrations = discover_all_migrations(
+            known_migrations = discover_all_migrations(
                 user_migrations_path=migrations_path,
                 include_internal=True,
             )
@@ -767,7 +770,7 @@ async def _apply_migrations_on_conn(
         # This is advisory: the migration ran successfully in the past, but the
         # file has since been deleted.  We warn rather than fail so that teams
         # can clean up tracking rows deliberately.
-        discovered_names = {name for name, _ in warning_migrations}
+        discovered_names = {name for name, _ in known_migrations}
         for applied_name in applied_records:
             if applied_name not in discovered_names:
                 logger.warning(
@@ -781,7 +784,9 @@ async def _apply_migrations_on_conn(
 
         # Verify checksums of already-applied migrations whose files are still present.
         # A mismatch means an applied migration file was edited, which is unsafe.
-        applied_by_name = {name: path for name, path in all_migrations if name in applied_records}
+        applied_by_name = {
+            name: path for name, path in known_migrations if name in applied_records
+        }
         for mig_name, mig_path in applied_by_name.items():
             stored = applied_records.get(mig_name)
             if stored is None:
@@ -800,14 +805,14 @@ async def _apply_migrations_on_conn(
                 )
 
         # Get pending migrations
-        pending = get_pending_migrations(all_migrations, applied)
+        pending = get_pending_migrations(execution_migrations, applied)
 
         results: Dict[str, Any] = {
             "applied": [],
             "skipped": applied,
             "pending_skipped": [],
             "errors": [],
-            "total_discovered": len(all_migrations),
+            "total_discovered": len(execution_migrations),
         }
 
         if not pending:
@@ -822,7 +827,7 @@ async def _apply_migrations_on_conn(
             for node in build_migration_graph(
                 migrations_path=migrations_path,
                 include_internal=include_internal,
-                migrations_list=all_migrations,
+                migrations_list=execution_migrations,
             ).execution_order()
             if node.name in pending_by_name
         ]
@@ -842,6 +847,7 @@ async def _apply_migrations_on_conn(
                     path,
                     fake=fake,
                     verbose=verbose,
+                    ensure_table=False,
                 )
 
                 results["applied"].append(name)

--- a/aksara/migrations/executor.py
+++ b/aksara/migrations/executor.py
@@ -338,6 +338,18 @@ def extract_app_label_from_name(migration_name: str, file_path: Path) -> str:
     return parent if parent else "default"
 
 
+def _format_migration_display_name(app_label: str, name: str) -> str:
+    """Return a readable migration identifier for user-facing messages."""
+    if not app_label:
+        return name
+
+    normalized_app = app_label.replace(".", "_")
+    if name.startswith(f"{normalized_app}_") or name.startswith("aksara_contrib_"):
+        return name
+
+    return f"{app_label}.{name}"
+
+
 def build_migration_graph(
     migrations_path: Optional[Path] = None,
     include_internal: bool = True,
@@ -418,12 +430,13 @@ def build_migration_graph(
             
         except Exception as e:
             app_label = extract_app_label_from_name(name, path)
+            display_name = _format_migration_display_name(app_label, name)
             if strict:
                 raise ValueError(
-                    f"Could not load migration {app_label}.{name} from {path}: {e}"
+                    f"Could not load migration {display_name} from {path}: {e}"
                 ) from e
             # Non-strict: warn and continue without dependencies (best-effort graph).
-            logger.warning(f"Could not load migration {app_label}.{name} from {path}: {e}")
+            logger.warning(f"Could not load migration {display_name} from {path}: {e}")
             node = MigrationNode(app_label=app_label, name=name)
             graph.add_node(node)
     

--- a/aksara/migrations/executor.py
+++ b/aksara/migrations/executor.py
@@ -740,12 +740,13 @@ async def apply_migrations(
     Returns:
         Dict with results:
             - applied: List of migrations applied in this run.
-            - skipped: List of migrations already applied before this run.
+                        - skipped: List of migrations discovered for this run that were
+                            already applied before this run.
             - pending_skipped: List of pending migrations not attempted
               because an earlier pending migration failed.
             - errors: List of (name, error) tuples.
-            - total_discovered: Total number of migrations discovered before
-              filtering applied/pending.
+                        - total_discovered: Total number of migrations discovered for this
+                            run after include_internal filtering.
     """
     migrations_path = Path(migrations_path)
 
@@ -803,6 +804,8 @@ async def _apply_migrations_on_conn(
             user_migrations_path=migrations_path,
             include_internal=include_internal,
         )
+        execution_names = {name for name, _ in execution_migrations}
+        skipped_for_run = [name for name in applied_records if name in execution_names]
         known_migrations = execution_migrations
         if not include_internal:
             known_migrations = discover_all_migrations(
@@ -853,7 +856,7 @@ async def _apply_migrations_on_conn(
 
         results: Dict[str, Any] = {
             "applied": [],
-            "skipped": applied,
+            "skipped": skipped_for_run,
             "pending_skipped": [],
             "errors": [],
             "total_discovered": len(execution_migrations),

--- a/aksara/migrations/executor.py
+++ b/aksara/migrations/executor.py
@@ -624,6 +624,10 @@ async def apply_migration(
     """
     try:
         async with _raw_connection(connection) as conn:
+            # ensure_migrations_table() is idempotent, and direct apply_migration()
+            # calls need the tracking table before recording the migration.
+            await ensure_migrations_table(conn)
+
             if file_path.suffix == ".py":
                 # Python migration: all operations + record_migration in one transaction
                 # so a partial failure leaves the DB unchanged and the migration unrecorded.
@@ -752,12 +756,18 @@ async def _apply_migrations_on_conn(
             user_migrations_path=migrations_path,
             include_internal=include_internal,
         )
+        warning_migrations = all_migrations
+        if not include_internal:
+            warning_migrations = discover_all_migrations(
+                user_migrations_path=migrations_path,
+                include_internal=True,
+            )
 
         # Warn about applied migration records that no longer have a file on disk.
         # This is advisory: the migration ran successfully in the past, but the
         # file has since been deleted.  We warn rather than fail so that teams
         # can clean up tracking rows deliberately.
-        discovered_names = {name for name, _ in all_migrations}
+        discovered_names = {name for name, _ in warning_migrations}
         for applied_name in applied_records:
             if applied_name not in discovered_names:
                 logger.warning(

--- a/aksara/migrations/executor.py
+++ b/aksara/migrations/executor.py
@@ -922,9 +922,13 @@ async def _apply_migrations_on_conn(
     finally:
         # Always release the advisory lock, even if an error occurred mid-run.
         try:
-            await conn.execute(
+            released = await conn.fetchval(
                 "SELECT pg_advisory_unlock(hashtext($1))", _ADVISORY_LOCK_KEY
             )
+            if released is False:
+                logger.warning(
+                    "Migration advisory lock was not held or could not be released by this session."
+                )
         except Exception as e:
             logger.warning("Failed to release migration advisory lock: %s", e)
 

--- a/aksara/migrations/executor.py
+++ b/aksara/migrations/executor.py
@@ -753,7 +753,9 @@ async def _apply_migrations_on_conn(
                     f"Applied migration {applied_name!r} is recorded in the database "
                     "but its file was not found on disk. "
                     "If you intentionally deleted the file, remove the tracking row "
-                    f"manually: DELETE FROM aksara_migrations WHERE name = '{applied_name}';"
+                    "manually with a parameterized query: "
+                    "DELETE FROM aksara_migrations WHERE name = $1; "
+                    f"migration name: {applied_name!r}"
                 )
 
         # Verify checksums of already-applied migrations whose files are still present.
@@ -848,9 +850,12 @@ async def _apply_migrations_on_conn(
 
     finally:
         # Always release the advisory lock, even if an error occurred mid-run.
-        await conn.execute(
-            "SELECT pg_advisory_unlock(hashtext($1))", _ADVISORY_LOCK_KEY
-        )
+        try:
+            await conn.execute(
+                "SELECT pg_advisory_unlock(hashtext($1))", _ADVISORY_LOCK_KEY
+            )
+        except Exception as e:
+            logger.warning("Failed to release migration advisory lock: %s", e)
 
 
 # =============================================================================

--- a/aksara/migrations/executor.py
+++ b/aksara/migrations/executor.py
@@ -502,63 +502,104 @@ def _split_sql_statements(sql: str) -> list[str]:
     blocks, line comments (--), and block comments (/* ... */) so that
     semicolons inside any of those constructs are never treated as statement
     delimiters.
+
+    Raises:
+        ValueError: If the SQL ends while still inside a block comment,
+            single-quoted string, double-quoted identifier, or dollar-quoted
+            block.
     """
     statements: list[str] = []
     current: list[str] = []
     i = 0
     n = len(sql)
+    state = "normal"
+    block_comment_depth = 0
+    dollar_tag: str | None = None
 
     while i < n:
         ch = sql[i]
+        nxt = sql[i + 1] if i + 1 < n else ""
+
+        if state == "line_comment":
+            if ch == "\n":
+                current.append(ch)
+                state = "normal"
+            i += 1
+            continue
+
+        if state == "block_comment":
+            if ch == "/" and nxt == "*":
+                block_comment_depth += 1
+                i += 2
+                continue
+            if ch == "*" and nxt == "/":
+                block_comment_depth -= 1
+                i += 2
+                if block_comment_depth == 0:
+                    state = "normal"
+                continue
+            i += 1
+            continue
+
+        if state == "single_quote":
+            current.append(ch)
+            i += 1
+            if ch == "'":
+                if i < n and sql[i] == "'":
+                    current.append(sql[i])
+                    i += 1
+                else:
+                    state = "normal"
+            continue
+
+        if state == "double_quote":
+            current.append(ch)
+            i += 1
+            if ch == '"':
+                if i < n and sql[i] == '"':
+                    current.append(sql[i])
+                    i += 1
+                else:
+                    state = "normal"
+            continue
+
+        if state == "dollar_quote":
+            if dollar_tag is not None and sql.startswith(dollar_tag, i):
+                current.extend(dollar_tag)
+                i += len(dollar_tag)
+                dollar_tag = None
+                state = "normal"
+                continue
+            current.append(ch)
+            i += 1
+            continue
 
         # Line comment: skip to end of line (do not add to current statement)
-        if ch == "-" and i + 1 < n and sql[i + 1] == "-":
-            while i < n and sql[i] != "\n":
-                i += 1
+        if ch == "-" and nxt == "-":
+            state = "line_comment"
+            i += 2
             continue
 
         # Block comment: skip /* ... */
-        if ch == "/" and i + 1 < n and sql[i + 1] == "*":
+        if ch == "/" and nxt == "*":
+            state = "block_comment"
+            block_comment_depth = 1
             current.append(" ")
             i += 2
-            while i < n:
-                if sql[i] == "*" and i + 1 < n and sql[i + 1] == "/":
-                    i += 2
-                    break
-                i += 1
             continue
 
         # Single-quoted string literal — copy verbatim, handling '' escape
         if ch == "'":
+            state = "single_quote"
             current.append(ch)
             i += 1
-            while i < n:
-                c = sql[i]
-                current.append(c)
-                i += 1
-                if c == "'":
-                    if i < n and sql[i] == "'":
-                        # Escaped quote inside string
-                        current.append(sql[i])
-                        i += 1
-                    else:
-                        break
             continue
 
         # Double-quoted identifier — copy verbatim, handling "" escape
         if ch == '"':
+            state = "double_quote"
             current.append(ch)
             i += 1
-            while i < n:
-                c = sql[i]
-                current.append(c)
-                i += 1
-                if c == '"':
-                    if i < n and sql[i] == '"':
-                        current.append(sql[i])
-                        i += 1
-                    else:
-                        break
             continue
 
         # Dollar-quoting: $$...$$  or  $tag$...$tag$
@@ -569,16 +610,10 @@ def _split_sql_statements(sql: str) -> list[str]:
                     break
                 j += 1
             if j < n and sql[j] == "$":
-                tag = sql[i : j + 1]
-                current.extend(tag)
+                dollar_tag = sql[i : j + 1]
+                current.extend(dollar_tag)
+                state = "dollar_quote"
                 i = j + 1
-                while i < n:
-                    if sql[i : i + len(tag)] == tag:
-                        current.extend(tag)
-                        i += len(tag)
-                        break
-                    current.append(sql[i])
-                    i += 1
                 continue
 
         # Statement delimiter
@@ -592,6 +627,15 @@ def _split_sql_statements(sql: str) -> list[str]:
 
         current.append(ch)
         i += 1
+
+    if state == "block_comment":
+        raise ValueError("Unterminated block comment in SQL migration")
+    if state == "single_quote":
+        raise ValueError("Unterminated single-quoted string in SQL migration")
+    if state == "double_quote":
+        raise ValueError("Unterminated double-quoted identifier in SQL migration")
+    if state == "dollar_quote":
+        raise ValueError("Unterminated dollar-quoted block in SQL migration")
 
     # Trailing statement without a terminating semicolon
     remainder = "".join(current).strip()

--- a/aksara/migrations/executor.py
+++ b/aksara/migrations/executor.py
@@ -438,6 +438,57 @@ def check_migration_conflicts(
 # Migration Execution
 # =============================================================================
 
+
+from contextlib import asynccontextmanager
+
+
+@asynccontextmanager
+async def _raw_connection(connection):
+    """Yield a raw asyncpg connection.
+
+    `connection` can be either:
+      - an asyncpg Connection/PoolConnectionProxy (already has `.transaction()`)
+      - an Aksara Database wrapper (has `.acquire()` but not `.transaction()`)
+
+    Callers that need a single pinned connection for advisory locking or
+    transactions must go through this helper so both cases are handled.
+    """
+    if hasattr(connection, "transaction"):
+        # Already a raw asyncpg connection — use as-is.
+        yield connection
+    else:
+        # Database wrapper — acquire a dedicated connection from the pool.
+        async with connection.acquire() as conn:
+            yield conn
+
+
+def _split_sql_statements(sql: str) -> list[str]:
+    """Split a SQL script into individual statements on ';' boundaries.
+
+    asyncpg's connection.execute() only runs the first statement in a
+    multi-statement string.  This helper strips comments and blank lines,
+    then splits on ';' so every statement is executed.
+    """
+    statements = []
+    current: list[str] = []
+    for line in sql.splitlines():
+        stripped = line.strip()
+        # Skip line comments and blank lines
+        if stripped.startswith("--") or not stripped:
+            continue
+        current.append(line)
+        if stripped.endswith(";"):
+            stmt = "\n".join(current).strip()
+            if stmt:
+                statements.append(stmt)
+            current = []
+    # Trailing statement without a terminating semicolon
+    remainder = "\n".join(current).strip()
+    if remainder:
+        statements.append(remainder)
+    return statements
+
+
 async def apply_migration(
     connection,
     name: str,
@@ -460,36 +511,44 @@ async def apply_migration(
         True if successful, False otherwise
     """
     try:
-        if file_path.suffix == ".py":
-            # Python migration
-            migration_class = load_migration_module(file_path)
-            migration = migration_class()
-            
-            if not fake:
-                for i, op in enumerate(migration.operations):
-                    if verbose:
-                        logger.info(f"  → {op.describe()}")
-                    await op.apply(connection)
-            
-            await record_migration(connection, name)
-            
-        elif file_path.suffix == ".sql":
-            # Legacy SQL migration
-            sql = file_path.read_text()
-            
-            if not fake:
-                await connection.execute(sql)
-            
-            # Compute simple checksum for SQL
-            import hashlib
-            checksum = hashlib.sha256(sql.encode()).hexdigest()[:16]
-            await record_migration(connection, name, checksum)
-        
-        else:
-            raise ValueError(f"Unknown migration type: {file_path.suffix}")
-        
+        async with _raw_connection(connection) as conn:
+            if file_path.suffix == ".py":
+                # Python migration: all operations + record_migration in one transaction
+                # so a partial failure leaves the DB unchanged and the migration unrecorded.
+                migration_class = load_migration_module(file_path)
+                migration = migration_class()
+
+                if not fake:
+                    async with conn.transaction():
+                        for op in migration.operations:
+                            if verbose:
+                                logger.info(f"  → {op.describe()}")
+                            await op.apply(conn)
+                        await record_migration(conn, name)
+                else:
+                    await record_migration(conn, name)
+
+            elif file_path.suffix == ".sql":
+                # SQL migration: split on statement boundaries so every statement runs,
+                # then record_migration in the same transaction.
+                import hashlib
+                sql = file_path.read_text()
+                checksum = hashlib.sha256(sql.encode()).hexdigest()[:16]
+
+                if not fake:
+                    statements = _split_sql_statements(sql)
+                    async with conn.transaction():
+                        for stmt in statements:
+                            await conn.execute(stmt)
+                        await record_migration(conn, name, checksum)
+                else:
+                    await record_migration(conn, name, checksum)
+
+            else:
+                raise ValueError(f"Unknown migration type: {file_path.suffix}")
+
         return True
-        
+
     except Exception as e:
         logger.error(f"Error applying migration {name}: {e}")
         raise
@@ -520,77 +579,124 @@ async def apply_migrations(
             - errors: List of (name, error) tuples if any
     """
     migrations_path = Path(migrations_path)
-    
-    # Ensure migrations table exists
-    await ensure_migrations_table(connection)
-    
-    # Get applied migrations
-    applied = await get_applied_migrations(connection)
-    
-    # Discover all migrations (internal + user)
-    all_migrations = discover_all_migrations(
-        user_migrations_path=migrations_path,
-        include_internal=include_internal,
+
+    # Pin to a single raw asyncpg connection for the entire migration run.
+    # This is required because:
+    #   1. Advisory locks are session-scoped — releasing the connection also
+    #      releases the lock.
+    #   2. The Database wrapper acquires a fresh pool connection per call, so
+    #      we must hold one explicitly here.
+    async with _raw_connection(connection) as conn:
+        return await _apply_migrations_on_conn(
+            conn,
+            migrations_path,
+            fake=fake,
+            verbose=verbose,
+            include_internal=include_internal,
+        )
+
+
+async def _apply_migrations_on_conn(
+    conn,
+    migrations_path: Path,
+    *,
+    fake: bool,
+    verbose: bool,
+    include_internal: bool,
+) -> Dict[str, Any]:
+    """Inner implementation of apply_migrations that works on a raw asyncpg connection."""
+    # Acquire a session-level advisory lock so that two processes cannot run
+    # migrations concurrently.  pg_try_advisory_lock() is non-blocking; if
+    # another process holds the lock we fail fast rather than silently
+    # double-applying.
+    _ADVISORY_LOCK_KEY = "aksara_migrations"
+    lock_acquired = await conn.fetchval(
+        "SELECT pg_try_advisory_lock(hashtext($1))", _ADVISORY_LOCK_KEY
     )
-    
-    # Get pending migrations
-    pending = get_pending_migrations(all_migrations, applied)
-    
-    results = {
-        "applied": [],
-        "skipped": applied,
-        "errors": [],
-        "total_discovered": len(all_migrations),
-    }
-    
-    if not pending:
+    if not lock_acquired:
+        raise RuntimeError(
+            "Could not acquire migration advisory lock — another process may be "
+            "running migrations.  Wait for that process to finish or release the "
+            f"lock manually: SELECT pg_advisory_unlock(hashtext('{_ADVISORY_LOCK_KEY}'));"
+        )
+
+    try:
+        # Ensure migrations table exists
+        await ensure_migrations_table(conn)
+
+        # Get applied migrations
+        applied = await get_applied_migrations(conn)
+
+        # Discover all migrations (internal + user)
+        all_migrations = discover_all_migrations(
+            user_migrations_path=migrations_path,
+            include_internal=include_internal,
+        )
+
+        # Get pending migrations
+        pending = get_pending_migrations(all_migrations, applied)
+
+        results = {
+            "applied": [],
+            "skipped": applied,
+            "errors": [],
+            "total_discovered": len(all_migrations),
+        }
+
+        if not pending:
+            if verbose:
+                logger.info("No pending migrations.")
+            return results
+
+        # Apply only pending migrations, but do so in dependency order.
+        pending_by_name = {name: path for name, path in pending}
+        ordered_pending = [
+            (node.name, pending_by_name[node.name])
+            for node in build_migration_graph(
+                migrations_path=migrations_path,
+                include_internal=include_internal,
+                migrations_list=all_migrations,
+            ).execution_order()
+            if node.name in pending_by_name
+        ]
+
         if verbose:
-            logger.info("No pending migrations.")
+            logger.info(f"Found {len(pending)} pending migration(s).")
+
+        for name, path in ordered_pending:
+            try:
+                if verbose:
+                    action = "Marking" if fake else "Applying"
+                    logger.info(f"\n{action}: {name}")
+
+                await apply_migration(
+                    conn,
+                    name,
+                    path,
+                    fake=fake,
+                    verbose=verbose,
+                )
+
+                results["applied"].append(name)
+
+                if verbose:
+                    status = "marked as applied" if fake else "applied successfully"
+                    logger.info(f"  ✓ {status}")
+
+            except Exception as e:
+                results["errors"].append((name, str(e)))
+                if verbose:
+                    logger.error(f"  ✗ Error: {e}")
+                # Stop on first error
+                break
+
         return results
 
-    # Apply only pending migrations, but do so in dependency order.
-    pending_by_name = {name: path for name, path in pending}
-    ordered_pending = [
-        (node.name, pending_by_name[node.name])
-        for node in build_migration_graph(
-            migrations_path=migrations_path,
-            include_internal=include_internal,
-            migrations_list=all_migrations,
-        ).execution_order()
-        if node.name in pending_by_name
-    ]
-    
-    if verbose:
-        logger.info(f"Found {len(pending)} pending migration(s).")
-    
-    for name, path in ordered_pending:
-        try:
-            if verbose:
-                action = "Marking" if fake else "Applying"
-                logger.info(f"\n{action}: {name}")
-            
-            await apply_migration(
-                connection,
-                name,
-                path,
-                fake=fake,
-                verbose=verbose,
-            )
-            
-            results["applied"].append(name)
-            
-            if verbose:
-                status = "marked as applied" if fake else "applied successfully"
-                logger.info(f"  ✓ {status}")
-                
-        except Exception as e:
-            results["errors"].append((name, str(e)))
-            if verbose:
-                logger.error(f"  ✗ Error: {e}")
-            # Stop on first error
-            break
-    
-    return results
+    finally:
+        # Always release the advisory lock, even if an error occurred mid-run.
+        await conn.execute(
+            "SELECT pg_advisory_unlock(hashtext($1))", _ADVISORY_LOCK_KEY
+        )
 
 
 # =============================================================================
@@ -921,12 +1027,11 @@ def model_to_create_table(model_class) -> str:
                 field_code = f"op.EnumField({av_repr}, enum_name='{enum_name}')"
         
         elif isinstance(field, Array):
-            # Map item_type to SQL type for the migration
-            type_name = field.item_type.__name__ if hasattr(field.item_type, '__name__') else 'str'
-            parts = [f"item_type='{type_name}'"]
+            sql_type = Array.TYPE_MAP.get(field.item_type, "TEXT[]")
+            parts = [f"sql_type={sql_type!r}"]
             if field.nullable:
                 parts.append("nullable=True")
-            field_code = f"op.TextField({', '.join(parts)})"  # Fallback: array stored as text
+            field_code = f"op.ArrayField({', '.join(parts)})"
         
         elif isinstance(field, ForeignKey):
             # Get target table name (try __tablename__ first, then _table_name)

--- a/aksara/migrations/executor.py
+++ b/aksara/migrations/executor.py
@@ -733,9 +733,10 @@ async def _apply_migrations_on_conn(
     )
     if not lock_acquired:
         raise RuntimeError(
-            "Could not acquire migration advisory lock — another process may be "
-            "running migrations.  Wait for that process to finish or release the "
-            f"lock manually: SELECT pg_advisory_unlock(hashtext('{_ADVISORY_LOCK_KEY}'));"
+            "Could not acquire Aksara migration advisory lock. Another migration "
+            "process may already be running. Wait for that process to finish. If "
+            "the lock appears stuck, identify the holding backend using "
+            "pg_locks/pg_stat_activity and terminate that backend if appropriate."
         )
 
     try:

--- a/aksara/migrations/graph.py
+++ b/aksara/migrations/graph.py
@@ -266,28 +266,41 @@ class MigrationGraph:
         else:
             nodes = dict(self.nodes)
         
-        # Track visited and result
-        visited: Set[Tuple[str, str]] = set()
+        # Three-state DFS: unvisited → visiting → done.
+        # "visiting" lets us detect back-edges (cycles).
+        visiting: Set[Tuple[str, str]] = set()
+        done: Set[Tuple[str, str]] = set()
         result: List[MigrationNode] = []
-        
-        def visit(key: Tuple[str, str]) -> None:
-            if key in visited:
+
+        def visit(key: Tuple[str, str], path: List[Tuple[str, str]]) -> None:
+            if key in done:
                 return
             if key not in nodes:
-                return  # External dependency
-            
-            visited.add(key)
+                return  # External dependency — already applied or from another app
+            if key in visiting:
+                # Back-edge: build a human-readable cycle description
+                cycle_start = path.index(key)
+                cycle = path[cycle_start:] + [key]
+                cycle_str = " → ".join(f"{a}.{m}" for a, m in cycle)
+                raise ValueError(
+                    f"Migration dependency cycle detected: {cycle_str}"
+                )
+
+            visiting.add(key)
             node = nodes[key]
-            
-            # Visit dependencies first
+            path.append(key)
+
             for dep in node.dependencies:
-                visit(dep)
-            
+                visit(dep, path)
+
+            path.pop()
+            visiting.discard(key)
+            done.add(key)
             result.append(node)
-        
+
         # Visit all nodes
         for key in nodes:
-            visit(key)
+            visit(key, [])
         
         return result
     

--- a/aksara/migrations/operations.py
+++ b/aksara/migrations/operations.py
@@ -117,11 +117,75 @@ _UNSAFE_PREDICATE_KEYWORDS = frozenset({
 })
 
 
+def _scan_sql_predicate_unquoted(predicate: str, *, context: str) -> str:
+    """Return only unquoted predicate text while rejecting unsafe tokens."""
+    unquoted: list[str] = []
+    i = 0
+    n = len(predicate)
+
+    while i < n:
+        ch = predicate[i]
+
+        if ch == "'":
+            i += 1
+            while i < n:
+                if predicate[i] == "'":
+                    if i + 1 < n and predicate[i + 1] == "'":
+                        i += 2
+                        continue
+                    i += 1
+                    break
+                i += 1
+            else:
+                raise ValueError(
+                    f"Unsafe {context} for partial index: unterminated single-quoted string."
+                )
+            unquoted.append(" ")
+            continue
+
+        if ch == '"':
+            i += 1
+            while i < n:
+                if predicate[i] == '"':
+                    if i + 1 < n and predicate[i + 1] == '"':
+                        i += 2
+                        continue
+                    i += 1
+                    break
+                i += 1
+            else:
+                raise ValueError(
+                    f"Unsafe {context} for partial index: unterminated double-quoted identifier."
+                )
+            unquoted.append(" ")
+            continue
+
+        if ch == ";":
+            raise ValueError(f"Unsafe {context} for partial index: semicolons are not allowed.")
+        if ch == "-" and i + 1 < n and predicate[i + 1] == "-":
+            raise ValueError(
+                f"Unsafe {context} for partial index: line comments (--) are not allowed."
+            )
+        if (
+            (ch == "/" and i + 1 < n and predicate[i + 1] == "*")
+            or (ch == "*" and i + 1 < n and predicate[i + 1] == "/")
+        ):
+            raise ValueError(
+                f"Unsafe {context} for partial index: block comments are not allowed."
+            )
+
+        unquoted.append(ch)
+        i += 1
+
+    return "".join(unquoted)
+
+
 def _validate_sql_predicate(predicate: str, *, context: str = "SQL predicate") -> str:
     """Validate a developer-authored SQL predicate (e.g. for a partial index).
 
     Does **not** attempt to fully parse SQL — only rejects the most obvious
-    multi-statement and DDL/DML patterns that have no place in a WHERE clause:
+    unquoted multi-statement and DDL/DML patterns that have no place in a
+    WHERE clause:
 
       * Semicolons (``;``).
       * Line comments (``--``).
@@ -137,14 +201,9 @@ def _validate_sql_predicate(predicate: str, *, context: str = "SQL predicate") -
     predicate = predicate.strip()
     if not predicate:
         raise ValueError(f"Unsafe {context} for partial index: predicate must not be empty.")
-    if ";" in predicate:
-        raise ValueError(f"Unsafe {context} for partial index: semicolons are not allowed.")
-    if "--" in predicate:
-        raise ValueError(f"Unsafe {context} for partial index: line comments (--) are not allowed.")
-    if "/*" in predicate or "*/" in predicate:
-        raise ValueError(f"Unsafe {context} for partial index: block comments are not allowed.")
+    unquoted = _scan_sql_predicate_unquoted(predicate, context=context)
     # Word-boundary keyword check — case-insensitive
-    upper = predicate.upper()
+    upper = unquoted.upper()
     for kw in _UNSAFE_PREDICATE_KEYWORDS:
         # Match whole-word only to avoid rejecting 'created_at' for CREATE etc.
         if re.search(rf"\b{re.escape(kw)}\b", upper):

--- a/aksara/migrations/operations.py
+++ b/aksara/migrations/operations.py
@@ -174,6 +174,7 @@ _UNSAFE_SQL_TYPE_KEYWORDS = frozenset({
     "DROP", "ALTER", "DELETE", "INSERT", "UPDATE", "CREATE",
     "TRUNCATE", "GRANT", "REVOKE", "EXECUTE", "CALL", "COPY", "SELECT",
 })
+_ARRAY_SQL_TYPE_ARGS_RE = re.compile(r"^([A-Z ]+)\((\d+)(?:\s*,\s*\d+)?\)$")
 
 
 def _validate_array_sql_type(sql_type: str) -> str:
@@ -183,7 +184,7 @@ def _validate_array_sql_type(sql_type: str) -> str:
       * Must be a non-empty string.
       * Must end with ``[]`` (case-insensitive normalised to uppercase).
       * Base type (everything before the final ``[]``) must be on the allowed
-        list after stripping an optional ``(length)`` specifier.
+                list after stripping an optional numeric length/precision specifier.
       * Must not contain semicolons, comments, quotes, or DDL/DML keywords.
 
     Returns the normalised (uppercased) sql_type string.
@@ -210,13 +211,19 @@ def _validate_array_sql_type(sql_type: str) -> str:
         raise ValueError(
             f"ArrayField sql_type must end with '[]', got {sql_type!r}"
         )
-    # Strip [] and optional (length) to get the base type
+    # Strip [] and parse any numeric length/precision suffix.
     base = upper[:-2].strip()
-    # Allow optional length specifier like VARCHAR(255)
-    base_no_len = re.sub(r"\(\d+\)$", "", base).strip()
-    if base_no_len not in _ALLOWED_ARRAY_BASE_TYPES:
+    base_name = base
+    args_match = _ARRAY_SQL_TYPE_ARGS_RE.fullmatch(base)
+    if args_match:
+        base_name = args_match.group(1).strip()
+    elif "(" in base or ")" in base:
         raise ValueError(
-            f"ArrayField sql_type has unknown base type {base_no_len!r}. "
+            f"ArrayField sql_type has malformed length/precision specifier: {sql_type!r}"
+        )
+    if base_name not in _ALLOWED_ARRAY_BASE_TYPES:
+        raise ValueError(
+            f"ArrayField sql_type has unknown base type {base_name!r}. "
             f"Allowed base types: {', '.join(sorted(_ALLOWED_ARRAY_BASE_TYPES))}"
         )
     return upper

--- a/aksara/migrations/operations.py
+++ b/aksara/migrations/operations.py
@@ -16,9 +16,11 @@ Keep them in sync when adding new field types or options.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
+import re
 from abc import ABC, abstractmethod
 from typing import Any, List, Optional, Tuple, Union
 
@@ -60,6 +62,140 @@ def _validate_fk_action(action: str) -> str:
             f"Allowed: {', '.join(sorted(_VALID_FK_ACTIONS))}"
         )
     return normalised
+
+
+def _make_constraint_name(*parts: str, max_length: int = 63) -> str:
+    """Build a deterministic PostgreSQL-safe constraint identifier.
+
+    Joins *parts* with underscores.  If the result is within *max_length*
+    bytes it is returned as-is.  When it exceeds the limit the name is
+    truncated to leave room for an 8-character stable hash suffix so that:
+
+      * The result is always <= *max_length* characters.
+      * Different long names produce different constraint names (no silent
+        collision).
+      * The output is deterministic across runs.
+
+    Callers must pass the result through ``_quote_ident()`` before embedding
+    in SQL.
+    """
+    full = "_".join(p for p in parts if p)
+    if len(full) <= max_length:
+        return full
+    # Hash the full name for a stable suffix; use first 8 hex chars.
+    suffix = hashlib.sha256(full.encode()).hexdigest()[:8]
+    # Trim to make room: max_length - 1 underscore - 8 hash chars
+    prefix = full[: max_length - 9]
+    return f"{prefix}_{suffix}"
+
+
+# DDL/DML keywords that must never appear in a partial-index predicate.
+_UNSAFE_PREDICATE_KEYWORDS = frozenset({
+    "DROP", "ALTER", "DELETE", "INSERT", "UPDATE", "CREATE",
+    "TRUNCATE", "GRANT", "REVOKE", "EXECUTE", "CALL", "COPY",
+})
+
+
+def _validate_sql_predicate(predicate: str, *, context: str = "SQL predicate") -> str:
+    """Validate a developer-authored SQL predicate (e.g. for a partial index).
+
+    Does **not** attempt to fully parse SQL — only rejects the most obvious
+    multi-statement and DDL/DML patterns that have no place in a WHERE clause:
+
+      * Semicolons (``;``).
+      * Line comments (``--``).
+      * Block comments (``/* … */``).
+      * DDL/DML keywords (DROP, ALTER, DELETE, INSERT, UPDATE, CREATE,
+        TRUNCATE, GRANT, REVOKE, EXECUTE, CALL, COPY).
+
+    Returns *predicate* unchanged when it looks safe.
+    Raises ``ValueError`` with a clear message otherwise.
+    """
+    if not isinstance(predicate, str):
+        raise ValueError(f"Unsafe {context}: must be a string, got {type(predicate).__name__!r}")
+    if ";" in predicate:
+        raise ValueError(f"Unsafe {context} for partial index: semicolons are not allowed.")
+    if "--" in predicate:
+        raise ValueError(f"Unsafe {context} for partial index: line comments (--) are not allowed.")
+    if "/*" in predicate or "*/" in predicate:
+        raise ValueError(f"Unsafe {context} for partial index: block comments are not allowed.")
+    # Word-boundary keyword check — case-insensitive
+    upper = predicate.upper()
+    for kw in _UNSAFE_PREDICATE_KEYWORDS:
+        # Match whole-word only to avoid rejecting 'created_at' for CREATE etc.
+        if re.search(rf"\b{re.escape(kw)}\b", upper):
+            raise ValueError(
+                f"Unsafe {context} for partial index: keyword {kw!r} is not allowed in predicates."
+            )
+    return predicate
+
+
+# Allowed PostgreSQL base types for array columns.
+# Normalised to uppercase; matched after stripping the trailing [] and optional
+# length specifier (e.g. VARCHAR(255)).
+_ALLOWED_ARRAY_BASE_TYPES = frozenset({
+    "TEXT", "INTEGER", "INT", "BIGINT", "SMALLINT",
+    "DOUBLE PRECISION", "REAL", "FLOAT",
+    "BOOLEAN", "UUID",
+    "DATE", "TIMESTAMP", "TIMESTAMPTZ",
+    "TIMESTAMP WITH TIME ZONE", "TIMESTAMP WITHOUT TIME ZONE",
+    "JSONB", "JSON",
+    "NUMERIC", "DECIMAL",
+    "VARCHAR", "CHARACTER VARYING",
+})
+
+# Patterns that are never safe inside a sql_type value.
+_UNSAFE_SQL_TYPE_RE = re.compile(r";|--|/\*|\*/|'|\"")
+_UNSAFE_SQL_TYPE_KEYWORDS = frozenset({
+    "DROP", "ALTER", "DELETE", "INSERT", "UPDATE", "CREATE",
+    "TRUNCATE", "GRANT", "REVOKE", "EXECUTE", "CALL", "COPY", "SELECT",
+})
+
+
+def _validate_array_sql_type(sql_type: str) -> str:
+    """Validate and normalise an ArrayField sql_type value.
+
+    Requirements:
+      * Must be a non-empty string.
+      * Must end with ``[]`` (case-insensitive normalised to uppercase).
+      * Base type (everything before the final ``[]``) must be on the allowed
+        list after stripping an optional ``(length)`` specifier.
+      * Must not contain semicolons, comments, quotes, or DDL/DML keywords.
+
+    Returns the normalised (uppercased) sql_type string.
+    Raises ``ValueError`` on violation.
+    """
+    if not isinstance(sql_type, str) or not sql_type.strip():
+        raise ValueError(
+            f"ArrayField sql_type must be a non-empty string; got {sql_type!r}"
+        )
+    upper = sql_type.strip().upper()
+    # Reject inline injection patterns
+    if _UNSAFE_SQL_TYPE_RE.search(sql_type):
+        raise ValueError(
+            f"ArrayField sql_type contains unsafe characters: {sql_type!r}"
+        )
+    # Keyword check
+    for kw in _UNSAFE_SQL_TYPE_KEYWORDS:
+        if re.search(rf"\b{re.escape(kw)}\b", upper):
+            raise ValueError(
+                f"ArrayField sql_type contains disallowed keyword {kw!r}: {sql_type!r}"
+            )
+    # Must end with []
+    if not upper.endswith("[]"):
+        raise ValueError(
+            f"ArrayField sql_type must end with '[]', got {sql_type!r}"
+        )
+    # Strip [] and optional (length) to get the base type
+    base = upper[:-2].strip()
+    # Allow optional length specifier like VARCHAR(255)
+    base_no_len = re.sub(r"\(\d+\)$", "", base).strip()
+    if base_no_len not in _ALLOWED_ARRAY_BASE_TYPES:
+        raise ValueError(
+            f"ArrayField sql_type has unknown base type {base_no_len!r}. "
+            f"Allowed base types: {', '.join(sorted(_ALLOWED_ARRAY_BASE_TYPES))}"
+        )
+    return upper
 
 
 def _escape_sql_string(value: str) -> str:
@@ -423,7 +559,7 @@ class ArrayField(FieldOp):
         nullable: bool = True,
         default: Any = None,
     ):
-        self.sql_type = sql_type
+        self.sql_type = _validate_array_sql_type(sql_type)
         self.nullable = nullable
         self.default = default
 
@@ -751,16 +887,20 @@ class ManyToManyField(FieldOp):
         jtn = _quote_ident(self.join_table_name)
         st = _quote_ident(self.source_table)
         tt = _quote_ident(self.target_table)
+        src_constraint = _quote_ident(_make_constraint_name("fk", self.join_table_name, "source"))
+        tgt_constraint = _quote_ident(_make_constraint_name("fk", self.join_table_name, "target"))
+        src_col = _quote_ident(self.source_column)
+        tgt_col = _quote_ident(self.target_column)
         return f'''CREATE TABLE IF NOT EXISTS {jtn} (
     "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     "source_id" UUID NOT NULL,
     "target_id" UUID NOT NULL,
     "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    CONSTRAINT fk_{self.join_table_name}_source 
-        FOREIGN KEY (source_id) REFERENCES {st}({self.source_column}) ON DELETE CASCADE,
-    CONSTRAINT fk_{self.join_table_name}_target 
-        FOREIGN KEY (target_id) REFERENCES {tt}({self.target_column}) ON DELETE CASCADE,
-    UNIQUE (source_id, target_id)
+    CONSTRAINT {src_constraint}
+        FOREIGN KEY ("source_id") REFERENCES {st}({src_col}) ON DELETE CASCADE,
+    CONSTRAINT {tgt_constraint}
+        FOREIGN KEY ("target_id") REFERENCES {tt}({tgt_col}) ON DELETE CASCADE,
+    UNIQUE ("source_id", "target_id")
 )'''
     
     def get_drop_join_table_sql(self) -> str:
@@ -1040,7 +1180,7 @@ class IndexOp:
         self.table = table
         self.columns = columns
         self.unique = unique
-        self.where = where
+        self.where = _validate_sql_predicate(where, context="IndexOp.where") if where is not None else None
         self.method = method
     
     def to_sql(self) -> str:

--- a/aksara/migrations/operations.py
+++ b/aksara/migrations/operations.py
@@ -1755,14 +1755,27 @@ class AddConstraint(Operation):
         return f"AddConstraint(table='{self.table}', name='{self.name}')"
 
 
+def _is_missing_constraint_error(exc: Exception) -> bool:
+    """Return True when *exc* indicates the constraint does not exist.
+
+    Prefers SQLSTATE 42704 (undefined_object) which asyncpg exposes on the
+    exception as ``exc.sqlstate``.  Falls back to English message matching only
+    when sqlstate is not available (e.g. wrapped exceptions, future drivers).
+    """
+    sqlstate = getattr(exc, "sqlstate", None)
+    if sqlstate is not None:
+        return sqlstate == "42704"
+    return "does not exist" in str(exc).lower()
+
+
 class RemoveConstraint(Operation):
     """
     Remove a constraint from a table.
-    
+
     Example:
         RemoveConstraint(table="users", name="check_age_positive")
     """
-    
+
     def __init__(
         self,
         table: str,
@@ -1773,18 +1786,18 @@ class RemoveConstraint(Operation):
         self.table = table
         self.name = name
         self.if_exists = if_exists
-    
+
     async def apply(self, connection) -> None:
         """Drop the constraint."""
         # PostgreSQL doesn't support IF EXISTS for constraints directly
         sql = f'ALTER TABLE {_quote_ident(self.table)} DROP CONSTRAINT {_quote_ident(self.name)}'
-        
+
         if hasattr(connection, 'execute'):
             try:
                 await connection.execute(sql)
             except Exception as e:
-                if self.if_exists and "does not exist" in str(e).lower():
-                    pass  # Ignore if it doesn't exist
+                if self.if_exists and _is_missing_constraint_error(e):
+                    pass  # Constraint absent — suppress when if_exists=True
                 else:
                     raise
         else:

--- a/aksara/migrations/operations.py
+++ b/aksara/migrations/operations.py
@@ -1931,12 +1931,26 @@ def _is_missing_constraint_error(exc: Exception) -> bool:
 
     Prefers SQLSTATE 42704 (undefined_object) which asyncpg exposes on the
     exception as ``exc.sqlstate``.  Falls back to English message matching only
-    when sqlstate is not available (e.g. wrapped exceptions, future drivers).
+    when sqlstate is not available anywhere on the wrapped exception chain.
     """
-    sqlstate = getattr(exc, "sqlstate", None)
+    sqlstate = _extract_sqlstate(exc)
     if sqlstate is not None:
         return sqlstate == "42704"
     return "does not exist" in str(exc).lower()
+
+
+def _extract_sqlstate(exc: BaseException) -> str | None:
+    """Return the first available SQLSTATE from an exception chain."""
+    for candidate in (
+        exc,
+        getattr(exc, "original_exception", None),
+        getattr(exc, "__cause__", None),
+        getattr(exc, "__context__", None),
+    ):
+        sqlstate = getattr(candidate, "sqlstate", None)
+        if sqlstate is not None:
+            return sqlstate
+    return None
 
 
 class RemoveConstraint(Operation):

--- a/aksara/migrations/operations.py
+++ b/aksara/migrations/operations.py
@@ -1949,6 +1949,7 @@ __all__ = [
     "EnumField",
     "OneToOneField",
     "ManyToManyField",
+    "ArrayField",
     # Extended field types (Django parity)
     "SlugField",
     "TimeField",

--- a/aksara/migrations/operations.py
+++ b/aksara/migrations/operations.py
@@ -167,6 +167,12 @@ _ALLOWED_ARRAY_BASE_TYPES = frozenset({
     "NUMERIC", "DECIMAL",
     "VARCHAR", "CHARACTER VARYING",
 })
+_ARRAY_LENGTH_TYPES = frozenset({"VARCHAR", "CHARACTER VARYING"})
+_ARRAY_PRECISION_SCALE_TYPES = frozenset({"NUMERIC", "DECIMAL"})
+_ARRAY_TIMESTAMP_PRECISION_TYPES = frozenset({
+    "TIMESTAMP", "TIMESTAMPTZ",
+    "TIMESTAMP WITH TIME ZONE", "TIMESTAMP WITHOUT TIME ZONE",
+})
 
 # Patterns that are never safe inside a sql_type value.
 _UNSAFE_SQL_TYPE_RE = re.compile(r";|--|/\*|\*/|'|\"")
@@ -174,7 +180,41 @@ _UNSAFE_SQL_TYPE_KEYWORDS = frozenset({
     "DROP", "ALTER", "DELETE", "INSERT", "UPDATE", "CREATE",
     "TRUNCATE", "GRANT", "REVOKE", "EXECUTE", "CALL", "COPY", "SELECT",
 })
-_ARRAY_SQL_TYPE_ARGS_RE = re.compile(r"^([A-Z ]+)\((\d+)(?:\s*,\s*\d+)?\)$")
+_ARRAY_SQL_TYPE_ARGS_RE = re.compile(r"^([A-Z ]+)\(([^()]*)\)$")
+
+
+def _validate_array_sql_type_args(base_name: str, args_spec: str, sql_type: str) -> None:
+    """Validate a parenthesized ArrayField base-type argument specifier."""
+    parts = [part.strip() for part in args_spec.split(",")]
+    if any(not part or not part.isdigit() for part in parts):
+        raise ValueError(
+            f"ArrayField sql_type has malformed length/precision specifier: {sql_type!r}"
+        )
+
+    if base_name in _ARRAY_LENGTH_TYPES:
+        if len(parts) == 1:
+            return
+        raise ValueError(
+            f"ArrayField sql_type has malformed length/precision specifier: {sql_type!r}"
+        )
+
+    if base_name in _ARRAY_PRECISION_SCALE_TYPES:
+        if len(parts) in {1, 2}:
+            return
+        raise ValueError(
+            f"ArrayField sql_type has malformed length/precision specifier: {sql_type!r}"
+        )
+
+    if base_name in _ARRAY_TIMESTAMP_PRECISION_TYPES:
+        if len(parts) == 1:
+            return
+        raise ValueError(
+            f"ArrayField sql_type has malformed length/precision specifier: {sql_type!r}"
+        )
+
+    raise ValueError(
+        f"ArrayField sql_type base type {base_name!r} does not allow length/precision specifier: {sql_type!r}"
+    )
 
 
 def _validate_array_sql_type(sql_type: str) -> str:
@@ -217,6 +257,12 @@ def _validate_array_sql_type(sql_type: str) -> str:
     args_match = _ARRAY_SQL_TYPE_ARGS_RE.fullmatch(base)
     if args_match:
         base_name = args_match.group(1).strip()
+        if base_name not in _ALLOWED_ARRAY_BASE_TYPES:
+            raise ValueError(
+                f"ArrayField sql_type has unknown base type {base_name!r}. "
+                f"Allowed base types: {', '.join(sorted(_ALLOWED_ARRAY_BASE_TYPES))}"
+            )
+        _validate_array_sql_type_args(base_name, args_match.group(2), sql_type)
     elif "(" in base or ")" in base:
         raise ValueError(
             f"ArrayField sql_type has malformed length/precision specifier: {sql_type!r}"

--- a/aksara/migrations/operations.py
+++ b/aksara/migrations/operations.py
@@ -64,6 +64,23 @@ def _validate_fk_action(action: str) -> str:
     return normalised
 
 
+def _truncate_utf8(value: str, max_bytes: int) -> str:
+    """Truncate a string to a UTF-8 byte budget without splitting characters."""
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+
+    out: list[str] = []
+    used = 0
+    for ch in value:
+        ch_bytes = ch.encode("utf-8")
+        if used + len(ch_bytes) > max_bytes:
+            break
+        out.append(ch)
+        used += len(ch_bytes)
+    return "".join(out)
+
+
 def _make_constraint_name(*parts: str, max_length: int = 63) -> str:
     """Build a deterministic PostgreSQL-safe constraint identifier.
 
@@ -71,7 +88,7 @@ def _make_constraint_name(*parts: str, max_length: int = 63) -> str:
     bytes it is returned as-is.  When it exceeds the limit the name is
     truncated to leave room for an 8-character stable hash suffix so that:
 
-      * The result is always <= *max_length* characters.
+      * The result is always <= *max_length* UTF-8 bytes.
       * Different long names produce different constraint names (no silent
         collision).
       * The output is deterministic across runs.
@@ -83,13 +100,14 @@ def _make_constraint_name(*parts: str, max_length: int = 63) -> str:
         raise ValueError("max_length must be at least 10")
 
     full = "_".join(p for p in parts if p)
-    if len(full) <= max_length:
+    if len(full.encode("utf-8")) <= max_length:
         return full
     # Hash the full name for a stable suffix; use first 8 hex chars.
-    suffix = hashlib.sha256(full.encode()).hexdigest()[:8]
+    suffix = hashlib.sha256(full.encode("utf-8")).hexdigest()[:8]
     # Trim to make room: max_length - 1 underscore - 8 hash chars
-    prefix = full[: max_length - 9]
-    return f"{prefix}_{suffix}"
+    prefix = _truncate_utf8(full, max_length - 9)
+    result = f"{prefix}_{suffix}"
+    return result
 
 
 # DDL/DML keywords that must never appear in a partial-index predicate.

--- a/aksara/migrations/operations.py
+++ b/aksara/migrations/operations.py
@@ -79,6 +79,9 @@ def _make_constraint_name(*parts: str, max_length: int = 63) -> str:
     Callers must pass the result through ``_quote_ident()`` before embedding
     in SQL.
     """
+    if max_length < 10:
+        raise ValueError("max_length must be at least 10")
+
     full = "_".join(p for p in parts if p)
     if len(full) <= max_length:
         return full
@@ -113,6 +116,9 @@ def _validate_sql_predicate(predicate: str, *, context: str = "SQL predicate") -
     """
     if not isinstance(predicate, str):
         raise ValueError(f"Unsafe {context}: must be a string, got {type(predicate).__name__!r}")
+    predicate = predicate.strip()
+    if not predicate:
+        raise ValueError(f"Unsafe {context} for partial index: predicate must not be empty.")
     if ";" in predicate:
         raise ValueError(f"Unsafe {context} for partial index: semicolons are not allowed.")
     if "--" in predicate:

--- a/aksara/testing.py
+++ b/aksara/testing.py
@@ -187,46 +187,23 @@ async def create_test_app(
 
 
 async def _apply_test_migrations(database_url: str) -> None:
-    """Apply pending migrations for testing."""
+    """Apply pending migrations via the canonical executor path.
+
+    Delegates to apply_migrations() so test environments get the same
+    advisory-lock, transaction-per-migration, SQL-splitting, and checksum
+    guarantees as production runs.  Previously this helper used a manual
+    loop that recorded NULL checksums and skipped transaction wrapping.
+    """
     from pathlib import Path
     from aksara.db import Database
     from aksara.conf import settings
-    from aksara.migrations.executor import (
-        discover_migrations,
-        get_pending_migrations,
-        ensure_migrations_table,
-        get_applied_migrations,
-        record_migration,
-        load_migration_module,
-        discover_internal_migrations,
-    )
-    
+    from aksara.migrations.executor import apply_migrations
+
+    mig_dir = Path(settings.migrations_dir)
     db = Database(database_url)
     await db.connect()
-    
     try:
-        await ensure_migrations_table(db)
-        applied = await get_applied_migrations(db)
-        
-        # Discover all migrations
-        mig_dir = Path(settings.migrations_dir)
-        user_migrations = discover_migrations(mig_dir) if mig_dir.exists() else []
-        internal_migrations = discover_internal_migrations()
-        all_migrations = user_migrations + internal_migrations
-        
-        pending = get_pending_migrations(all_migrations, applied)
-        
-        for name, path in pending:
-            if path.suffix == ".py":
-                migration_class = load_migration_module(path)
-                migration = migration_class()
-                for op in migration.operations:
-                    await op.apply(db)
-                await record_migration(db, name)
-            elif path.suffix == ".sql":
-                sql = path.read_text()
-                await db.execute(sql)
-                await record_migration(db, name)
+        await apply_migrations(db, mig_dir, fake=False, verbose=False, include_internal=True)
     finally:
         await db.disconnect()
 

--- a/aksara/testing.py
+++ b/aksara/testing.py
@@ -193,6 +193,11 @@ async def _apply_test_migrations(database_url: str) -> None:
     advisory-lock, transaction-per-migration, SQL-splitting, and checksum
     guarantees as production runs.  Previously this helper used a manual
     loop that recorded NULL checksums and skipped transaction wrapping.
+
+    Raises:
+        RuntimeError: If apply_migrations() reports one or more migration
+            errors, including the first failed migration and any skipped
+            pending migrations.
     """
     from pathlib import Path
     from aksara.db import Database
@@ -203,7 +208,23 @@ async def _apply_test_migrations(database_url: str) -> None:
     db = Database(database_url)
     await db.connect()
     try:
-        await apply_migrations(db, mig_dir, fake=False, verbose=False, include_internal=True)
+        result = await apply_migrations(
+            db,
+            mig_dir,
+            fake=False,
+            verbose=False,
+            include_internal=True,
+        )
+        errors = result.get("errors") or []
+        if errors:
+            failed_name, failed_error = errors[0]
+            pending_skipped = result.get("pending_skipped") or []
+            message = (
+                f"Test migration application failed at {failed_name}: {failed_error}."
+            )
+            if pending_skipped:
+                message += f" Pending migrations skipped: {pending_skipped}"
+            raise RuntimeError(message)
     finally:
         await db.disconnect()
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -35,13 +35,39 @@ All notable changes to Aksara.
   item types (`str`, `int`, `float`, `bool`, `UUID`) to PostgreSQL array type
   strings.
 
+### Migration Safety (P1 Fixes)
+
+- **Generated migration warnings**: `operations_to_code()` emits a `# WARNING`
+  comment before any `op.AddField` that is `nullable=False` with no `default`.
+  Adding a non-null column without a default fails on non-empty tables; the
+  comment directs developers to use a temporary default, a backfill, or a
+  nullable-first data-migration pair. Primary-key fields are exempt.
+- **Checksum recording and verification**: Python migration files now have
+  their SHA-256 checksum stored in `aksara_migrations.checksum` when applied
+  (previously only SQL migrations stored a checksum). Before running pending
+  migrations, `apply_migrations()` verifies the on-disk checksum of every
+  already-applied migration. A mismatch raises `ValueError` with the migration
+  name and clear instructions. Rows with `NULL` checksums (pre-v0.5.50) are
+  warned about but not rejected.
+- **Migration graph load errors**: `build_migration_graph()` now accepts
+  `strict: bool = True`. In strict mode a migration file that cannot be loaded
+  raises `ValueError` with the migration name, file path, and original error.
+  Previously the error was silently logged and the migration was added as a
+  dependency-less root node. Pass `strict=False` to restore the old best-effort
+  behaviour for tooling that needs to inspect partially-broken graphs.
+- **Skipped migration reporting**: `apply_migrations()` result dict now
+  includes `"pending_skipped": list[str]`. When a migration fails, all
+  remaining pending migrations that were not attempted are listed here. Verbose
+  mode logs each skipped name.
+
 ### Tests
 
 - Added `tests/migrations/test_v0550_safety.py` with 29 unit tests covering
-  all six P0 fixes (transaction wrapping, fake-mode behavior, rollback on
-  failure, multi-statement SQL, `_split_sql_statements` edge cases, three-state
-  DFS cycle detection including diamond and self-cycles, advisory lock
-  acquisition and release).
+  all P0 fixes (transaction wrapping, fake-mode behavior, rollback on failure,
+  multi-statement SQL, `_split_sql_statements` edge cases, three-state DFS
+  cycle detection, advisory lock acquisition and release).
+- Added `tests/migrations/test_v0550_p1_safety.py` with 34 unit and DB-backed
+  tests covering all four P1 fixes.
 
 ---
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -8,6 +8,25 @@ All notable changes to Aksara.
 
 ## Unreleased — v0.5.50 Migration Safety Patch
 
+### Migration Safety (P2-B Guardrails)
+
+- **M2M constraint name quoting and length bounding**: `ManyToManyField.get_join_table_sql()`
+  now uses a new `_make_constraint_name()` helper that truncates deterministically (SHA-256
+  suffix) when the name exceeds PostgreSQL's 63-byte identifier limit. Constraint names are
+  double-quoted via `_quote_ident()`. Source/target column references are also quoted.
+- **Partial-index predicate validation**: `IndexOp.__init__()` now validates the `where`
+  predicate through `_validate_sql_predicate()` at construction time. The check rejects
+  semicolons, line and block comments, and DDL/DML keywords (DROP, ALTER, DELETE, INSERT,
+  UPDATE, CREATE, TRUNCATE, GRANT, REVOKE, EXECUTE, CALL, COPY) using whole-word matching.
+  Safe predicates like `created_at > NOW()` are not affected.
+- **ArrayField sql_type validation**: `ArrayField.__init__()` now validates `sql_type`
+  through `_validate_array_sql_type()` at construction time. Only types from an explicit
+  allowlist of PostgreSQL base types are accepted. The value is normalised to uppercase.
+  Injection patterns (semicolons, comments, quotes, DDL keywords) are rejected outright.
+  **Migration note**: `ArrayField(sql_type="text[]")` now normalises to `"TEXT[]"`.
+  Custom or third-party PostgreSQL array base types not on the allowlist will raise
+  `ValueError` at construction time; open an issue to have them added.
+
 ### Migration Cleanup (P2-A)
 
 - Removed dead `Migration._initialized` flag. The flag was set in `__init__`
@@ -83,6 +102,12 @@ All notable changes to Aksara.
   cycle detection, advisory lock acquisition and release).
 - Added `tests/migrations/test_v0550_p1_safety.py` with 34 unit and DB-backed
   tests covering all four P1 fixes.
+- Added `tests/migrations/test_v0550_p2a_cleanup.py` with 22 regression tests
+  covering all four P2-A cleanups.
+- Added `tests/migrations/test_v0550_p2b_guardrails.py` with 62 unit tests
+  covering `_make_constraint_name`, M2M constraint quoting, `_validate_sql_predicate`,
+  `IndexOp.where` validation, `_validate_array_sql_type`, and `ArrayField` construction
+  validation.
 
 ---
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -6,6 +6,45 @@ All notable changes to Aksara.
 
 ---
 
+## Unreleased — v0.5.50 Migration Safety Patch
+
+### Migration Safety (P0 Fixes)
+
+- **Transaction atomicity**: Python migrations now wrap all operations and
+  `record_migration` in a single `connection.transaction()` block. A failed
+  operation rolls back all prior operations from the same migration; the
+  migration is never recorded as applied unless every operation succeeds.
+- **Advisory lock**: `apply_migrations()` acquires a PostgreSQL session-level
+  advisory lock before inspecting applied migrations, preventing two concurrent
+  processes from running migrations simultaneously. The lock is always released
+  in a `finally` block.
+- **Multi-statement SQL**: SQL migrations no longer rely on a single
+  `connection.execute()` call (asyncpg only runs the first statement). A new
+  `_split_sql_statements()` helper splits on `;` boundaries; each statement is
+  executed individually inside the same transaction as `record_migration`.
+- **Cycle detection**: `MigrationGraph.execution_order()` now uses a three-state
+  DFS (unvisited → visiting → done). A back-edge raises `ValueError` with a
+  human-readable description of the cycle. Previously, cycles would silently
+  produce incomplete or incorrect ordering.
+- **`ArrayField` in `operations.__all__`**: `ArrayField` was missing from
+  `__all__`, making it invisible to `from aksara.migrations.operations import *`.
+  It is now included.
+- **Array codegen**: `model_to_create_table()` was generating
+  `op.TextField(item_type=...)` for `Array` fields — an invalid call.  It now
+  generates `op.ArrayField(sql_type=...)`, using `Array.TYPE_MAP` to map Python
+  item types (`str`, `int`, `float`, `bool`, `UUID`) to PostgreSQL array type
+  strings.
+
+### Tests
+
+- Added `tests/migrations/test_v0550_safety.py` with 29 unit tests covering
+  all six P0 fixes (transaction wrapping, fake-mode behavior, rollback on
+  failure, multi-statement SQL, `_split_sql_statements` edge cases, three-state
+  DFS cycle detection including diamond and self-cycles, advisory lock
+  acquisition and release).
+
+---
+
 ## v0.5.49 — Security Hardening & Release Trust
 
 ### Security

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -73,14 +73,18 @@ does not require any action on existing projects.
 
 ### Unified execution path
 
-- **One canonical executor**: `aksara migrate` and the testing helpers now apply
-  migrations through the same canonical executor. Previously the CLI and the test
-  helper each had their own apply loop that bypassed transactions, the advisory
-  lock, SQL statement splitting, and checksum recording.
-- **Consistent guarantees everywhere**: because every entry point shares the same
-  executor, CLI runs and test runs get the same transactions, advisory lock, SQL
-  splitting, checksum recording, and checksum verification. Test environments no
-  longer record empty checksums or emit spurious checksum warnings on later runs.
+- **One canonical executor for file-based migrations**: `aksara migrate` and the
+  testing helpers now apply file-based migrations through the same canonical
+  executor. Previously the CLI and the test helper each had their own apply loop
+  that bypassed transactions, the advisory lock, SQL statement splitting, and
+  checksum recording.
+- **Consistent guarantees for file-based CLI and test runs**: because those
+  entry points now share the same executor for file-based migrations, CLI runs
+  and test runs get the same transactions, advisory lock, SQL splitting,
+  checksum recording, and checksum verification. Test environments no longer
+  record empty checksums or emit spurious checksum warnings on later runs. The
+  legacy model-based CLI fallback remains available for bootstrap scenarios and
+  does not provide the full file-based migration integrity model.
 - The dry-run preview path is unchanged.
 
 ### Compatibility notes

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -8,6 +8,27 @@ All notable changes to Aksara.
 
 ## Unreleased — v0.5.50 Migration Safety Patch
 
+### Migration Execution Unification (P2-C-lite)
+
+- **CLI migrate now uses the canonical executor path**: `aksara migrate` previously applied
+  migrations through its own manual loop, bypassing the advisory lock, transaction wrapping,
+  SQL statement splitting, and checksum recording introduced in P0/P1. It now delegates to
+  `aksara.migrations.executor.apply_migrations()` for all real and fake-mode runs. The
+  dry-run preview path is unchanged.
+- **Testing helper uses the canonical executor path**: `aksara.testing._apply_test_migrations()`
+  previously applied migrations without transactions and recorded `NULL` checksums. It now
+  delegates to `apply_migrations()`, giving test environments the same safety guarantees as
+  production runs and eliminating spurious checksum warnings on subsequent `apply_migrations()`
+  calls.
+- **CLI legacy helpers preserved**: `MIGRATION_TABLE_SQL`, `compute_checksum`,
+  `ensure_migrations_table`, `get_applied_migrations`, and `record_migration` remain importable
+  from `aksara.cli.main` as compatibility shims. New code should import from
+  `aksara.migrations.executor`.
+- **Deferred**: Migration table schema versioning (`app_label` column, `schema_version` column,
+  `UNIQUE(app_label, name)` redesign) and automatic checksum backfill are deferred to a future
+  design pass. Automatic backfill cannot be done safely because it would bless already-modified
+  migration files with their current checksum, defeating tamper detection.
+
 ### Migration Safety (P2-B Guardrails)
 
 - **M2M constraint name quoting and length bounding**: `ManyToManyField.get_join_table_sql()`
@@ -108,6 +129,10 @@ All notable changes to Aksara.
   covering `_make_constraint_name`, M2M constraint quoting, `_validate_sql_predicate`,
   `IndexOp.where` validation, `_validate_array_sql_type`, and `ArrayField` construction
   validation.
+- Added `tests/migrations/test_v0550_p2c_unification.py` with 17 unit tests verifying
+  that the CLI `migrate` command and the testing helper both delegate to
+  `apply_migrations()`, that the CLI no longer calls `op.apply()` directly, and that
+  `record_migration` is not called independently from the testing helper.
 
 ---
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -6,133 +6,113 @@ All notable changes to Aksara.
 
 ---
 
-## Unreleased — v0.5.50 Migration Safety Patch
+## Unreleased — v0.5.50 Migration Safety & Correctness
 
-### Migration Execution Unification (P2-C-lite)
+This patch makes migrations apply safely and consistently across every entry
+point, verifies the integrity of already-applied migrations, and hardens the SQL
+that the framework generates. It does not change the migration file format and
+does not require any action on existing projects.
 
-- **CLI migrate now uses the canonical executor path**: `aksara migrate` previously applied
-  migrations through its own manual loop, bypassing the advisory lock, transaction wrapping,
-  SQL statement splitting, and checksum recording introduced in P0/P1. It now delegates to
-  `aksara.migrations.executor.apply_migrations()` for all real and fake-mode runs. The
-  dry-run preview path is unchanged.
-- **Testing helper uses the canonical executor path**: `aksara.testing._apply_test_migrations()`
-  previously applied migrations without transactions and recorded `NULL` checksums. It now
-  delegates to `apply_migrations()`, giving test environments the same safety guarantees as
-  production runs and eliminating spurious checksum warnings on subsequent `apply_migrations()`
-  calls.
-- **CLI legacy helpers preserved**: `MIGRATION_TABLE_SQL`, `compute_checksum`,
-  `ensure_migrations_table`, `get_applied_migrations`, and `record_migration` remain importable
-  from `aksara.cli.main` as compatibility shims. New code should import from
-  `aksara.migrations.executor`.
-- **Deferred**: Migration table schema versioning (`app_label` column, `schema_version` column,
-  `UNIQUE(app_label, name)` redesign) and automatic checksum backfill are deferred to a future
-  design pass. Automatic backfill cannot be done safely because it would bless already-modified
-  migration files with their current checksum, defeating tamper detection.
+### Migration execution safety
 
-### Migration Safety (P2-B Guardrails)
+- **Transactional Python migrations**: every operation in a Python migration and
+  the row that records the migration as applied now run inside a single
+  transaction. If any operation fails, the whole migration rolls back and is
+  never recorded as applied.
+- **Statement-by-statement SQL migrations**: SQL migrations are split into
+  individual statements and executed one at a time inside the same transaction
+  as the recording step, so multi-statement SQL files apply completely instead
+  of stopping after the first statement.
+- **Advisory lock**: applying migrations now acquires a PostgreSQL advisory lock
+  before inspecting and running pending migrations, so two processes cannot run
+  migrations at the same time. The lock is always released, even on failure.
+- **Cycle detection**: the migration dependency graph detects circular
+  dependencies and raises a clear error naming the cycle instead of silently
+  producing an incorrect order.
 
-- **M2M constraint name quoting and length bounding**: `ManyToManyField.get_join_table_sql()`
-  now uses a new `_make_constraint_name()` helper that truncates deterministically (SHA-256
-  suffix) when the name exceeds PostgreSQL's 63-byte identifier limit. Constraint names are
-  double-quoted via `_quote_ident()`. Source/target column references are also quoted.
-- **Partial-index predicate validation**: `IndexOp.__init__()` now validates the `where`
-  predicate through `_validate_sql_predicate()` at construction time. The check rejects
-  semicolons, line and block comments, and DDL/DML keywords (DROP, ALTER, DELETE, INSERT,
-  UPDATE, CREATE, TRUNCATE, GRANT, REVOKE, EXECUTE, CALL, COPY) using whole-word matching.
-  Safe predicates like `created_at > NOW()` are not affected.
-- **ArrayField sql_type validation**: `ArrayField.__init__()` now validates `sql_type`
-  through `_validate_array_sql_type()` at construction time. Only types from an explicit
-  allowlist of PostgreSQL base types are accepted. The value is normalised to uppercase.
-  Injection patterns (semicolons, comments, quotes, DDL keywords) are rejected outright.
-  **Migration note**: `ArrayField(sql_type="text[]")` now normalises to `"TEXT[]"`.
-  Custom or third-party PostgreSQL array base types not on the allowlist will raise
-  `ValueError` at construction time; open an issue to have them added.
+### Migration integrity
 
-### Migration Cleanup (P2-A)
+- **Checksums for Python and SQL migrations**: both Python and SQL migrations now
+  store a checksum when applied. Before running pending migrations, the checksum
+  of every already-applied migration is verified against the file on disk. A
+  mismatch fails with the migration name and clear next steps, so a quietly
+  edited migration cannot be applied as if unchanged.
+- **Backward compatibility**: migrations recorded before this version may have no
+  stored checksum. These are reported as a warning and remain valid — they are
+  not rejected.
+- **Safer generated non-null fields**: adding a non-null field without a default
+  fails on a table that already has rows. Generated migrations now include a
+  warning comment on such fields, pointing to a temporary default, a backfill, or
+  a nullable-first data migration. Primary keys are exempt.
 
-- Removed dead `Migration._initialized` flag. The flag was set in `__init__`
-  but never read. `Migration` subclasses instantiate identically.
-- Removed unreachable `isinstance(field, type(None))` branch from the
-  autodetector's `_model_field_to_op()`. The `else` fallback already covers
-  unknown field types.
-- `RemoveConstraint.apply()` now uses a `_is_missing_constraint_error()`
-  helper that prefers SQLSTATE `42704` (PostgreSQL `undefined_object`) over
-  English message text matching. The string fallback is kept for wrapped
-  exceptions that do not expose `sqlstate`.
-- CLI `aksara migrate` now displays which pending migrations were skipped after
-  a failure, via a new `_display_pending_skipped()` helper. The warning is only
-  shown when there are remaining migrations and only in non-dry-run mode.
+### Failure reporting
 
-### Migration Safety (P0 Fixes)
+- **Strict graph loading by default**: a migration file that cannot be loaded now
+  raises a clear error naming the migration, its path, and the underlying cause,
+  instead of being silently skipped. A non-strict mode remains available for
+  tooling that needs to inspect a partially broken graph.
+- **Pending migrations skipped after a failure**: when a migration fails, the
+  remaining pending migrations that were not attempted are reported, and the CLI
+  shows which migrations were skipped.
 
-- **Transaction atomicity**: Python migrations now wrap all operations and
-  `record_migration` in a single `connection.transaction()` block. A failed
-  operation rolls back all prior operations from the same migration; the
-  migration is never recorded as applied unless every operation succeeds.
-- **Advisory lock**: `apply_migrations()` acquires a PostgreSQL session-level
-  advisory lock before inspecting applied migrations, preventing two concurrent
-  processes from running migrations simultaneously. The lock is always released
-  in a `finally` block.
-- **Multi-statement SQL**: SQL migrations no longer rely on a single
-  `connection.execute()` call (asyncpg only runs the first statement). A new
-  `_split_sql_statements()` helper splits on `;` boundaries; each statement is
-  executed individually inside the same transaction as `record_migration`.
-- **Cycle detection**: `MigrationGraph.execution_order()` now uses a three-state
-  DFS (unvisited → visiting → done). A back-edge raises `ValueError` with a
-  human-readable description of the cycle. Previously, cycles would silently
-  produce incomplete or incorrect ordering.
-- **`ArrayField` in `operations.__all__`**: `ArrayField` was missing from
-  `__all__`, making it invisible to `from aksara.migrations.operations import *`.
-  It is now included.
-- **Array codegen**: `model_to_create_table()` was generating
-  `op.TextField(item_type=...)` for `Array` fields — an invalid call.  It now
-  generates `op.ArrayField(sql_type=...)`, using `Array.TYPE_MAP` to map Python
-  item types (`str`, `int`, `float`, `bool`, `UUID`) to PostgreSQL array type
-  strings.
+### SQL-generation guardrails
 
-### Migration Safety (P1 Fixes)
+- **Many-to-many constraint and column quoting**: join-table constraint names are
+  deterministic, double-quoted, and bounded to PostgreSQL's identifier length
+  limit; source and target column references are quoted.
+- **Partial-index predicate validation**: an index `where` predicate is validated
+  when it is defined. Obvious unsafe patterns — statement terminators, comments,
+  and DDL/DML keywords — are rejected. Ordinary predicates such as
+  `created_at > NOW()` are unaffected.
+- **Array field type validation**: an array field's SQL type is validated against
+  an allowlist of PostgreSQL base types and normalised to a canonical form.
+  Injection-style input is rejected when the field is defined.
+  **Compatibility note**: `ArrayField(sql_type="text[]")` now normalises to
+  `"TEXT[]"`. A base type that is not on the allowlist raises an error when the
+  field is defined; open an issue to have additional types added.
 
-- **Generated migration warnings**: `operations_to_code()` emits a `# WARNING`
-  comment before any `op.AddField` that is `nullable=False` with no `default`.
-  Adding a non-null column without a default fails on non-empty tables; the
-  comment directs developers to use a temporary default, a backfill, or a
-  nullable-first data-migration pair. Primary-key fields are exempt.
-- **Checksum recording and verification**: Python migration files now have
-  their SHA-256 checksum stored in `aksara_migrations.checksum` when applied
-  (previously only SQL migrations stored a checksum). Before running pending
-  migrations, `apply_migrations()` verifies the on-disk checksum of every
-  already-applied migration. A mismatch raises `ValueError` with the migration
-  name and clear instructions. Rows with `NULL` checksums (pre-v0.5.50) are
-  warned about but not rejected.
-- **Migration graph load errors**: `build_migration_graph()` now accepts
-  `strict: bool = True`. In strict mode a migration file that cannot be loaded
-  raises `ValueError` with the migration name, file path, and original error.
-  Previously the error was silently logged and the migration was added as a
-  dependency-less root node. Pass `strict=False` to restore the old best-effort
-  behaviour for tooling that needs to inspect partially-broken graphs.
-- **Skipped migration reporting**: `apply_migrations()` result dict now
-  includes `"pending_skipped": list[str]`. When a migration fails, all
-  remaining pending migrations that were not attempted are listed here. Verbose
-  mode logs each skipped name.
+### Unified execution path
+
+- **One canonical executor**: `aksara migrate` and the testing helpers now apply
+  migrations through the same canonical executor. Previously the CLI and the test
+  helper each had their own apply loop that bypassed transactions, the advisory
+  lock, SQL statement splitting, and checksum recording.
+- **Consistent guarantees everywhere**: because every entry point shares the same
+  executor, CLI runs and test runs get the same transactions, advisory lock, SQL
+  splitting, checksum recording, and checksum verification. Test environments no
+  longer record empty checksums or emit spurious checksum warnings on later runs.
+- The dry-run preview path is unchanged.
+
+### Compatibility notes
+
+- The migration file format is unchanged. Existing migrations are not
+  re-generated or altered.
+- Legacy CLI helpers (`MIGRATION_TABLE_SQL`, `compute_checksum`,
+  `ensure_migrations_table`, `get_applied_migrations`, and `record_migration`)
+  remain importable from `aksara.cli.main` as compatibility shims; new code
+  should import from `aksara.migrations.executor`.
+
+### Deferred work
+
+The following migration-metadata items are intentionally **not** part of this
+patch and remain future work:
+
+- Migration metadata schema versioning (a `schema_version` column).
+- An app-label / name identity split (an `app_label` column and a
+  `UNIQUE(app_label, name)` redesign of the tracking table).
+- Automatic checksum backfill for historical rows. Backfilling automatically is
+  unsafe because it would bless already-edited files with their current checksum
+  and defeat tamper detection.
+- A dedicated migration verify/backfill command.
 
 ### Tests
 
-- Added `tests/migrations/test_v0550_safety.py` with 29 unit tests covering
-  all P0 fixes (transaction wrapping, fake-mode behavior, rollback on failure,
-  multi-statement SQL, `_split_sql_statements` edge cases, three-state DFS
-  cycle detection, advisory lock acquisition and release).
-- Added `tests/migrations/test_v0550_p1_safety.py` with 34 unit and DB-backed
-  tests covering all four P1 fixes.
-- Added `tests/migrations/test_v0550_p2a_cleanup.py` with 22 regression tests
-  covering all four P2-A cleanups.
-- Added `tests/migrations/test_v0550_p2b_guardrails.py` with 62 unit tests
-  covering `_make_constraint_name`, M2M constraint quoting, `_validate_sql_predicate`,
-  `IndexOp.where` validation, `_validate_array_sql_type`, and `ArrayField` construction
-  validation.
-- Added `tests/migrations/test_v0550_p2c_unification.py` with 17 unit tests verifying
-  that the CLI `migrate` command and the testing helper both delegate to
-  `apply_migrations()`, that the CLI no longer calls `op.apply()` directly, and that
-  `record_migration` is not called independently from the testing helper.
+- Added unit and DB-backed test coverage for the new migration behavior:
+  transactional application and rollback, fake-mode behavior, multi-statement SQL
+  splitting, cycle detection, advisory lock acquisition and release, checksum
+  recording and verification, strict graph loading, skipped-migration reporting,
+  the SQL-generation guardrails, and the unified executor path shared by the CLI
+  and the testing helpers.
 
 ---
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -8,6 +8,21 @@ All notable changes to Aksara.
 
 ## Unreleased — v0.5.50 Migration Safety Patch
 
+### Migration Cleanup (P2-A)
+
+- Removed dead `Migration._initialized` flag. The flag was set in `__init__`
+  but never read. `Migration` subclasses instantiate identically.
+- Removed unreachable `isinstance(field, type(None))` branch from the
+  autodetector's `_model_field_to_op()`. The `else` fallback already covers
+  unknown field types.
+- `RemoveConstraint.apply()` now uses a `_is_missing_constraint_error()`
+  helper that prefers SQLSTATE `42704` (PostgreSQL `undefined_object`) over
+  English message text matching. The string fallback is kept for wrapped
+  exceptions that do not expose `sqlstate`.
+- CLI `aksara migrate` now displays which pending migrations were skipped after
+  a failure, via a new `_display_pending_skipped()` helper. The warning is only
+  shown when there are remaining migrations and only in non-dry-run mode.
+
 ### Migration Safety (P0 Fixes)
 
 - **Transaction atomicity**: Python migrations now wrap all operations and

--- a/docs/docs/cli/commands.md
+++ b/docs/docs/cli/commands.md
@@ -150,6 +150,20 @@ aksara migrate --fake
 aksara migrate --migrations-dir custom_migrations
 ```
 
+**Behavior:**
+
+- Migrations are applied through the canonical migration executor.
+- Each migration runs inside a transaction; a failed migration rolls back and is
+  not recorded as applied.
+- A PostgreSQL advisory lock prevents two runners from migrating concurrently.
+- Already-applied migrations are skipped. Their checksums are verified first, and
+  a mismatch (an applied migration was edited) fails the run with a clear message.
+- Migrations recorded before checksums existed may warn but are not rejected.
+- If a migration fails, the pending migrations that were skipped are reported.
+
+`--dry-run` only previews; it does not apply migrations. See
+[Migration Safety](../orm/migration-safety.md) for details.
+
 ---
 
 ### status

--- a/docs/docs/cli/index.md
+++ b/docs/docs/cli/index.md
@@ -159,12 +159,14 @@ aksara migrate --migrations-dir dir     # Custom migrations directory
 aksara migrate --database-url URL       # Specify database
 ```
 
-`aksara migrate` applies migrations through the canonical executor: each
-migration runs in a transaction, a PostgreSQL advisory lock prevents concurrent
-runners, already-applied migrations are skipped after their checksums are
-verified, a checksum mismatch fails clearly, historical migrations without a
-checksum may warn, and pending migrations skipped after a failure are reported.
-See [Migration Safety](../orm/migration-safety.md).
+When migration files exist, `aksara migrate` applies them through the canonical
+executor: each migration runs in a transaction, a PostgreSQL advisory lock
+prevents concurrent runners, already-applied migrations are skipped after their
+checksums are verified, a checksum mismatch fails clearly, historical
+migrations without a checksum may warn, and pending migrations skipped after a
+failure are reported. If no migration files exist, the command can still fall
+back to a legacy model-based bootstrap path, which does not provide the full
+file-based migration integrity model. See [Migration Safety](../orm/migration-safety.md).
 
 ### shell
 

--- a/docs/docs/cli/index.md
+++ b/docs/docs/cli/index.md
@@ -159,6 +159,13 @@ aksara migrate --migrations-dir dir     # Custom migrations directory
 aksara migrate --database-url URL       # Specify database
 ```
 
+`aksara migrate` applies migrations through the canonical executor: each
+migration runs in a transaction, a PostgreSQL advisory lock prevents concurrent
+runners, already-applied migrations are skipped after their checksums are
+verified, a checksum mismatch fails clearly, historical migrations without a
+checksum may warn, and pending migrations skipped after a failure are reported.
+See [Migration Safety](../orm/migration-safety.md).
+
 ### shell
 
 Interactive Python shell with models loaded:

--- a/docs/docs/orm/migration-safety.md
+++ b/docs/docs/orm/migration-safety.md
@@ -1,9 +1,10 @@
 # Migration Safety
 
-Aksara applies migrations through a single, canonical execution path designed to
-be safe to run repeatedly, safe to run from more than one place, and safe to run
-against a database that already has data. This page explains what that path does
-and why, so you can reason about what happens when you run `aksara migrate`.
+Aksara applies file-based migrations through a single, canonical execution path
+designed to be safe to run repeatedly, safe to run from more than one place,
+and safe to run against a database that already has data. This page explains
+what that file-based path does and why, so you can reason about what happens
+when you run `aksara migrate` with migration files present.
 
 If you are looking for how to *write* migrations — operations, dependencies, data
 migrations — see [Migrations](migrations.md). This page is about how migrations
@@ -13,17 +14,23 @@ are *applied* and verified.
 
 ## Canonical executor path
 
-Every migration run goes through the same executor in
+File-based migration runs go through the same executor in
 `aksara.migrations.executor`:
 
-- `aksara migrate` applies migrations through it.
+- `aksara migrate` applies file-based migrations through it when migration
+  files exist.
 - The testing helpers (for example, applying migrations in a test database) use
   the same executor.
 
-Because there is one path, local, CI, and production runs get the same
-guarantees: transactions, the advisory lock, SQL statement splitting, checksum
-recording, and checksum verification. There is no "lighter" code path that skips
-safety checks.
+Because file-based migrations share one path, local, CI, and production
+file-based runs get the same guarantees: transactions, the advisory lock, SQL
+statement splitting, checksum recording, and checksum verification.
+
+The legacy model-based fallback path is still available when `aksara migrate`
+finds no migration files. That path is intended for initial/simple bootstrap
+scenarios and does not provide the full file-based migration integrity model.
+In particular, it does not make the same checksum-verification claims as the
+file-based executor.
 
 The `aksara migrate --dry-run` preview path does not apply anything — it only
 shows what would run — and is unchanged.

--- a/docs/docs/orm/migration-safety.md
+++ b/docs/docs/orm/migration-safety.md
@@ -1,0 +1,176 @@
+# Migration Safety
+
+Aksara applies migrations through a single, canonical execution path designed to
+be safe to run repeatedly, safe to run from more than one place, and safe to run
+against a database that already has data. This page explains what that path does
+and why, so you can reason about what happens when you run `aksara migrate`.
+
+If you are looking for how to *write* migrations — operations, dependencies, data
+migrations — see [Migrations](migrations.md). This page is about how migrations
+are *applied* and verified.
+
+---
+
+## Canonical executor path
+
+Every migration run goes through the same executor in
+`aksara.migrations.executor`:
+
+- `aksara migrate` applies migrations through it.
+- The testing helpers (for example, applying migrations in a test database) use
+  the same executor.
+
+Because there is one path, local, CI, and production runs get the same
+guarantees: transactions, the advisory lock, SQL statement splitting, checksum
+recording, and checksum verification. There is no "lighter" code path that skips
+safety checks.
+
+The `aksara migrate --dry-run` preview path does not apply anything — it only
+shows what would run — and is unchanged.
+
+---
+
+## Transactional migration application
+
+A Python migration's operations and the row that records the migration as applied
+run inside a **single transaction**.
+
+- If every operation succeeds, the migration is recorded as applied and the
+  transaction commits.
+- If any operation fails, the entire migration rolls back. Partial operations are
+  not left behind, and the migration is **not** recorded as applied.
+
+This means a failed migration leaves your schema as it was before that migration
+started. You fix the cause and re-run; you do not have to manually undo a
+half-applied migration.
+
+---
+
+## Advisory lock
+
+Before inspecting which migrations are applied and running the pending ones, the
+executor acquires a **PostgreSQL advisory lock**.
+
+This prevents two processes — two deploy steps, a deploy racing a developer, two
+CI jobs — from running migrations against the same database at the same time. The
+second runner does not proceed concurrently; it is told the lock is held. The
+lock is always released when the run finishes, including when a run fails.
+
+---
+
+## SQL migration statement handling
+
+SQL migrations are split into individual statements and executed one at a time,
+inside the same transaction as the recording step.
+
+This matters because the underlying driver runs only the first statement of a
+multi-statement string. Splitting ensures a SQL migration with several statements
+applies completely, not just up to the first `;`.
+
+---
+
+## Checksums and applied migration integrity
+
+When a migration is applied, Aksara stores a checksum of the migration (both
+Python and SQL migrations store one). Before running any pending migrations, the
+executor verifies the checksum of every **already-applied** migration against the
+file currently on disk.
+
+If an already-applied migration file has changed since it was applied, the
+checksums no longer match and the run fails with the migration name and clear next
+steps. This catches the case where an applied migration was edited in place —
+which would otherwise drift your code and your database apart silently.
+
+The rule this enforces is the same one in [Migrations](migrations.md): **do not
+edit a migration that has already been applied.** Create a new migration instead.
+
+---
+
+## Handling historical NULL checksums
+
+Migrations that were applied before checksums were recorded have no stored
+checksum. These rows are still valid — they are **not** rejected. The executor
+reports them with a warning so you know which historical migrations cannot be
+integrity-checked, and continues.
+
+There is intentionally no automatic backfill of these checksums (see
+[Deferred metadata work](#deferred-metadata-work)).
+
+---
+
+## Failure reporting
+
+Two behaviors make failures easier to understand:
+
+- **Strict graph loading by default.** If a migration file cannot be loaded
+  (import error, bad definition), the run fails with a clear error naming the
+  migration, its path, and the underlying cause — instead of silently skipping
+  it and applying an incomplete set. A non-strict mode remains available for
+  tooling that needs to inspect a partially broken graph.
+- **Skipped pending migrations are reported.** When a migration fails, the
+  pending migrations that were not attempted are reported, and the CLI shows you
+  which migrations were skipped, so you know exactly where the run stopped.
+
+---
+
+## Adding non-null fields without defaults
+
+Adding a `nullable=False` column with no default fails on a table that already
+contains rows — PostgreSQL cannot fill the existing rows.
+
+When a generated migration contains such a field, Aksara emits a warning comment
+on it. The comment points you to a safe rollout:
+
+1. Add the column as nullable, or with a temporary default.
+2. Backfill the existing rows.
+3. Then enforce non-null in a follow-up migration.
+
+Primary-key fields are exempt from the warning.
+
+---
+
+## SQL-generation guardrails
+
+The DDL Aksara generates is hardened against malformed and unsafe identifiers:
+
+- **Many-to-many constraints and columns.** Join-table constraint names are
+  deterministic, double-quoted, and bounded to PostgreSQL's identifier length
+  limit; source and target column references are quoted.
+- **Partial-index predicates.** An index `where` predicate is validated when it
+  is defined. Obvious unsafe patterns — statement terminators, comments, and
+  DDL/DML keywords — are rejected. Ordinary predicates such as
+  `created_at > NOW()` are unaffected.
+- **Array field types.** An array field's SQL type is validated against an
+  allowlist of PostgreSQL base types and normalised to a canonical form. For
+  example, `ArrayField(sql_type="text[]")` normalises to `"TEXT[]"`. A base type
+  that is not on the allowlist raises an error when the field is defined; open an
+  issue to have additional types added.
+
+---
+
+## Deferred metadata work
+
+Some migration-metadata features are intentionally **not** implemented yet. They
+are called out here so you do not assume behavior that does not exist:
+
+- **Migration metadata schema versioning** — there is no `schema_version` column
+  on the tracking table.
+- **App-label / name identity split** — there is no `app_label` column and no
+  `UNIQUE(app_label, name)` redesign of the tracking table.
+- **Automatic checksum backfill** — historical NULL-checksum rows are not
+  backfilled automatically. Doing so would bless already-edited files with their
+  current checksum and defeat tamper detection.
+- **A migration verify/backfill command** — there is no dedicated command for
+  this yet.
+
+The internal `aksara_migrations` tracking table layout may change when this work
+lands. See the [v0.6 Stability Contract](../roadmap/v0-6-stability-contract.md)
+for what is and is not a stable contract.
+
+---
+
+## Related Documentation
+
+- [Migrations](migrations.md) — writing migrations, operations, dependencies
+- [CLI Reference](../cli/index.md) — `aksara migrate` and `aksara status`
+- [v0.6 Stability Contract](../roadmap/v0-6-stability-contract.md) — what is stable

--- a/docs/docs/orm/migrations.md
+++ b/docs/docs/orm/migrations.md
@@ -137,6 +137,18 @@ aksara status
 #  [ ] 0003_auto_add_avatar              # Not applied
 ```
 
+### How Migrations Are Applied Safely
+
+`aksara migrate` and the testing helpers apply migrations through one canonical
+executor that wraps each migration in a transaction, takes a PostgreSQL advisory
+lock so two processes cannot migrate at once, executes multi-statement SQL
+statement-by-statement, and verifies the checksum of every already-applied
+migration before running new ones.
+
+See [Migration Safety](migration-safety.md) for the full behavior, including what
+happens when a migration fails, what a checksum mismatch means, and how historical
+migrations without a stored checksum are handled.
+
 ---
 
 ## Migration Operations
@@ -452,6 +464,10 @@ Once a migration has been applied to any environment:
 - Don't modify it
 - Create a new migration for further changes
 
+Aksara enforces this: each applied migration's checksum is verified against the
+file on disk before new migrations run, and an edited applied migration fails the
+run with a clear error. See [Migration Safety](migration-safety.md).
+
 ### Preview Before Applying
 
 ```bash
@@ -585,6 +601,7 @@ aksara status
 
 ## Related Documentation
 
+- [Migration Safety](migration-safety.md) — how migrations are applied and verified
 - [Models](models.md) — Model definition
 - [Fields](fields.md) — Field types
 - [CLI Reference](../cli/index.md) — All CLI commands

--- a/docs/docs/releasing.md
+++ b/docs/docs/releasing.md
@@ -13,6 +13,10 @@ workflow and confirm these checks pass:
 - Security tests
 - Diagnostics tests
 - Bounded fuzz/adversarial tests
+- DB-backed migration tests (transactional application, advisory lock, and
+  checksum verification) against a real PostgreSQL database
+- A migration smoke check: `aksara migrate` and `aksara status` against a
+  scratch database, confirming checksum recording and verification
 - `aksara doctor production-check`
 - Strict docs build
 - Dependency audit

--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -57,17 +57,30 @@ Aksara is public and pre-1.0. The near-term roadmap prioritizes trust, first-use
 
 ## Future Roadmap
 
-### v0.5.50 - Durable AI Session Store
+### v0.5.50 - Migration Safety & Correctness
+
+Make migrations apply safely and consistently across every entry point. Python
+migrations are transactional, SQL migrations execute statement-by-statement,
+applying migrations takes a PostgreSQL advisory lock, the dependency graph
+detects cycles, and checksums verify that already-applied migrations have not
+changed on disk. The CLI and testing helpers share one canonical executor, and
+SQL-generation guardrails harden the generated DDL.
+
+Migration metadata schema versioning, an app-label / name identity split,
+automatic checksum backfill, and a migration verify/backfill command remain
+future work.
+
+### v0.5.51 - Durable AI Session Store
 
 Persist investigation sessions, AI Console transcripts, and AI review state so multi-step analysis can resume reliably across process restarts.
 
-### v0.5.51 - AI Memory Foundation
+### v0.5.52 - AI Memory Foundation
 
-Introduce a minimal, explicit memory foundation for project-level AI context. This is not part of v0.5.49.
+Introduce a minimal, explicit memory foundation for project-level AI context.
 
-### v0.5.52 - AI System Radar
+### v0.5.53 - AI System Radar
 
-Add system-level monitoring surfaces for AI-assisted project health. This is not part of v0.5.49.
+Add system-level monitoring surfaces for AI-assisted project health.
 
 ### v0.6.0-alpha.1 - Stability, Auditability, and Reference App
 

--- a/docs/docs/roadmap/v0-6-stability-contract.md
+++ b/docs/docs/roadmap/v0-6-stability-contract.md
@@ -93,6 +93,17 @@ The analysis engines and Studio APIs for these features are operational but
 their output schemas, API paths, and scoring models are not frozen. Do not
 build automation that depends on specific output formats from these tools.
 
+### Migration Tracking Metadata
+
+The migration *commands*, the migration *file* format, and existing generated
+migrations are stable (see above). The internal `aksara_migrations` tracking
+table is not. Its columns may evolve in a future release — for example, metadata
+schema versioning or an app-label / name identity split — so do not build
+automation against the tracking table's column layout. Migration execution
+safety, integrity (checksums), and the SQL-generation guardrails are intended to
+remain in place; the metadata-schema redesign that would change the tracking
+table is deferred future work.
+
 ### Long-Running AI Session State
 
 Durable AI session storage and AI Console transcript persistence are planned

--- a/docs/docs/security/overview.md
+++ b/docs/docs/security/overview.md
@@ -21,6 +21,9 @@ as first-class security concerns.
   expiration, and token metadata
 - Studio/MCP production exposure diagnostics
 - Bounded adversarial tests for generated surfaces
+- Migration safety controls that improve the reliability and integrity of
+  generated schema changes (transactional application, advisory locking,
+  checksum verification of applied migrations, and SQL-generation guardrails)
 - Public security matrix example with optional private matrix enforcement
 
 ## Generated Surfaces

--- a/docs/docs/security/security-coverage.md
+++ b/docs/docs/security/security-coverage.md
@@ -43,6 +43,8 @@ diagnostic condition.
 - Pagination
 - Serializer payloads
 - Migration defaults and identifiers
+- Migration execution safety and integrity (transactional application, advisory
+  locking, checksum verification, and SQL-generation guardrails)
 - Malformed and oversized payloads
 - Release-gate package build verification
 - Dependency audit, static analysis, secret scanning, and SBOM generation

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
       - Signals: orm/signals.md
       - Fixtures: orm/fixtures.md
       - Migrations: orm/migrations.md
+      - Migration Safety: orm/migration-safety.md
       - Model Meta: orm/model-meta.md
   - API:
       - api/index.md

--- a/tests/cli/test_migrations_cli.py
+++ b/tests/cli/test_migrations_cli.py
@@ -127,10 +127,20 @@ class TestMigrateCommand:
         return_value=["0001_initial"],
     )
     @patch("aksara.migrations.executor.check_migration_conflicts", return_value=[])
-    @patch("aksara.migrations.executor.get_pending_migrations", return_value=[])
+    @patch(
+        "aksara.migrations.executor.apply_migrations",
+        new_callable=AsyncMock,
+        return_value={
+            "applied": [],
+            "skipped": ["0001_initial"],
+            "pending_skipped": [],
+            "errors": [],
+            "total_discovered": 1,
+        },
+    )
     def test_all_migrations_already_applied(
         self,
-        mock_pending,
+        mock_apply,
         mock_conflicts,
         mock_applied,
         mock_ensure_table,

--- a/tests/cli/test_migrations_cli.py
+++ b/tests/cli/test_migrations_cli.py
@@ -4,6 +4,7 @@ Tests for the makemigrations and migrate CLI commands.
 
 from __future__ import annotations
 
+from contextlib import ExitStack
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -106,6 +107,53 @@ class TestMakemigrationsCommand:
 
 
 class TestMigrateCommand:
+    def _invoke_with_apply_exception(self, tmp_path, monkeypatch, exc):
+        from aksara.conf import settings
+
+        migrations_dir = tmp_path / "migrations"
+        migration_path = migrations_dir / "0001_initial.py"
+        migrations_dir.mkdir()
+        migration_path.write_text("# migration")
+
+        monkeypatch.setattr(settings, "database_url", "postgresql://localhost/test", raising=False)
+        monkeypatch.setattr(settings, "migrations_dir", str(migrations_dir), raising=False)
+
+        with ExitStack() as stack:
+            stack.enter_context(patch("aksara.db.Database", return_value=_FakeDatabase()))
+            stack.enter_context(
+                patch(
+                    "aksara.migrations.executor.discover_migrations",
+                    return_value=[("0001_initial", migration_path)],
+                )
+            )
+            stack.enter_context(
+                patch("aksara.migrations.executor.build_migration_graph", return_value=MagicMock())
+            )
+            stack.enter_context(
+                patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock)
+            )
+            stack.enter_context(
+                patch(
+                    "aksara.migrations.executor.get_applied_migrations",
+                    new_callable=AsyncMock,
+                    return_value=[],
+                )
+            )
+            stack.enter_context(
+                patch("aksara.migrations.executor.check_migration_conflicts", return_value=[])
+            )
+            apply_mock = stack.enter_context(
+                patch(
+                    "aksara.migrations.executor.apply_migrations",
+                    new_callable=AsyncMock,
+                    side_effect=exc,
+                )
+            )
+
+            result = runner.invoke(cli, ["migrate"])
+
+        return result, apply_mock
+
     def test_requires_database_url(self, monkeypatch) -> None:
         from aksara.conf import settings
 
@@ -165,3 +213,33 @@ class TestMigrateCommand:
 
         assert result.exit_code == 0
         assert "All migrations already applied!" in result.output
+
+    def test_apply_migrations_runtime_error_is_clean_cli_failure(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        result, apply_mock = self._invoke_with_apply_exception(
+            tmp_path,
+            monkeypatch,
+            RuntimeError("Could not acquire migration advisory lock"),
+        )
+
+        assert result.exit_code != 0
+        assert "Migration failed:" in result.output
+        assert "advisory lock" in result.output
+        assert "Traceback" not in result.output
+        apply_mock.assert_awaited_once()
+
+    def test_apply_migrations_value_error_is_clean_cli_failure(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        result, apply_mock = self._invoke_with_apply_exception(
+            tmp_path,
+            monkeypatch,
+            ValueError("Migration checksum mismatch for '0001_initial'"),
+        )
+
+        assert result.exit_code != 0
+        assert "Migration failed:" in result.output
+        assert "checksum mismatch" in result.output
+        assert "Traceback" not in result.output
+        apply_mock.assert_awaited_once()

--- a/tests/cli/test_migrations_cli.py
+++ b/tests/cli/test_migrations_cli.py
@@ -214,6 +214,37 @@ class TestMigrateCommand:
         assert result.exit_code == 0
         assert "All migrations already applied!" in result.output
 
+    @patch("aksara.migrations.executor.discover_migrations")
+    @patch(
+        "aksara.migrations.executor.build_migration_graph",
+        side_effect=ValueError("Could not load migration app.0001_bad"),
+    )
+    def test_preflight_graph_error_is_clean_cli_failure(
+        self,
+        mock_graph,
+        mock_discover,
+        monkeypatch,
+        tmp_path,
+    ) -> None:
+        from aksara.conf import settings
+
+        migrations_dir = tmp_path / "migrations"
+        migration_path = migrations_dir / "0001_bad.py"
+        migrations_dir.mkdir()
+        migration_path.write_text("def broken(:")
+
+        monkeypatch.setattr(settings, "database_url", "postgresql://localhost/test", raising=False)
+        monkeypatch.setattr(settings, "migrations_dir", str(migrations_dir), raising=False)
+        mock_discover.return_value = [("0001_bad", migration_path)]
+
+        result = runner.invoke(cli, ["migrate"])
+
+        assert result.exit_code != 0
+        assert "Could not build migration graph" in result.output
+        assert "Could not load migration" in result.output
+        assert "Traceback" not in result.output
+        mock_graph.assert_called_once()
+
     def test_apply_migrations_runtime_error_is_clean_cli_failure(
         self, monkeypatch, tmp_path
     ) -> None:

--- a/tests/migrations/test_conflicts.py
+++ b/tests/migrations/test_conflicts.py
@@ -682,16 +682,19 @@ class Migration(Migration):
         assert node.dependencies == []
     
     def test_invalid_migration_file(self, tmp_path):
-        """Invalid migration files should be handled gracefully."""
+        """Invalid migration files raise in strict mode (default) and are tolerated with strict=False."""
         (tmp_path / "0001_broken.py").write_text("this is not valid python :{")
-        
-        # Should not crash, but migration won't be loaded properly
+
+        # strict=True (default) must raise clearly
+        with pytest.raises(ValueError, match="Could not load migration"):
+            build_migration_graph(migrations_path=tmp_path, include_internal=False)
+
+        # strict=False falls back to the old best-effort behaviour (node without deps)
         graph = build_migration_graph(
             migrations_path=tmp_path,
             include_internal=False,
+            strict=False,
         )
-        
-        # Node should still be added (but without dependencies)
         assert len(graph) == 1
     
     def test_migration_without_dependencies_attr(self, tmp_path):

--- a/tests/migrations/test_executor.py
+++ b/tests/migrations/test_executor.py
@@ -672,7 +672,11 @@ class Migration(Migration):
     monkeypatch.setattr(migration_executor, "get_applied_migrations", AsyncMock(return_value=[]))
     monkeypatch.setattr(migration_executor, "apply_migration", _record_apply)
 
-    result = await apply_migrations(object(), tmp_path, verbose=False, include_internal=False)
+    # Use a minimal async-capable connection mock that satisfies the advisory lock calls
+    mock_conn = AsyncMock()
+    mock_conn.fetchval = AsyncMock(return_value=True)  # lock acquired
+
+    result = await apply_migrations(mock_conn, tmp_path, verbose=False, include_internal=False)
 
     assert result["errors"] == []
     assert applied_order == [dependency_name, dependent_name]

--- a/tests/migrations/test_executor.py
+++ b/tests/migrations/test_executor.py
@@ -669,7 +669,7 @@ class Migration(Migration):
         applied_order.append(name)
 
     monkeypatch.setattr(migration_executor, "ensure_migrations_table", AsyncMock())
-    monkeypatch.setattr(migration_executor, "get_applied_migrations", AsyncMock(return_value=[]))
+    monkeypatch.setattr(migration_executor, "get_applied_migration_records", AsyncMock(return_value={}))
     monkeypatch.setattr(migration_executor, "apply_migration", _record_apply)
 
     # Use a minimal async-capable connection mock that satisfies the advisory lock calls

--- a/tests/migrations/test_executor.py
+++ b/tests/migrations/test_executor.py
@@ -665,7 +665,15 @@ class Migration(Migration):
 
     applied_order = []
 
-    async def _record_apply(_connection, name, path, *, fake=False, verbose=True):
+    async def _record_apply(
+        _connection,
+        name,
+        path,
+        *,
+        fake=False,
+        verbose=True,
+        ensure_table=True,
+    ):
         applied_order.append(name)
 
     monkeypatch.setattr(migration_executor, "ensure_migrations_table", AsyncMock())

--- a/tests/migrations/test_v0550_p1_safety.py
+++ b/tests/migrations/test_v0550_p1_safety.py
@@ -59,6 +59,10 @@ class TestAddFieldNonNullWarning:
         code = self._code_for(op.StringField(nullable=False, default="draft"))
         assert "WARNING" not in code
 
+    def test_non_null_string_default_no_warning(self):
+        code = self._code_for(op.StringField(nullable=False, default="x"))
+        assert "WARNING" not in code
+
     def test_nullable_no_warning(self):
         code = self._code_for(op.StringField(nullable=True))
         assert "WARNING" not in code
@@ -78,6 +82,18 @@ class TestAddFieldNonNullWarning:
 
     def test_integer_non_null_with_default_no_warning(self):
         code = self._code_for(op.IntegerField(nullable=False, default=0))
+        assert "WARNING" not in code
+
+    def test_datetime_auto_now_add_db_default_no_warning(self):
+        code = self._code_for(op.DateTimeField(auto_now_add=True, nullable=False))
+        assert "WARNING" not in code
+
+    def test_datetime_non_null_no_default_gets_warning(self):
+        code = self._code_for(op.DateTimeField(nullable=False))
+        assert "WARNING" in code
+
+    def test_boolean_non_null_with_default_no_warning(self):
+        code = self._code_for(op.BooleanField(default=True, nullable=False))
         assert "WARNING" not in code
 
     def test_add_field_still_present_when_warned(self):

--- a/tests/migrations/test_v0550_p1_safety.py
+++ b/tests/migrations/test_v0550_p1_safety.py
@@ -138,6 +138,22 @@ class TestChecksumHelper:
         f2.write_text("content B")
         assert _compute_file_checksum(f1) != _compute_file_checksum(f2)
 
+    def test_lf_and_crlf_content_have_same_checksum(self, tmp_path):
+        lf = tmp_path / "lf.py"
+        crlf = tmp_path / "crlf.py"
+        lf.write_bytes(b"line1\nline2\n")
+        crlf.write_bytes(b"line1\r\nline2\r\n")
+
+        assert _compute_file_checksum(lf) == _compute_file_checksum(crlf)
+
+    def test_lf_and_cr_only_content_have_same_checksum(self, tmp_path):
+        lf = tmp_path / "lf.py"
+        cr = tmp_path / "cr.py"
+        lf.write_bytes(b"line1\nline2\n")
+        cr.write_bytes(b"line1\rline2\r")
+
+        assert _compute_file_checksum(lf) == _compute_file_checksum(cr)
+
 
 class TestApplyMigrationStoresChecksum:
     """Unit tests — verify apply_migration passes checksum to record_migration."""
@@ -168,6 +184,31 @@ class TestApplyMigrationStoresChecksum:
         _, call_name, call_checksum = rm.call_args.args
         assert call_checksum is not None
         assert len(call_checksum) == 16
+
+    @pytest.mark.asyncio
+    async def test_python_migration_checksum_normalizes_line_endings(self, tmp_path):
+        lf = tmp_path / "0001_lf.py"
+        crlf = tmp_path / "0001_crlf.py"
+        migration_code_lf = b"from aksara.migrations.base import Migration\n\nclass Migration(Migration):\n    operations = []\n"
+        migration_code_crlf = migration_code_lf.replace(b"\n", b"\r\n")
+        lf.write_bytes(migration_code_lf)
+        crlf.write_bytes(migration_code_crlf)
+        conn = self._make_raw_conn()
+
+        with patch("aksara.migrations.executor.load_migration_module") as lm, \
+             patch("aksara.migrations.executor.record_migration", new_callable=AsyncMock) as rm:
+            mock_mig = MagicMock()
+            mock_mig.return_value.operations = []
+            lm.return_value = mock_mig
+
+            await apply_migration(conn, "0001_lf", lf, fake=False, verbose=False)
+            lf_checksum = rm.await_args.args[2]
+            rm.reset_mock()
+
+            await apply_migration(conn, "0001_crlf", crlf, fake=False, verbose=False)
+            crlf_checksum = rm.await_args.args[2]
+
+        assert lf_checksum == crlf_checksum
 
     @pytest.mark.asyncio
     async def test_direct_apply_ensures_tracking_table_before_transaction(self, tmp_path):
@@ -250,6 +291,26 @@ class TestApplyMigrationStoresChecksum:
         assert call_checksum is not None
         assert len(call_checksum) == 16
 
+    @pytest.mark.asyncio
+    async def test_sql_migration_checksum_normalizes_line_endings(self, tmp_path):
+        lf = tmp_path / "0001_lf.sql"
+        crlf = tmp_path / "0001_crlf.sql"
+        sql_lf = b"CREATE TABLE t (id SERIAL);\nINSERT INTO t VALUES (1);\n"
+        sql_crlf = sql_lf.replace(b"\n", b"\r\n")
+        lf.write_bytes(sql_lf)
+        crlf.write_bytes(sql_crlf)
+        conn = self._make_raw_conn()
+
+        with patch("aksara.migrations.executor.record_migration", new_callable=AsyncMock) as rm:
+            await apply_migration(conn, "0001_lf", lf, fake=False, verbose=False)
+            lf_checksum = rm.await_args.args[2]
+            rm.reset_mock()
+
+            await apply_migration(conn, "0001_crlf", crlf, fake=False, verbose=False)
+            crlf_checksum = rm.await_args.args[2]
+
+        assert lf_checksum == crlf_checksum
+
 
 class TestChecksumVerification:
     """Checksum mismatch and NULL-checksum behavior in apply_migrations."""
@@ -298,6 +359,45 @@ class TestChecksumVerification:
              patch("aksara.migrations.executor.get_applied_migration_records",
                    new_callable=AsyncMock,
                    return_value={"0001_init": "0000000000000000"}), \
+             patch("aksara.migrations.executor.discover_all_migrations",
+                   return_value=[("0001_init", f)]), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]):
+            with pytest.raises(ValueError, match="checksum mismatch"):
+                await apply_migrations(conn, tmp_path, verbose=False)
+
+    @pytest.mark.asyncio
+    async def test_checksum_verification_ignores_crlf_vs_lf_differences(self, tmp_path):
+        f = tmp_path / "0001_init.py"
+        lf_content = b"# migration\nprint('ok')\n"
+        f.write_bytes(lf_content)
+        stored_cs = _compute_file_checksum(f)
+        f.write_bytes(lf_content.replace(b"\n", b"\r\n"))
+
+        conn = self._make_conn()
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch("aksara.migrations.executor.get_applied_migration_records",
+                   new_callable=AsyncMock,
+                   return_value={"0001_init": stored_cs}), \
+             patch("aksara.migrations.executor.discover_all_migrations",
+                   return_value=[("0001_init", f)]), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]):
+            result = await apply_migrations(conn, tmp_path, verbose=False)
+
+        assert result["errors"] == []
+        assert result["skipped"] == ["0001_init"]
+
+    @pytest.mark.asyncio
+    async def test_checksum_verification_still_fails_when_content_changes(self, tmp_path):
+        f = tmp_path / "0001_init.py"
+        f.write_bytes(b"# migration\nprint('ok')\n")
+        stored_cs = _compute_file_checksum(f)
+        f.write_bytes(b"# migration\nprint('changed')\n")
+
+        conn = self._make_conn()
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch("aksara.migrations.executor.get_applied_migration_records",
+                   new_callable=AsyncMock,
+                   return_value={"0001_init": stored_cs}), \
              patch("aksara.migrations.executor.discover_all_migrations",
                    return_value=[("0001_init", f)]), \
              patch("aksara.migrations.executor.get_pending_migrations", return_value=[]):

--- a/tests/migrations/test_v0550_p1_safety.py
+++ b/tests/migrations/test_v0550_p1_safety.py
@@ -1,0 +1,531 @@
+"""
+v0.5.50 P1 Migration Safety — Regression Tests
+
+Covers four P1 fixes:
+  1. AddField NOT NULL without DEFAULT warning in generated code
+  2. Checksum recording (Python) and verification for applied migrations
+  3. build_migration_graph raises clearly on migration load errors
+  4. apply_migrations reports pending_skipped after a failure
+"""
+
+import os
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aksara.migrations import operations as op
+from aksara.migrations.executor import (
+    _compute_file_checksum,
+    build_migration_graph,
+    apply_migration,
+    apply_migrations,
+    get_applied_migration_records,
+    record_migration,
+    ensure_migrations_table,
+)
+from aksara.migrations.autodetector import operations_to_code
+
+
+# =============================================================================
+# Fix 1: AddField NOT NULL without DEFAULT warning
+# =============================================================================
+
+class TestAddFieldNonNullWarning:
+    def _code_for(self, field_op, table="posts", name="status"):
+        operation = op.AddField(table=table, name=name, field=field_op)
+        return operations_to_code([operation])
+
+    def test_non_null_no_default_gets_warning(self):
+        code = self._code_for(op.StringField(nullable=False))
+        assert "WARNING" in code
+        assert "non-null" in code.lower() or "non_null" in code.lower() or "non-null field" in code
+
+    def test_warning_mentions_field_name(self):
+        code = self._code_for(op.StringField(nullable=False), name="status")
+        assert '"status"' in code
+
+    def test_warning_mentions_table_name(self):
+        code = self._code_for(op.StringField(nullable=False), table="articles")
+        assert '"articles"' in code
+
+    def test_warning_precedes_add_field(self):
+        code = self._code_for(op.StringField(nullable=False))
+        warning_pos = code.index("WARNING")
+        add_field_pos = code.index("op.AddField")
+        assert warning_pos < add_field_pos
+
+    def test_non_null_with_default_no_warning(self):
+        code = self._code_for(op.StringField(nullable=False, default="draft"))
+        assert "WARNING" not in code
+
+    def test_nullable_no_warning(self):
+        code = self._code_for(op.StringField(nullable=True))
+        assert "WARNING" not in code
+
+    def test_nullable_default_none_no_warning(self):
+        # nullable=True is the risky-free case even without a default
+        code = self._code_for(op.StringField(nullable=True, default=None))
+        assert "WARNING" not in code
+
+    def test_primary_key_no_warning(self):
+        code = self._code_for(op.UUIDField(primary_key=True), name="id")
+        assert "WARNING" not in code
+
+    def test_integer_non_null_no_default_gets_warning(self):
+        code = self._code_for(op.IntegerField(nullable=False))
+        assert "WARNING" in code
+
+    def test_integer_non_null_with_default_no_warning(self):
+        code = self._code_for(op.IntegerField(nullable=False, default=0))
+        assert "WARNING" not in code
+
+    def test_add_field_still_present_when_warned(self):
+        code = self._code_for(op.StringField(nullable=False))
+        assert "op.AddField" in code
+
+    def test_no_warning_for_create_table(self):
+        operation = op.CreateTable(
+            name="posts",
+            fields=[
+                ("id", op.UUIDField(primary_key=True)),
+                ("status", op.StringField(nullable=False)),
+            ],
+        )
+        code = operations_to_code([operation])
+        assert "WARNING" not in code
+
+
+# =============================================================================
+# Fix 2: Checksum recording and verification
+# =============================================================================
+
+class TestChecksumHelper:
+    def test_compute_file_checksum_returns_16_chars(self, tmp_path):
+        f = tmp_path / "mig.py"
+        f.write_text("hello")
+        cs = _compute_file_checksum(f)
+        assert len(cs) == 16
+        assert cs.isalnum()
+
+    def test_same_content_same_checksum(self, tmp_path):
+        f1 = tmp_path / "a.py"
+        f2 = tmp_path / "b.py"
+        f1.write_text("same content")
+        f2.write_text("same content")
+        assert _compute_file_checksum(f1) == _compute_file_checksum(f2)
+
+    def test_different_content_different_checksum(self, tmp_path):
+        f1 = tmp_path / "a.py"
+        f2 = tmp_path / "b.py"
+        f1.write_text("content A")
+        f2.write_text("content B")
+        assert _compute_file_checksum(f1) != _compute_file_checksum(f2)
+
+
+class TestApplyMigrationStoresChecksum:
+    """Unit tests — verify apply_migration passes checksum to record_migration."""
+
+    def _make_raw_conn(self):
+        conn = AsyncMock()
+        tx = AsyncMock()
+        tx.__aenter__ = AsyncMock(return_value=tx)
+        tx.__aexit__ = AsyncMock(return_value=False)
+        conn.transaction = MagicMock(return_value=tx)
+        return conn
+
+    @pytest.mark.asyncio
+    async def test_python_migration_stores_checksum(self, tmp_path):
+        f = tmp_path / "0001_init.py"
+        f.write_text("")
+        conn = self._make_raw_conn()
+
+        with patch("aksara.migrations.executor.load_migration_module") as lm, \
+             patch("aksara.migrations.executor.record_migration", new_callable=AsyncMock) as rm:
+            mock_mig = MagicMock()
+            mock_mig.return_value.operations = []
+            lm.return_value = mock_mig
+
+            await apply_migration(conn, "0001_init", f, fake=False, verbose=False)
+
+        rm.assert_awaited_once()
+        _, call_name, call_checksum = rm.call_args.args
+        assert call_checksum is not None
+        assert len(call_checksum) == 16
+
+    @pytest.mark.asyncio
+    async def test_sql_migration_stores_checksum(self, tmp_path):
+        f = tmp_path / "0001_init.sql"
+        f.write_text("CREATE TABLE t (id SERIAL);")
+        conn = self._make_raw_conn()
+
+        with patch("aksara.migrations.executor.record_migration", new_callable=AsyncMock) as rm:
+            await apply_migration(conn, "0001_init", f, fake=False, verbose=False)
+
+        rm.assert_awaited_once()
+        _, call_name, call_checksum = rm.call_args.args
+        assert call_checksum is not None
+        assert len(call_checksum) == 16
+
+
+class TestChecksumVerification:
+    """Checksum mismatch and NULL-checksum behavior in apply_migrations."""
+
+    def _make_conn(self, lock_acquired=True):
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=lock_acquired)
+        conn.execute = AsyncMock()
+        tx = AsyncMock()
+        tx.__aenter__ = AsyncMock(return_value=tx)
+        tx.__aexit__ = AsyncMock(return_value=False)
+        conn.transaction = MagicMock(return_value=tx)
+        return conn
+
+    @pytest.mark.asyncio
+    async def test_matching_checksum_allows_skip(self, tmp_path):
+        """Already-applied migration with matching checksum is skipped silently."""
+        f = tmp_path / "0001_init.py"
+        f.write_text("# migration")
+        stored_cs = _compute_file_checksum(f)
+
+        conn = self._make_conn()
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch("aksara.migrations.executor.get_applied_migration_records",
+                   new_callable=AsyncMock,
+                   return_value={"0001_init": stored_cs}), \
+             patch("aksara.migrations.executor.discover_all_migrations",
+                   return_value=[("0001_init", f)]), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]):
+            result = await apply_migrations(conn, tmp_path, verbose=False)
+
+        assert result["errors"] == []
+        assert result["applied"] == []
+
+    @pytest.mark.asyncio
+    async def test_checksum_mismatch_raises(self, tmp_path):
+        """Already-applied migration with changed contents raises ValueError."""
+        f = tmp_path / "0001_init.py"
+        f.write_text("# MODIFIED after apply")
+
+        conn = self._make_conn()
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch("aksara.migrations.executor.get_applied_migration_records",
+                   new_callable=AsyncMock,
+                   return_value={"0001_init": "0000000000000000"}), \
+             patch("aksara.migrations.executor.discover_all_migrations",
+                   return_value=[("0001_init", f)]), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]):
+            with pytest.raises(ValueError, match="checksum mismatch"):
+                await apply_migrations(conn, tmp_path, verbose=False)
+
+    @pytest.mark.asyncio
+    async def test_null_checksum_does_not_fail(self, tmp_path):
+        """Backward compat: NULL stored checksum skips verification (warns only)."""
+        f = tmp_path / "0001_init.py"
+        f.write_text("# migration")
+
+        conn = self._make_conn()
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch("aksara.migrations.executor.get_applied_migration_records",
+                   new_callable=AsyncMock,
+                   return_value={"0001_init": None}), \
+             patch("aksara.migrations.executor.discover_all_migrations",
+                   return_value=[("0001_init", f)]), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]):
+            result = await apply_migrations(conn, tmp_path, verbose=False)
+
+        assert result["errors"] == []
+
+    @pytest.mark.asyncio
+    async def test_error_message_includes_migration_name(self, tmp_path):
+        f = tmp_path / "app_0002_posts.py"
+        f.write_text("# changed")
+
+        conn = self._make_conn()
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch("aksara.migrations.executor.get_applied_migration_records",
+                   new_callable=AsyncMock,
+                   return_value={"app_0002_posts": "deadbeefdeadbeef"}), \
+             patch("aksara.migrations.executor.discover_all_migrations",
+                   return_value=[("app_0002_posts", f)]), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]):
+            with pytest.raises(ValueError) as exc_info:
+                await apply_migrations(conn, tmp_path, verbose=False)
+
+        assert "app_0002_posts" in str(exc_info.value)
+        assert "applied" in str(exc_info.value).lower()
+
+
+# =============================================================================
+# DB-backed checksum tests (require DATABASE_URL)
+# =============================================================================
+
+@pytest.fixture
+async def db():
+    from aksara.db import Database
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        pytest.skip("DATABASE_URL not set")
+    database = Database(db_url)
+    await database.connect()
+    await ensure_migrations_table(database)
+    await database.execute("DELETE FROM aksara_migrations WHERE name LIKE 'test_p1_%'")
+    yield database
+    await database.execute("DELETE FROM aksara_migrations WHERE name LIKE 'test_p1_%'")
+    await database.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_python_migration_records_checksum_in_db(db, tmp_path):
+    f = tmp_path / "test_p1_0001.py"
+    f.write_text("# migration content")
+    expected_cs = _compute_file_checksum(f)
+
+    with patch("aksara.migrations.executor.load_migration_module") as lm:
+        mock_mig = MagicMock()
+        mock_mig.return_value.operations = []
+        lm.return_value = mock_mig
+        await apply_migration(db, "test_p1_0001", f, fake=False, verbose=False)
+
+    records = await get_applied_migration_records(db)
+    assert "test_p1_0001" in records
+    assert records["test_p1_0001"] == expected_cs
+
+
+@pytest.mark.asyncio
+async def test_null_checksum_backward_compat_in_db(db, tmp_path):
+    """Row with NULL checksum must not block apply_migrations."""
+    await record_migration(db, "test_p1_legacy", None)
+
+    f = tmp_path / "test_p1_legacy.py"
+    f.write_text("# migration")
+
+    conn_mock = AsyncMock()
+    conn_mock.fetchval = AsyncMock(return_value=True)
+    conn_mock.execute = AsyncMock()
+    tx = AsyncMock()
+    tx.__aenter__ = AsyncMock(return_value=tx)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    conn_mock.transaction = MagicMock(return_value=tx)
+
+    with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+         patch("aksara.migrations.executor.get_applied_migration_records",
+               new_callable=AsyncMock,
+               return_value={"test_p1_legacy": None}), \
+         patch("aksara.migrations.executor.discover_all_migrations",
+               return_value=[("test_p1_legacy", f)]), \
+         patch("aksara.migrations.executor.get_pending_migrations", return_value=[]):
+        result = await apply_migrations(conn_mock, tmp_path, verbose=False)
+
+    assert result["errors"] == []
+
+
+# =============================================================================
+# Fix 3: build_migration_graph raises on load errors
+# =============================================================================
+
+class TestBuildMigrationGraphStrictErrors:
+    def test_syntax_error_raises_value_error(self, tmp_path):
+        bad = tmp_path / "0001_bad.py"
+        bad.write_text("def broken(:")
+
+        with pytest.raises(ValueError, match="Could not load migration"):
+            build_migration_graph(migrations_path=tmp_path, include_internal=False)
+
+    def test_error_includes_migration_name(self, tmp_path):
+        bad = tmp_path / "0002_broken.py"
+        bad.write_text("def broken(:")
+
+        with pytest.raises(ValueError) as exc_info:
+            build_migration_graph(migrations_path=tmp_path, include_internal=False)
+
+        assert "0002_broken" in str(exc_info.value)
+
+    def test_error_includes_file_path(self, tmp_path):
+        bad = tmp_path / "0003_broken.py"
+        bad.write_text("def broken(:")
+
+        with pytest.raises(ValueError) as exc_info:
+            build_migration_graph(migrations_path=tmp_path, include_internal=False)
+
+        assert str(tmp_path) in str(exc_info.value)
+
+    def test_error_chains_original_exception(self, tmp_path):
+        bad = tmp_path / "0001_bad.py"
+        bad.write_text("import nonexistent_module_xyz")
+
+        with pytest.raises(ValueError) as exc_info:
+            build_migration_graph(migrations_path=tmp_path, include_internal=False)
+
+        assert exc_info.value.__cause__ is not None
+
+    def test_non_strict_does_not_raise(self, tmp_path):
+        bad = tmp_path / "0001_bad.py"
+        bad.write_text("def broken(:")
+
+        # Should not raise; returns graph with the bad node dependency-less
+        graph = build_migration_graph(
+            migrations_path=tmp_path, include_internal=False, strict=False
+        )
+        assert len(graph) == 1
+
+    def test_valid_migrations_build_graph_correctly(self, tmp_path):
+        good = tmp_path / "0001_good.py"
+        good.write_text(
+            "from aksara.migrations.base import Migration\n"
+            "from aksara.migrations import operations as op\n"
+            "class Migration(Migration):\n"
+            "    operations = []\n"
+        )
+        graph = build_migration_graph(migrations_path=tmp_path, include_internal=False)
+        assert len(graph) == 1
+
+    def test_sql_migration_load_error_is_not_raised(self, tmp_path):
+        """SQL migrations are not loaded for deps — a bad SQL file should not raise."""
+        sql = tmp_path / "0001_init.sql"
+        sql.write_text("this is not valid SQL but we only read text, don't parse")
+
+        # SQL migrations don't go through load_migration_module, so no error
+        graph = build_migration_graph(migrations_path=tmp_path, include_internal=False)
+        assert len(graph) == 1
+
+
+# =============================================================================
+# Fix 4: apply_migrations reports pending_skipped after failure
+# =============================================================================
+
+class TestPendingSkippedReporting:
+    """Unit tests for pending_skipped in apply_migrations result."""
+
+    def _make_conn(self):
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=True)
+        conn.execute = AsyncMock()
+        tx = AsyncMock()
+        tx.__aenter__ = AsyncMock(return_value=tx)
+        tx.__aexit__ = AsyncMock(return_value=False)
+        conn.transaction = MagicMock(return_value=tx)
+        return conn
+
+    def _make_py_file(self, tmp_path, name):
+        f = tmp_path / f"{name}.py"
+        f.write_text(
+            "from aksara.migrations.base import Migration\n"
+            "from aksara.migrations import operations as op\n"
+            "class Migration(Migration):\n"
+            "    operations = []\n"
+        )
+        return f
+
+    @pytest.mark.asyncio
+    async def test_no_failure_pending_skipped_empty(self, tmp_path):
+        conn = self._make_conn()
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch("aksara.migrations.executor.get_applied_migration_records",
+                   new_callable=AsyncMock, return_value={}), \
+             patch("aksara.migrations.executor.discover_all_migrations", return_value=[]), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]):
+            result = await apply_migrations(conn, tmp_path, verbose=False)
+
+        assert result["pending_skipped"] == []
+
+    @pytest.mark.asyncio
+    async def test_failure_in_first_skips_rest(self, tmp_path):
+        f1 = self._make_py_file(tmp_path, "0001_a")
+        f2 = self._make_py_file(tmp_path, "0002_b")
+        f3 = self._make_py_file(tmp_path, "0003_c")
+        migs = [("0001_a", f1), ("0002_b", f2), ("0003_c", f3)]
+
+        conn = self._make_conn()
+
+        async def _fail_first(conn, name, path, *, fake, verbose):
+            if name == "0001_a":
+                raise RuntimeError("first fails")
+
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch("aksara.migrations.executor.get_applied_migration_records",
+                   new_callable=AsyncMock, return_value={}), \
+             patch("aksara.migrations.executor.discover_all_migrations", return_value=migs), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=migs), \
+             patch("aksara.migrations.executor.build_migration_graph") as mock_graph, \
+             patch("aksara.migrations.executor.apply_migration", side_effect=_fail_first):
+
+            mock_nodes = [MagicMock(name=n) for n, _ in migs]
+            for node, (n, _) in zip(mock_nodes, migs):
+                node.name = n
+            mock_graph.return_value.execution_order.return_value = mock_nodes
+
+            result = await apply_migrations(conn, tmp_path, verbose=False)
+
+        assert len(result["errors"]) == 1
+        assert "0001_a" in result["errors"][0][0]
+        assert "0002_b" in result["pending_skipped"]
+        assert "0003_c" in result["pending_skipped"]
+        assert "0001_a" not in result["pending_skipped"]
+
+    @pytest.mark.asyncio
+    async def test_failure_in_middle_skips_later(self, tmp_path):
+        f1 = self._make_py_file(tmp_path, "0001_a")
+        f2 = self._make_py_file(tmp_path, "0002_b")
+        f3 = self._make_py_file(tmp_path, "0003_c")
+        migs = [("0001_a", f1), ("0002_b", f2), ("0003_c", f3)]
+        applied_migs = []
+
+        conn = self._make_conn()
+
+        async def _fail_second(conn, name, path, *, fake, verbose):
+            if name == "0002_b":
+                raise RuntimeError("second fails")
+            applied_migs.append(name)
+
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch("aksara.migrations.executor.get_applied_migration_records",
+                   new_callable=AsyncMock, return_value={}), \
+             patch("aksara.migrations.executor.discover_all_migrations", return_value=migs), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=migs), \
+             patch("aksara.migrations.executor.build_migration_graph") as mock_graph, \
+             patch("aksara.migrations.executor.apply_migration", side_effect=_fail_second):
+
+            mock_nodes = [MagicMock() for n, _ in migs]
+            for node, (n, _) in zip(mock_nodes, migs):
+                node.name = n
+            mock_graph.return_value.execution_order.return_value = mock_nodes
+
+            result = await apply_migrations(conn, tmp_path, verbose=False)
+
+        assert "0001_a" in result["applied"]
+        assert len(result["errors"]) == 1
+        assert "0002_b" in result["errors"][0][0]
+        assert result["pending_skipped"] == ["0003_c"]
+        assert "0003_c" not in applied_migs
+
+    @pytest.mark.asyncio
+    async def test_skipped_migrations_not_attempted(self, tmp_path):
+        f1 = self._make_py_file(tmp_path, "0001_a")
+        f2 = self._make_py_file(tmp_path, "0002_b")
+        migs = [("0001_a", f1), ("0002_b", f2)]
+
+        attempted = []
+        conn = self._make_conn()
+
+        async def _track_and_fail(conn, name, path, *, fake, verbose):
+            attempted.append(name)
+            if name == "0001_a":
+                raise RuntimeError("fail")
+
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch("aksara.migrations.executor.get_applied_migration_records",
+                   new_callable=AsyncMock, return_value={}), \
+             patch("aksara.migrations.executor.discover_all_migrations", return_value=migs), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=migs), \
+             patch("aksara.migrations.executor.build_migration_graph") as mock_graph, \
+             patch("aksara.migrations.executor.apply_migration", side_effect=_track_and_fail):
+
+            mock_nodes = [MagicMock() for n, _ in migs]
+            for node, (n, _) in zip(mock_nodes, migs):
+                node.name = n
+            mock_graph.return_value.execution_order.return_value = mock_nodes
+
+            result = await apply_migrations(conn, tmp_path, verbose=False)
+
+        assert "0002_b" not in attempted
+        assert "0002_b" in result["pending_skipped"]

--- a/tests/migrations/test_v0550_p1_safety.py
+++ b/tests/migrations/test_v0550_p1_safety.py
@@ -8,6 +8,7 @@ Covers four P1 fixes:
   4. apply_migrations reports pending_skipped after a failure
 """
 
+import logging
 import os
 import pytest
 from pathlib import Path
@@ -234,6 +235,56 @@ class TestChecksumVerification:
             result = await apply_migrations(conn, tmp_path, verbose=False)
 
         assert result["errors"] == []
+
+    @pytest.mark.asyncio
+    async def test_null_checksum_warning_emitted_when_not_verbose(self, tmp_path, caplog):
+        """Operators should see legacy NULL-checksum warnings even in CLI mode."""
+        f = tmp_path / "0001_init.py"
+        f.write_text("# migration")
+
+        conn = self._make_conn()
+        caplog.set_level(logging.WARNING, logger="aksara.migrations.executor")
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch("aksara.migrations.executor.get_applied_migration_records",
+                   new_callable=AsyncMock,
+                   return_value={"0001_init": None}), \
+             patch("aksara.migrations.executor.discover_all_migrations",
+                   return_value=[("0001_init", f)]), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]):
+            result = await apply_migrations(conn, tmp_path, verbose=False)
+
+        assert result["errors"] == []
+        assert "Checksum unavailable" in caplog.text
+        assert "0001_init" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_null_checksum_does_not_block_pending_migrations(self, tmp_path):
+        legacy = tmp_path / "0001_legacy.py"
+        legacy.write_text("# legacy")
+        pending = tmp_path / "0002_pending.py"
+        pending.write_text("# pending")
+
+        graph = MagicMock()
+        graph.execution_order.return_value = [type("Node", (), {"name": "0002_pending"})()]
+
+        conn = self._make_conn()
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch("aksara.migrations.executor.get_applied_migration_records",
+                   new_callable=AsyncMock,
+                   return_value={"0001_legacy": None}), \
+             patch("aksara.migrations.executor.discover_all_migrations",
+                   return_value=[("0001_legacy", legacy), ("0002_pending", pending)]), \
+             patch("aksara.migrations.executor.get_pending_migrations",
+                   return_value=[("0002_pending", pending)]), \
+             patch("aksara.migrations.executor.build_migration_graph",
+                   return_value=graph), \
+             patch("aksara.migrations.executor.apply_migration",
+                   new_callable=AsyncMock) as apply_mock:
+            result = await apply_migrations(conn, tmp_path, verbose=False)
+
+        assert result["errors"] == []
+        assert result["applied"] == ["0002_pending"]
+        apply_mock.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_error_message_includes_migration_name(self, tmp_path):

--- a/tests/migrations/test_v0550_p1_safety.py
+++ b/tests/migrations/test_v0550_p1_safety.py
@@ -210,6 +210,33 @@ class TestApplyMigrationStoresChecksum:
         assert "record_migration" in events
 
     @pytest.mark.asyncio
+    async def test_direct_apply_can_skip_tracking_table_setup(self, tmp_path):
+        f = tmp_path / "0001_init.py"
+        f.write_text("")
+        conn = self._make_raw_conn()
+
+        with patch(
+            "aksara.migrations.executor.ensure_migrations_table",
+            new_callable=AsyncMock,
+        ) as ensure_mock, patch("aksara.migrations.executor.load_migration_module") as lm, \
+             patch("aksara.migrations.executor.record_migration", new_callable=AsyncMock) as rm:
+            mock_mig = MagicMock()
+            mock_mig.return_value.operations = []
+            lm.return_value = mock_mig
+
+            await apply_migration(
+                conn,
+                "0001_init",
+                f,
+                fake=False,
+                verbose=False,
+                ensure_table=False,
+            )
+
+        ensure_mock.assert_not_awaited()
+        rm.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_sql_migration_stores_checksum(self, tmp_path):
         f = tmp_path / "0001_init.sql"
         f.write_text("CREATE TABLE t (id SERIAL);")
@@ -341,6 +368,92 @@ class TestChecksumVerification:
         assert result["errors"] == []
         assert result["applied"] == ["0002_pending"]
         apply_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_include_internal_false_verifies_applied_internal_checksums(self, tmp_path):
+        internal_name = "aksara_contrib_auth_migrations_0001_initial"
+        internal_file = tmp_path / "0001_internal.py"
+        internal_file.write_text("# internal migration")
+        internal_checksum = _compute_file_checksum(internal_file)
+        pending = tmp_path / "0002_pending.py"
+        pending.write_text("# pending")
+        graph = MagicMock()
+        graph.execution_order.return_value = [type("Node", (), {"name": "0002_pending"})()]
+        original_compute = _compute_file_checksum
+        computed_paths = []
+
+        def _track_checksum(path):
+            computed_paths.append(path)
+            return original_compute(path)
+
+        conn = self._make_conn()
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch(
+                 "aksara.migrations.executor.get_applied_migration_records",
+                 new_callable=AsyncMock,
+                 return_value={internal_name: internal_checksum},
+             ), \
+             patch(
+                 "aksara.migrations.executor.discover_all_migrations",
+                 side_effect=[
+                     [("0002_pending", pending)],
+                     [(internal_name, internal_file), ("0002_pending", pending)],
+                 ],
+             ), \
+             patch(
+                 "aksara.migrations.executor.get_pending_migrations",
+                 return_value=[("0002_pending", pending)],
+             ), \
+             patch("aksara.migrations.executor.build_migration_graph", return_value=graph), \
+             patch(
+                 "aksara.migrations.executor.apply_migration",
+                 new_callable=AsyncMock,
+             ) as apply_mock, \
+             patch(
+                 "aksara.migrations.executor._compute_file_checksum",
+                 side_effect=_track_checksum,
+             ):
+            result = await apply_migrations(conn, tmp_path, verbose=False, include_internal=False)
+
+        assert result["errors"] == []
+        assert internal_file in computed_paths
+        apply_mock.assert_awaited_once()
+        assert result["applied"] == ["0002_pending"]
+
+    @pytest.mark.asyncio
+    async def test_include_internal_false_raises_on_applied_internal_checksum_mismatch(self, tmp_path):
+        internal_name = "aksara_contrib_auth_migrations_0001_initial"
+        internal_file = tmp_path / "0001_internal.py"
+        internal_file.write_text("# internal migration")
+        pending = tmp_path / "0002_pending.py"
+        pending.write_text("# pending")
+
+        conn = self._make_conn()
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch(
+                 "aksara.migrations.executor.get_applied_migration_records",
+                 new_callable=AsyncMock,
+                 return_value={internal_name: "deadbeefdeadbeef"},
+             ), \
+             patch(
+                 "aksara.migrations.executor.discover_all_migrations",
+                 side_effect=[
+                     [("0002_pending", pending)],
+                     [(internal_name, internal_file), ("0002_pending", pending)],
+                 ],
+             ), \
+             patch(
+                 "aksara.migrations.executor.get_pending_migrations",
+                 return_value=[("0002_pending", pending)],
+             ), \
+             patch(
+                 "aksara.migrations.executor.apply_migration",
+                 new_callable=AsyncMock,
+             ) as apply_mock:
+            with pytest.raises(ValueError, match="checksum mismatch"):
+                await apply_migrations(conn, tmp_path, verbose=False, include_internal=False)
+
+        apply_mock.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_error_message_includes_migration_name(self, tmp_path):
@@ -592,7 +705,7 @@ class TestPendingSkippedReporting:
 
         conn = self._make_conn()
 
-        async def _fail_first(conn, name, path, *, fake, verbose):
+        async def _fail_first(conn, name, path, *, fake, verbose, ensure_table):
             if name == "0001_a":
                 raise RuntimeError("first fails")
 
@@ -627,7 +740,7 @@ class TestPendingSkippedReporting:
 
         conn = self._make_conn()
 
-        async def _fail_second(conn, name, path, *, fake, verbose):
+        async def _fail_second(conn, name, path, *, fake, verbose, ensure_table):
             if name == "0002_b":
                 raise RuntimeError("second fails")
             applied_migs.append(name)
@@ -662,7 +775,7 @@ class TestPendingSkippedReporting:
         attempted = []
         conn = self._make_conn()
 
-        async def _track_and_fail(conn, name, path, *, fake, verbose):
+        async def _track_and_fail(conn, name, path, *, fake, verbose, ensure_table):
             attempted.append(name)
             if name == "0001_a":
                 raise RuntimeError("fail")

--- a/tests/migrations/test_v0550_p1_safety.py
+++ b/tests/migrations/test_v0550_p1_safety.py
@@ -170,6 +170,46 @@ class TestApplyMigrationStoresChecksum:
         assert len(call_checksum) == 16
 
     @pytest.mark.asyncio
+    async def test_direct_apply_ensures_tracking_table_before_transaction(self, tmp_path):
+        f = tmp_path / "0001_init.py"
+        f.write_text("")
+        conn = self._make_raw_conn()
+        tx = conn.transaction.return_value
+        events = []
+
+        def _enter_transaction():
+            events.append("tx_enter")
+            return tx
+
+        async def _ensure_table(_conn):
+            events.append("ensure_table")
+
+        async def _record(*_args):
+            events.append("record_migration")
+
+        tx.__aenter__.side_effect = _enter_transaction
+
+        with patch(
+            "aksara.migrations.executor.ensure_migrations_table",
+            new_callable=AsyncMock,
+            side_effect=_ensure_table,
+        ) as ensure_mock, patch("aksara.migrations.executor.load_migration_module") as lm, \
+             patch(
+                 "aksara.migrations.executor.record_migration",
+                 new_callable=AsyncMock,
+                 side_effect=_record,
+             ):
+            mock_mig = MagicMock()
+            mock_mig.return_value.operations = []
+            lm.return_value = mock_mig
+
+            await apply_migration(conn, "0001_init", f, fake=False, verbose=False)
+
+        ensure_mock.assert_awaited_once()
+        assert events[:2] == ["ensure_table", "tx_enter"]
+        assert "record_migration" in events
+
+    @pytest.mark.asyncio
     async def test_sql_migration_stores_checksum(self, tmp_path):
         f = tmp_path / "0001_init.sql"
         f.write_text("CREATE TABLE t (id SERIAL);")
@@ -356,6 +396,54 @@ async def test_python_migration_records_checksum_in_db(db, tmp_path):
     records = await get_applied_migration_records(db)
     assert "test_p1_0001" in records
     assert records["test_p1_0001"] == expected_cs
+
+
+@pytest.mark.asyncio
+async def test_direct_apply_creates_tracking_table_on_fresh_db(db, tmp_path):
+    f = tmp_path / "test_p1_0002_fresh.py"
+    f.write_text("# migration content")
+    expected_cs = _compute_file_checksum(f)
+    existing_rows = await db.fetch(
+        "SELECT name, checksum, applied_at FROM aksara_migrations ORDER BY applied_at, id"
+    )
+
+    try:
+        await db.execute("DROP TABLE IF EXISTS aksara_migrations")
+
+        with patch("aksara.migrations.executor.load_migration_module") as lm:
+            mock_mig = MagicMock()
+            mock_mig.return_value.operations = []
+            lm.return_value = mock_mig
+            await apply_migration(db, "test_p1_0002_fresh", f, fake=False, verbose=False)
+
+        table_exists = await db.fetchval(
+            """
+            SELECT EXISTS (
+                SELECT FROM information_schema.tables
+                WHERE table_name = 'aksara_migrations'
+            )
+            """
+        )
+        assert table_exists is True
+
+        stored_checksum = await db.fetchval(
+            "SELECT checksum FROM aksara_migrations WHERE name = $1",
+            "test_p1_0002_fresh",
+        )
+        assert stored_checksum == expected_cs
+    finally:
+        await ensure_migrations_table(db)
+        await db.execute("DELETE FROM aksara_migrations")
+        for row in existing_rows:
+            await db.execute(
+                """
+                INSERT INTO aksara_migrations (name, checksum, applied_at)
+                VALUES ($1, $2, $3)
+                """,
+                row["name"],
+                row["checksum"],
+                row["applied_at"],
+            )
 
 
 @pytest.mark.asyncio

--- a/tests/migrations/test_v0550_p1_safety.py
+++ b/tests/migrations/test_v0550_p1_safety.py
@@ -698,6 +698,11 @@ async def test_null_checksum_backward_compat_in_db(db, tmp_path):
 # =============================================================================
 
 class TestBuildMigrationGraphStrictErrors:
+    def _make_user_migration_path(self, tmp_path, app_label: str, name: str) -> Path:
+        migrations_dir = tmp_path / app_label / "migrations"
+        migrations_dir.mkdir(parents=True)
+        return migrations_dir / f"{name}.py"
+
     def test_syntax_error_raises_value_error(self, tmp_path):
         bad = tmp_path / "0001_bad.py"
         bad.write_text("def broken(:")
@@ -732,6 +737,39 @@ class TestBuildMigrationGraphStrictErrors:
 
         assert exc_info.value.__cause__ is not None
 
+    def test_user_migration_error_includes_app_label_and_name(self, tmp_path):
+        bad = self._make_user_migration_path(tmp_path, "blog", "0001_bad")
+        bad.write_text("def broken(:")
+
+        with pytest.raises(ValueError) as exc_info:
+            build_migration_graph(migrations_path=bad.parent, include_internal=False)
+
+        assert "blog.0001_bad" in str(exc_info.value)
+
+    def test_internal_migration_error_avoids_redundant_app_prefix(self, tmp_path):
+        bad = tmp_path / "internal_bad.py"
+        bad.write_text("def broken(:")
+        internal_name = "aksara_contrib_auth_migrations_0001_initial"
+
+        with pytest.raises(ValueError) as exc_info:
+            build_migration_graph(migrations_list=[(internal_name, bad)], include_internal=False)
+
+        message = str(exc_info.value)
+        assert "auth.aksara_contrib_auth_migrations_0001_initial" not in message
+        assert internal_name in message
+
+    def test_internal_migration_error_includes_path_and_original_exception(self, tmp_path):
+        bad = tmp_path / "internal_bad.py"
+        bad.write_text("def broken(:")
+        internal_name = "aksara_contrib_auth_migrations_0001_initial"
+
+        with pytest.raises(ValueError) as exc_info:
+            build_migration_graph(migrations_list=[(internal_name, bad)], include_internal=False)
+
+        message = str(exc_info.value)
+        assert str(bad) in message
+        assert "invalid syntax" in message.lower()
+
     def test_non_strict_does_not_raise(self, tmp_path):
         bad = tmp_path / "0001_bad.py"
         bad.write_text("def broken(:")
@@ -741,6 +779,24 @@ class TestBuildMigrationGraphStrictErrors:
             migrations_path=tmp_path, include_internal=False, strict=False
         )
         assert len(graph) == 1
+
+    def test_non_strict_warning_uses_internal_display_name_formatting(self, tmp_path):
+        bad = tmp_path / "internal_bad.py"
+        bad.write_text("def broken(:")
+        internal_name = "aksara_contrib_auth_migrations_0001_initial"
+
+        with patch("aksara.migrations.executor.logger.warning") as mock_warning:
+            graph = build_migration_graph(
+                migrations_list=[(internal_name, bad)],
+                include_internal=False,
+                strict=False,
+            )
+
+        assert len(graph) == 1
+        warning_message = mock_warning.call_args.args[0]
+        assert "auth.aksara_contrib_auth_migrations_0001_initial" not in warning_message
+        assert internal_name in warning_message
+        assert str(bad) in warning_message
 
     def test_valid_migrations_build_graph_correctly(self, tmp_path):
         good = tmp_path / "0001_good.py"

--- a/tests/migrations/test_v0550_p1_safety.py
+++ b/tests/migrations/test_v0550_p1_safety.py
@@ -283,6 +283,9 @@ class TestChecksumVerification:
 
         assert result["errors"] == []
         assert result["applied"] == []
+        assert result["skipped"] == ["0001_init"]
+        assert result["total_discovered"] == 1
+        assert len(result["skipped"]) <= result["total_discovered"]
 
     @pytest.mark.asyncio
     async def test_checksum_mismatch_raises(self, tmp_path):
@@ -416,6 +419,9 @@ class TestChecksumVerification:
             result = await apply_migrations(conn, tmp_path, verbose=False, include_internal=False)
 
         assert result["errors"] == []
+        assert result["skipped"] == []
+        assert result["total_discovered"] == 1
+        assert len(result["skipped"]) <= result["total_discovered"]
         assert internal_file in computed_paths
         apply_mock.assert_awaited_once()
         assert result["applied"] == ["0002_pending"]

--- a/tests/migrations/test_v0550_p2a_cleanup.py
+++ b/tests/migrations/test_v0550_p2a_cleanup.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from aksara.migrations.base import Migration
 from aksara.migrations.operations import (
     RemoveConstraint,
+    _extract_sqlstate,
     _is_missing_constraint_error,
 )
 
@@ -111,6 +112,33 @@ class TestAutodetectorFallback:
 # Task 3: RemoveConstraint _is_missing_constraint_error
 # =============================================================================
 
+class TestExtractSqlstate:
+    def test_direct_sqlstate_is_returned_first(self):
+        exc = Exception("db error")
+        exc.sqlstate = "42704"
+        assert _extract_sqlstate(exc) == "42704"
+
+    def test_original_exception_sqlstate_is_returned(self):
+        exc = Exception("wrapped")
+        original = Exception("inner")
+        original.sqlstate = "42704"
+        exc.original_exception = original
+        assert _extract_sqlstate(exc) == "42704"
+
+    def test_cause_sqlstate_is_returned(self):
+        exc = Exception("wrapped")
+        cause = Exception("cause")
+        cause.sqlstate = "42704"
+        exc.__cause__ = cause
+        assert _extract_sqlstate(exc) == "42704"
+
+    def test_context_sqlstate_is_returned(self):
+        exc = Exception("wrapped")
+        context = Exception("context")
+        context.sqlstate = "42704"
+        exc.__context__ = context
+        assert _extract_sqlstate(exc) == "42704"
+
 class TestIsMissingConstraintError:
     def test_sqlstate_42704_returns_true(self):
         exc = Exception("some db error")
@@ -136,6 +164,34 @@ class TestIsMissingConstraintError:
         """Even if the string says 'does not exist', a non-42704 sqlstate wins."""
         exc = Exception("does not exist in some other way")
         exc.sqlstate = "08006"  # connection_failure
+        assert _is_missing_constraint_error(exc) is False
+
+    def test_original_exception_sqlstate_42704_returns_true(self):
+        exc = Exception("wrapped error")
+        original = Exception('constraint "foo" does not exist')
+        original.sqlstate = "42704"
+        exc.original_exception = original
+        assert _is_missing_constraint_error(exc) is True
+
+    def test_cause_sqlstate_42704_returns_true(self):
+        exc = Exception("wrapped error")
+        cause = Exception('constraint "foo" does not exist')
+        cause.sqlstate = "42704"
+        exc.__cause__ = cause
+        assert _is_missing_constraint_error(exc) is True
+
+    def test_context_sqlstate_42704_returns_true(self):
+        exc = Exception("wrapped error")
+        context = Exception('constraint "foo" does not exist')
+        context.sqlstate = "42704"
+        exc.__context__ = context
+        assert _is_missing_constraint_error(exc) is True
+
+    def test_non_42704_sqlstate_blocks_string_fallback_when_wrapped(self):
+        exc = Exception('constraint "foo" does not exist')
+        original = Exception('constraint "foo" does not exist')
+        original.sqlstate = "23505"
+        exc.original_exception = original
         assert _is_missing_constraint_error(exc) is False
 
 

--- a/tests/migrations/test_v0550_p2a_cleanup.py
+++ b/tests/migrations/test_v0550_p2a_cleanup.py
@@ -254,25 +254,23 @@ class TestRemoveConstraintErrorHandling:
 class TestCLIPendingSkippedDisplay:
     """Unit-test the _display_pending_skipped helper directly."""
 
-    def test_no_remaining_shows_nothing(self):
+    def test_empty_list_shows_nothing(self):
         from aksara.cli.main import _display_pending_skipped
 
         ui = MagicMock()
-        pending = [("0001_a", None), ("0002_b", None)]
-        # failed_index=1 (last item) — nothing after it
-        _display_pending_skipped(ui, pending, 1)
+        _display_pending_skipped(ui, [])
 
+        ui.blank.assert_not_called()
         ui.warning.assert_not_called()
         ui.text.assert_not_called()
 
-    def test_remaining_shows_warning_and_names(self):
+    def test_non_empty_list_shows_warning_and_names(self):
         from aksara.cli.main import _display_pending_skipped
 
         ui = MagicMock()
-        pending = [("0001_a", None), ("0002_b", None), ("0003_c", None)]
-        # failed at index 0
-        _display_pending_skipped(ui, pending, 0)
+        _display_pending_skipped(ui, ["0002_b", "0003_c"])
 
+        ui.blank.assert_called_once()
         ui.warning.assert_called_once()
         warning_msg = ui.warning.call_args.args[0]
         assert "2" in warning_msg or "Skipped" in warning_msg
@@ -280,34 +278,3 @@ class TestCLIPendingSkippedDisplay:
         text_calls = [str(c) for c in ui.text.call_args_list]
         assert any("0002_b" in c for c in text_calls)
         assert any("0003_c" in c for c in text_calls)
-        assert not any("0001_a" in c for c in text_calls)
-
-    def test_failure_in_middle_skips_only_later(self):
-        from aksara.cli.main import _display_pending_skipped
-
-        ui = MagicMock()
-        pending = [
-            ("0001_alpha", None),
-            ("0002_beta", None),
-            ("0003_gamma", None),
-            ("0004_delta", None),
-        ]
-        # failed at index 1 ("0002_beta")
-        _display_pending_skipped(ui, pending, 1)
-
-        text_calls = [str(c) for c in ui.text.call_args_list]
-        assert any("0003_gamma" in c for c in text_calls)
-        assert any("0004_delta" in c for c in text_calls)
-        assert not any("0001_alpha" in c for c in text_calls)
-        assert not any("0002_beta" in c for c in text_calls)
-
-    def test_single_remaining(self):
-        from aksara.cli.main import _display_pending_skipped
-
-        ui = MagicMock()
-        pending = [("first", None), ("second", None)]
-        _display_pending_skipped(ui, pending, 0)
-
-        ui.warning.assert_called_once()
-        text_calls = [str(c) for c in ui.text.call_args_list]
-        assert any("second" in c for c in text_calls)

--- a/tests/migrations/test_v0550_p2a_cleanup.py
+++ b/tests/migrations/test_v0550_p2a_cleanup.py
@@ -1,0 +1,257 @@
+"""
+v0.5.50 P2-A Migration Cleanup — Regression Tests
+
+Covers:
+  1. Migration._initialized removed — instantiation still works
+  2. Unreachable isinstance(field, type(None)) branch removed
+  3. RemoveConstraint _is_missing_constraint_error uses SQLSTATE first
+  4. CLI displays pending_skipped after a failure
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aksara.migrations.base import Migration
+from aksara.migrations.operations import (
+    RemoveConstraint,
+    _is_missing_constraint_error,
+)
+
+
+# =============================================================================
+# Task 1: Migration._initialized removed
+# =============================================================================
+
+class TestMigrationInstantiation:
+    def test_base_migration_instantiates(self):
+        m = Migration()
+        assert m is not None
+
+    def test_no_initialized_attribute(self):
+        m = Migration()
+        assert not hasattr(m, "_initialized"), (
+            "_initialized was a dead flag and should have been removed"
+        )
+
+    def test_subclass_with_operations_instantiates(self):
+        from aksara.migrations import operations as op
+
+        class MyMigration(Migration):
+            operations = [
+                op.CreateTable(
+                    name="things",
+                    fields=[("id", op.UUIDField(primary_key=True))],
+                )
+            ]
+
+        m = MyMigration()
+        assert len(m.operations) == 1
+
+    def test_subclass_with_dependencies_instantiates(self):
+        class MyMigration(Migration):
+            dependencies = [("myapp", "0001_initial")]
+            operations = []
+
+        m = MyMigration()
+        assert m.dependencies == [("myapp", "0001_initial")]
+
+    def test_multiple_instantiations_do_not_share_state(self):
+        class MyMigration(Migration):
+            operations = []
+
+        m1 = MyMigration()
+        m2 = MyMigration()
+        assert m1 is not m2
+
+    def test_repr(self):
+        m = Migration()
+        assert "Migration" in repr(m)
+
+
+# =============================================================================
+# Task 2: Unreachable isinstance(field, type(None)) branch removed
+# =============================================================================
+
+class TestAutodetectorFallback:
+    """Verify the NoneType branch removal doesn't break unknown-field fallback."""
+
+    def test_unknown_field_like_object_still_returns_string_field(self):
+        """An object that matches no known field type falls back to StringField."""
+        from aksara.migrations.autodetector import _model_field_to_op
+
+        class WeirdField:
+            nullable = True
+            default = None
+            primary_key = False
+            unique = False
+            max_length = None
+            auto_now = False
+            auto_now_add = False
+
+        field_op = _model_field_to_op("thing", WeirdField())
+        # Unknown type should still produce a usable op (StringField fallback)
+        assert field_op is not None
+
+    def test_standard_fields_still_detected(self):
+        from aksara.migrations.autodetector import _model_field_to_op
+        from aksara.fields import String, Boolean, DateTime, Integer
+
+        for field_cls, expected_type in [
+            (String, "StringField"),
+            (Boolean, "BooleanField"),
+            (DateTime, "DateTimeField"),
+            (Integer, "IntegerField"),
+        ]:
+            # Just check no exception — we already have broader autodetector tests
+            op = _model_field_to_op("col", field_cls())
+            assert op is not None
+
+
+# =============================================================================
+# Task 3: RemoveConstraint _is_missing_constraint_error
+# =============================================================================
+
+class TestIsMissingConstraintError:
+    def test_sqlstate_42704_returns_true(self):
+        exc = Exception("some db error")
+        exc.sqlstate = "42704"
+        assert _is_missing_constraint_error(exc) is True
+
+    def test_sqlstate_other_returns_false(self):
+        exc = Exception("some other error")
+        exc.sqlstate = "23505"  # unique_violation
+        assert _is_missing_constraint_error(exc) is False
+
+    def test_no_sqlstate_falls_back_to_string_match(self):
+        exc = Exception('ERROR: constraint "foo" does not exist')
+        assert not hasattr(exc, "sqlstate")
+        assert _is_missing_constraint_error(exc) is True
+
+    def test_no_sqlstate_unrelated_message_returns_false(self):
+        exc = Exception("connection refused")
+        assert not hasattr(exc, "sqlstate")
+        assert _is_missing_constraint_error(exc) is False
+
+    def test_sqlstate_takes_priority_over_string(self):
+        """Even if the string says 'does not exist', a non-42704 sqlstate wins."""
+        exc = Exception("does not exist in some other way")
+        exc.sqlstate = "08006"  # connection_failure
+        assert _is_missing_constraint_error(exc) is False
+
+
+class TestRemoveConstraintErrorHandling:
+    @pytest.mark.asyncio
+    async def test_if_exists_true_suppresses_42704(self):
+        conn = AsyncMock()
+        err = Exception("constraint missing")
+        err.sqlstate = "42704"
+        conn.execute.side_effect = err
+
+        op = RemoveConstraint(table="users", name="chk_age", if_exists=True)
+        # Should not raise
+        await op.apply(conn)
+
+    @pytest.mark.asyncio
+    async def test_if_exists_true_suppresses_english_fallback(self):
+        conn = AsyncMock()
+        conn.execute.side_effect = Exception('constraint "chk_age" does not exist')
+
+        op = RemoveConstraint(table="users", name="chk_age", if_exists=True)
+        await op.apply(conn)
+
+    @pytest.mark.asyncio
+    async def test_if_exists_true_does_not_suppress_unrelated_sqlstate(self):
+        conn = AsyncMock()
+        err = Exception("permission denied")
+        err.sqlstate = "42501"
+        conn.execute.side_effect = err
+
+        op = RemoveConstraint(table="users", name="chk_age", if_exists=True)
+        with pytest.raises(Exception, match="permission denied"):
+            await op.apply(conn)
+
+    @pytest.mark.asyncio
+    async def test_if_exists_false_does_not_suppress(self):
+        conn = AsyncMock()
+        err = Exception("constraint missing")
+        err.sqlstate = "42704"
+        conn.execute.side_effect = err
+
+        op = RemoveConstraint(table="users", name="chk_age", if_exists=False)
+        with pytest.raises(Exception):
+            await op.apply(conn)
+
+    @pytest.mark.asyncio
+    async def test_success_path_no_error(self):
+        conn = AsyncMock()
+        conn.execute.return_value = "ALTER TABLE"
+
+        op = RemoveConstraint(table="users", name="chk_age")
+        await op.apply(conn)
+        conn.execute.assert_awaited_once()
+
+
+# =============================================================================
+# Task 4: CLI pending_skipped display
+# =============================================================================
+
+class TestCLIPendingSkippedDisplay:
+    """Unit-test the _display_pending_skipped helper directly."""
+
+    def test_no_remaining_shows_nothing(self):
+        from aksara.cli.main import _display_pending_skipped
+
+        ui = MagicMock()
+        pending = [("0001_a", None), ("0002_b", None)]
+        # failed_index=1 (last item) — nothing after it
+        _display_pending_skipped(ui, pending, 1)
+
+        ui.warning.assert_not_called()
+        ui.text.assert_not_called()
+
+    def test_remaining_shows_warning_and_names(self):
+        from aksara.cli.main import _display_pending_skipped
+
+        ui = MagicMock()
+        pending = [("0001_a", None), ("0002_b", None), ("0003_c", None)]
+        # failed at index 0
+        _display_pending_skipped(ui, pending, 0)
+
+        ui.warning.assert_called_once()
+        warning_msg = ui.warning.call_args.args[0]
+        assert "2" in warning_msg or "Skipped" in warning_msg
+
+        text_calls = [str(c) for c in ui.text.call_args_list]
+        assert any("0002_b" in c for c in text_calls)
+        assert any("0003_c" in c for c in text_calls)
+        assert not any("0001_a" in c for c in text_calls)
+
+    def test_failure_in_middle_skips_only_later(self):
+        from aksara.cli.main import _display_pending_skipped
+
+        ui = MagicMock()
+        pending = [
+            ("0001_alpha", None),
+            ("0002_beta", None),
+            ("0003_gamma", None),
+            ("0004_delta", None),
+        ]
+        # failed at index 1 ("0002_beta")
+        _display_pending_skipped(ui, pending, 1)
+
+        text_calls = [str(c) for c in ui.text.call_args_list]
+        assert any("0003_gamma" in c for c in text_calls)
+        assert any("0004_delta" in c for c in text_calls)
+        assert not any("0001_alpha" in c for c in text_calls)
+        assert not any("0002_beta" in c for c in text_calls)
+
+    def test_single_remaining(self):
+        from aksara.cli.main import _display_pending_skipped
+
+        ui = MagicMock()
+        pending = [("first", None), ("second", None)]
+        _display_pending_skipped(ui, pending, 0)
+
+        ui.warning.assert_called_once()
+        text_calls = [str(c) for c in ui.text.call_args_list]
+        assert any("second" in c for c in text_calls)

--- a/tests/migrations/test_v0550_p2b_guardrails.py
+++ b/tests/migrations/test_v0550_p2b_guardrails.py
@@ -39,7 +39,7 @@ class TestMakeConstraintName:
     def test_64_char_name_gets_hash_suffix(self):
         part = "a" * 64
         name = _make_constraint_name(part)
-        assert len(name) <= 63
+        assert len(name.encode("utf-8")) <= 63
         assert "_" in name
         # suffix is last 8 chars after final underscore
         suffix = name.rsplit("_", 1)[-1]
@@ -59,7 +59,7 @@ class TestMakeConstraintName:
 
     def test_custom_max_length(self):
         name = _make_constraint_name("fk", "table", "col", max_length=20)
-        assert len(name) <= 20
+        assert len(name.encode("utf-8")) <= 20
 
     def test_max_length_less_than_10_rejected(self):
         with pytest.raises(ValueError, match="at least 10"):
@@ -67,11 +67,37 @@ class TestMakeConstraintName:
 
     def test_max_length_10_is_respected_for_long_input(self):
         name = _make_constraint_name("x" * 50, max_length=10)
-        assert len(name) <= 10
+        assert len(name.encode("utf-8")) <= 10
 
     def test_default_63_char_bound_still_applies(self):
         name = _make_constraint_name("x" * 100)
-        assert len(name) <= 63
+        assert len(name.encode("utf-8")) <= 63
+
+    def test_ascii_long_name_fits_63_bytes(self):
+        name = _make_constraint_name("ascii_" + ("x" * 100))
+        assert len(name.encode("utf-8")) <= 63
+
+    def test_non_ascii_name_under_byte_limit_returns_unchanged(self):
+        part = "é" * 31
+        name = _make_constraint_name(part)
+        assert name == part
+        assert len(name.encode("utf-8")) == 62
+
+    def test_non_ascii_long_name_fits_63_bytes(self):
+        name = _make_constraint_name("名" * 30)
+        assert len(name.encode("utf-8")) <= 63
+        assert "_" in name
+
+    def test_non_ascii_truncation_does_not_split_character(self):
+        name = _make_constraint_name("é" * 20, max_length=14)
+        prefix, suffix = name.rsplit("_", 1)
+        assert prefix == "éé"
+        assert len(suffix) == 8
+        assert len(name.encode("utf-8")) <= 14
+
+    def test_non_ascii_max_length_10_fits_byte_budget(self):
+        name = _make_constraint_name("é" * 20, max_length=10)
+        assert len(name.encode("utf-8")) <= 10
 
 
 class TestManyToManyFieldConstraintNames:

--- a/tests/migrations/test_v0550_p2b_guardrails.py
+++ b/tests/migrations/test_v0550_p2b_guardrails.py
@@ -1,0 +1,316 @@
+"""
+v0.5.50 P2-B Guardrails — Regression Tests
+
+Covers:
+  1. ManyToManyField constraint names are quoted and length-bounded
+  2. IndexOp.where predicate validation
+  3. ArrayField.sql_type validation
+"""
+
+import pytest
+
+from aksara.migrations.operations import (
+    ArrayField,
+    IndexOp,
+    ManyToManyField,
+    _make_constraint_name,
+    _validate_array_sql_type,
+    _validate_sql_predicate,
+)
+
+
+# =============================================================================
+# Task 1: _make_constraint_name helper
+# =============================================================================
+
+class TestMakeConstraintName:
+    def test_short_name_unchanged(self):
+        assert _make_constraint_name("fk", "users", "source") == "fk_users_source"
+
+    def test_empty_parts_skipped(self):
+        assert _make_constraint_name("fk", "", "target") == "fk_target"
+
+    def test_exactly_63_chars_unchanged(self):
+        part = "a" * 60
+        name = _make_constraint_name(part)
+        assert name == part
+        assert len(name) == 60
+
+    def test_64_char_name_gets_hash_suffix(self):
+        part = "a" * 64
+        name = _make_constraint_name(part)
+        assert len(name) <= 63
+        assert "_" in name
+        # suffix is last 8 chars after final underscore
+        suffix = name.rsplit("_", 1)[-1]
+        assert len(suffix) == 8
+
+    def test_deterministic(self):
+        name1 = _make_constraint_name("fk", "very_long_table_name_that_is_definitely_over_limit", "source")
+        name2 = _make_constraint_name("fk", "very_long_table_name_that_is_definitely_over_limit", "source")
+        assert name1 == name2
+
+    def test_different_long_names_produce_different_results(self):
+        long_a = "a" * 70
+        long_b = "b" * 70
+        name_a = _make_constraint_name(long_a)
+        name_b = _make_constraint_name(long_b)
+        assert name_a != name_b
+
+    def test_custom_max_length(self):
+        name = _make_constraint_name("fk", "table", "col", max_length=20)
+        assert len(name) <= 20
+
+
+class TestManyToManyFieldConstraintNames:
+    def _get_sql(self, source="users", target="posts", field="liked_posts"):
+        m2m = ManyToManyField(source, target, field)
+        return m2m.get_join_table_sql()
+
+    def test_constraint_names_are_quoted(self):
+        sql = self._get_sql()
+        # Each CONSTRAINT name should be double-quoted
+        import re
+        constraints = re.findall(r'CONSTRAINT\s+"([^"]+)"', sql)
+        assert len(constraints) == 2, f"Expected 2 quoted constraints, got: {constraints}"
+
+    def test_source_constraint_name_correct(self):
+        sql = self._get_sql("users", "posts", "liked_posts")
+        assert "fk_users_liked_posts_source" in sql
+
+    def test_target_constraint_name_correct(self):
+        sql = self._get_sql("users", "posts", "liked_posts")
+        assert "fk_users_liked_posts_target" in sql
+
+    def test_referenced_columns_are_quoted(self):
+        sql = self._get_sql()
+        # REFERENCES "users"("id") — column quoted
+        assert 'REFERENCES "users"("id")' in sql or 'REFERENCES "posts"("id")' in sql
+
+    def test_fk_columns_are_quoted(self):
+        sql = self._get_sql()
+        assert '"source_id"' in sql
+        assert '"target_id"' in sql
+
+    def test_long_table_name_constraint_fits_63_chars(self):
+        long_table = "a" * 40
+        long_field = "b" * 30
+        m2m = ManyToManyField(long_table, "posts", long_field)
+        sql = m2m.get_join_table_sql()
+        import re
+        constraints = re.findall(r'CONSTRAINT\s+"([^"]+)"', sql)
+        for c in constraints:
+            assert len(c) <= 63, f"Constraint name too long: {c!r}"
+
+    def test_join_table_sql_has_expected_structure(self):
+        sql = self._get_sql()
+        assert "CREATE TABLE IF NOT EXISTS" in sql
+        assert "PRIMARY KEY" in sql
+        assert "ON DELETE CASCADE" in sql
+        assert "UNIQUE" in sql
+
+
+# =============================================================================
+# Task 2: IndexOp.where predicate validation
+# =============================================================================
+
+class TestValidateSqlPredicate:
+    def test_simple_predicate_passes(self):
+        result = _validate_sql_predicate("active = true")
+        assert result == "active = true"
+
+    def test_comparison_predicate_passes(self):
+        assert _validate_sql_predicate("status != 'deleted'") == "status != 'deleted'"
+
+    def test_complex_but_safe_predicate_passes(self):
+        assert _validate_sql_predicate("amount > 0 AND currency = 'USD'") is not None
+
+    def test_semicolon_rejected(self):
+        with pytest.raises(ValueError, match="semicolons"):
+            _validate_sql_predicate("active = true; DROP TABLE users")
+
+    def test_line_comment_rejected(self):
+        with pytest.raises(ValueError, match="line comments"):
+            _validate_sql_predicate("active = true -- bypass")
+
+    def test_block_comment_open_rejected(self):
+        with pytest.raises(ValueError, match="block comments"):
+            _validate_sql_predicate("active = true /* inject */")
+
+    def test_block_comment_close_rejected(self):
+        with pytest.raises(ValueError, match="block comments"):
+            _validate_sql_predicate("*/ active = true")
+
+    def test_drop_keyword_rejected(self):
+        with pytest.raises(ValueError, match="DROP"):
+            _validate_sql_predicate("DROP TABLE users")
+
+    def test_delete_keyword_rejected(self):
+        with pytest.raises(ValueError, match="DELETE"):
+            _validate_sql_predicate("DELETE FROM users")
+
+    def test_insert_keyword_rejected(self):
+        with pytest.raises(ValueError, match="INSERT"):
+            _validate_sql_predicate("INSERT INTO x VALUES (1)")
+
+    def test_update_keyword_rejected(self):
+        with pytest.raises(ValueError, match="UPDATE"):
+            _validate_sql_predicate("UPDATE users SET x=1")
+
+    def test_create_keyword_rejected(self):
+        with pytest.raises(ValueError, match="CREATE"):
+            _validate_sql_predicate("CREATE TABLE evil (x int)")
+
+    def test_truncate_keyword_rejected(self):
+        with pytest.raises(ValueError, match="TRUNCATE"):
+            _validate_sql_predicate("TRUNCATE users")
+
+    def test_grant_keyword_rejected(self):
+        with pytest.raises(ValueError, match="GRANT"):
+            _validate_sql_predicate("GRANT ALL ON users TO attacker")
+
+    def test_keyword_case_insensitive(self):
+        with pytest.raises(ValueError, match="DROP"):
+            _validate_sql_predicate("drop table users")
+
+    def test_non_string_rejected(self):
+        with pytest.raises(ValueError):
+            _validate_sql_predicate(123)
+
+    def test_column_named_created_at_passes(self):
+        # "created" contains "CREATE" as substring but not as a whole word
+        assert _validate_sql_predicate("created_at > NOW()") is not None
+
+    def test_custom_context_in_error_message(self):
+        with pytest.raises(ValueError, match="my_context"):
+            _validate_sql_predicate("DROP TABLE x", context="my_context")
+
+
+class TestIndexOpWhereValidation:
+    def test_valid_where_accepted(self):
+        idx = IndexOp(name="idx_active", table="users", columns=["id"], where="active = true")
+        assert idx.where == "active = true"
+
+    def test_no_where_accepted(self):
+        idx = IndexOp(name="idx_all", table="users", columns=["id"])
+        assert idx.where is None
+
+    def test_semicolon_in_where_raises(self):
+        with pytest.raises(ValueError, match="semicolons"):
+            IndexOp(name="idx_bad", table="users", columns=["id"], where="x=1; DROP TABLE users")
+
+    def test_ddl_keyword_in_where_raises(self):
+        with pytest.raises(ValueError, match="DROP"):
+            IndexOp(name="idx_bad", table="users", columns=["id"], where="DROP TABLE users")
+
+    def test_line_comment_in_where_raises(self):
+        with pytest.raises(ValueError, match="line comments"):
+            IndexOp(name="idx_bad", table="users", columns=["id"], where="1=1 -- bypass")
+
+    def test_other_params_unaffected(self):
+        idx = IndexOp(
+            name="idx_unique_email",
+            table="users",
+            columns=["email"],
+            unique=True,
+            where="email IS NOT NULL",
+            method="btree",
+        )
+        assert idx.unique is True
+        assert idx.method == "btree"
+        assert "email IS NOT NULL" in idx.to_sql()
+
+
+# =============================================================================
+# Task 3: ArrayField.sql_type validation
+# =============================================================================
+
+class TestValidateArraySqlType:
+    def test_text_array_passes(self):
+        assert _validate_array_sql_type("TEXT[]") == "TEXT[]"
+
+    def test_lowercase_normalised_to_uppercase(self):
+        assert _validate_array_sql_type("text[]") == "TEXT[]"
+
+    def test_integer_array_passes(self):
+        assert _validate_array_sql_type("INTEGER[]") == "INTEGER[]"
+
+    def test_uuid_array_passes(self):
+        assert _validate_array_sql_type("UUID[]") == "UUID[]"
+
+    def test_jsonb_array_passes(self):
+        assert _validate_array_sql_type("JSONB[]") == "JSONB[]"
+
+    def test_varchar_with_length_passes(self):
+        assert _validate_array_sql_type("VARCHAR(255)[]") == "VARCHAR(255)[]"
+
+    def test_timestamp_with_time_zone_passes(self):
+        assert _validate_array_sql_type("TIMESTAMP WITH TIME ZONE[]") == "TIMESTAMP WITH TIME ZONE[]"
+
+    def test_missing_brackets_rejected(self):
+        with pytest.raises(ValueError, match="must end with"):
+            _validate_array_sql_type("TEXT")
+
+    def test_empty_string_rejected(self):
+        with pytest.raises(ValueError, match="non-empty string"):
+            _validate_array_sql_type("")
+
+    def test_none_rejected(self):
+        with pytest.raises(ValueError):
+            _validate_array_sql_type(None)
+
+    def test_unknown_base_type_rejected(self):
+        with pytest.raises(ValueError, match="unknown base type"):
+            _validate_array_sql_type("EVIL[]")
+
+    def test_semicolon_rejected(self):
+        with pytest.raises(ValueError, match="unsafe characters"):
+            _validate_array_sql_type("TEXT[]; DROP TABLE users")
+
+    def test_double_quote_rejected(self):
+        with pytest.raises(ValueError, match="unsafe characters"):
+            _validate_array_sql_type('TEXT"[]')
+
+    def test_ddl_keyword_rejected(self):
+        with pytest.raises(ValueError, match="disallowed keyword"):
+            _validate_array_sql_type("DROP[]")
+
+    def test_bigint_array_passes(self):
+        assert _validate_array_sql_type("BIGINT[]") == "BIGINT[]"
+
+    def test_boolean_array_passes(self):
+        assert _validate_array_sql_type("BOOLEAN[]") == "BOOLEAN[]"
+
+    def test_numeric_array_passes(self):
+        assert _validate_array_sql_type("NUMERIC[]") == "NUMERIC[]"
+
+
+class TestArrayFieldSqlTypeValidation:
+    def test_default_text_array_accepted(self):
+        f = ArrayField()
+        assert f.sql_type == "TEXT[]"
+
+    def test_custom_valid_type_accepted(self):
+        f = ArrayField(sql_type="INTEGER[]")
+        assert f.sql_type == "INTEGER[]"
+
+    def test_lowercase_normalised(self):
+        f = ArrayField(sql_type="uuid[]")
+        assert f.sql_type == "UUID[]"
+
+    def test_invalid_type_raises_at_construction(self):
+        with pytest.raises(ValueError):
+            ArrayField(sql_type="EVIL[]")
+
+    def test_missing_brackets_raises_at_construction(self):
+        with pytest.raises(ValueError, match="must end with"):
+            ArrayField(sql_type="TEXT")
+
+    def test_sql_injection_raises_at_construction(self):
+        with pytest.raises(ValueError):
+            ArrayField(sql_type="TEXT[]; DROP TABLE users")
+
+    def test_nullable_and_default_still_work(self):
+        f = ArrayField(sql_type="JSONB[]", nullable=False, default=[])
+        assert f.nullable is False
+        assert f.default == []

--- a/tests/migrations/test_v0550_p2b_guardrails.py
+++ b/tests/migrations/test_v0550_p2b_guardrails.py
@@ -163,17 +163,41 @@ class TestValidateSqlPredicate:
     def test_complex_but_safe_predicate_passes(self):
         assert _validate_sql_predicate("amount > 0 AND currency = 'USD'") is not None
 
+    def test_line_comment_marker_inside_string_passes(self):
+        assert _validate_sql_predicate("note LIKE '%--%'") == "note LIKE '%--%'"
+
+    def test_block_comment_marker_inside_string_passes(self):
+        assert _validate_sql_predicate("note LIKE '%/*%'") == "note LIKE '%/*%'"
+
+    def test_semicolon_inside_string_passes(self):
+        assert _validate_sql_predicate("note = 'a;b'") == "note = 'a;b'"
+
+    def test_keyword_inside_string_and_quoted_identifier_passes(self):
+        assert _validate_sql_predicate('"order" = \'drop\'') == '"order" = \'drop\''
+
     def test_semicolon_rejected(self):
         with pytest.raises(ValueError, match="semicolons"):
             _validate_sql_predicate("active = true; DROP TABLE users")
+
+    def test_semicolon_after_string_rejected(self):
+        with pytest.raises(ValueError, match="semicolons"):
+            _validate_sql_predicate("status = 'active'; DROP TABLE users")
 
     def test_line_comment_rejected(self):
         with pytest.raises(ValueError, match="line comments"):
             _validate_sql_predicate("active = true -- bypass")
 
+    def test_line_comment_after_string_rejected(self):
+        with pytest.raises(ValueError, match="line comments"):
+            _validate_sql_predicate("status = 'active' -- comment")
+
     def test_block_comment_open_rejected(self):
         with pytest.raises(ValueError, match="block comments"):
             _validate_sql_predicate("active = true /* inject */")
+
+    def test_block_comment_after_string_rejected(self):
+        with pytest.raises(ValueError, match="block comments"):
+            _validate_sql_predicate("status = 'active' /* comment */")
 
     def test_block_comment_close_rejected(self):
         with pytest.raises(ValueError, match="block comments"):
@@ -234,6 +258,14 @@ class TestValidateSqlPredicate:
     def test_predicate_is_stripped(self):
         assert _validate_sql_predicate(" status = 'active' ") == "status = 'active'"
 
+    def test_unterminated_single_quote_rejected(self):
+        with pytest.raises(ValueError, match="unterminated single"):
+            _validate_sql_predicate("status = 'active")
+
+    def test_unterminated_double_quote_rejected(self):
+        with pytest.raises(ValueError, match="unterminated double"):
+            _validate_sql_predicate('"bad_identifier = 1')
+
 
 class TestIndexOpWhereValidation:
     def test_valid_where_accepted(self):
@@ -268,6 +300,24 @@ class TestIndexOpWhereValidation:
             where=" status = 'active' ",
         )
         assert idx.where == "status = 'active'"
+
+    def test_quoted_string_comment_markers_in_where_accepted(self):
+        idx = IndexOp(
+            name="idx_note",
+            table="notes",
+            columns=["id"],
+            where="note LIKE '%--%' AND body LIKE '%/*%'",
+        )
+        assert idx.where == "note LIKE '%--%' AND body LIKE '%/*%'"
+
+    def test_semicolon_inside_quoted_string_in_where_accepted(self):
+        idx = IndexOp(
+            name="idx_note",
+            table="notes",
+            columns=["id"],
+            where="note = 'a;b'",
+        )
+        assert idx.where == "note = 'a;b'"
 
     def test_other_params_unaffected(self):
         idx = IndexOp(

--- a/tests/migrations/test_v0550_p2b_guardrails.py
+++ b/tests/migrations/test_v0550_p2b_guardrails.py
@@ -61,6 +61,18 @@ class TestMakeConstraintName:
         name = _make_constraint_name("fk", "table", "col", max_length=20)
         assert len(name) <= 20
 
+    def test_max_length_less_than_10_rejected(self):
+        with pytest.raises(ValueError, match="at least 10"):
+            _make_constraint_name("too", "short", max_length=9)
+
+    def test_max_length_10_is_respected_for_long_input(self):
+        name = _make_constraint_name("x" * 50, max_length=10)
+        assert len(name) <= 10
+
+    def test_default_63_char_bound_still_applies(self):
+        name = _make_constraint_name("x" * 100)
+        assert len(name) <= 63
+
 
 class TestManyToManyFieldConstraintNames:
     def _get_sql(self, source="users", target="posts", field="liked_posts"):
@@ -185,6 +197,17 @@ class TestValidateSqlPredicate:
         with pytest.raises(ValueError, match="my_context"):
             _validate_sql_predicate("DROP TABLE x", context="my_context")
 
+    def test_empty_string_rejected(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            _validate_sql_predicate("")
+
+    def test_whitespace_only_rejected(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            _validate_sql_predicate("   ")
+
+    def test_predicate_is_stripped(self):
+        assert _validate_sql_predicate(" status = 'active' ") == "status = 'active'"
+
 
 class TestIndexOpWhereValidation:
     def test_valid_where_accepted(self):
@@ -206,6 +229,19 @@ class TestIndexOpWhereValidation:
     def test_line_comment_in_where_raises(self):
         with pytest.raises(ValueError, match="line comments"):
             IndexOp(name="idx_bad", table="users", columns=["id"], where="1=1 -- bypass")
+
+    def test_whitespace_only_where_raises(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            IndexOp(name="idx_bad", table="users", columns=["id"], where="   ")
+
+    def test_where_is_stripped(self):
+        idx = IndexOp(
+            name="idx_active",
+            table="users",
+            columns=["id"],
+            where=" status = 'active' ",
+        )
+        assert idx.where == "status = 'active'"
 
     def test_other_params_unaffected(self):
         idx = IndexOp(

--- a/tests/migrations/test_v0550_p2b_guardrails.py
+++ b/tests/migrations/test_v0550_p2b_guardrails.py
@@ -306,6 +306,12 @@ class TestValidateArraySqlType:
     def test_varchar_with_length_passes(self):
         assert _validate_array_sql_type("VARCHAR(255)[]") == "VARCHAR(255)[]"
 
+    def test_character_varying_with_length_passes(self):
+        assert (
+            _validate_array_sql_type("CHARACTER VARYING(255)[]")
+            == "CHARACTER VARYING(255)[]"
+        )
+
     def test_numeric_with_precision_scale_passes(self):
         assert _validate_array_sql_type("NUMERIC(10,2)[]") == "NUMERIC(10,2)[]"
 
@@ -315,8 +321,29 @@ class TestValidateArraySqlType:
     def test_decimal_with_precision_scale_passes(self):
         assert _validate_array_sql_type("DECIMAL(12,4)[]") == "DECIMAL(12,4)[]"
 
+    def test_decimal_with_precision_only_passes(self):
+        assert _validate_array_sql_type("DECIMAL(12)[]") == "DECIMAL(12)[]"
+
+    def test_timestamp_with_precision_passes(self):
+        assert _validate_array_sql_type("TIMESTAMP(3)[]") == "TIMESTAMP(3)[]"
+
+    def test_timestamptz_with_precision_passes(self):
+        assert _validate_array_sql_type("TIMESTAMPTZ(6)[]") == "TIMESTAMPTZ(6)[]"
+
     def test_timestamp_with_time_zone_passes(self):
         assert _validate_array_sql_type("TIMESTAMP WITH TIME ZONE[]") == "TIMESTAMP WITH TIME ZONE[]"
+
+    def test_timestamp_with_time_zone_precision_passes(self):
+        assert (
+            _validate_array_sql_type("TIMESTAMP WITH TIME ZONE(3)[]")
+            == "TIMESTAMP WITH TIME ZONE(3)[]"
+        )
+
+    def test_timestamp_without_time_zone_precision_passes(self):
+        assert (
+            _validate_array_sql_type("TIMESTAMP WITHOUT TIME ZONE(3)[]")
+            == "TIMESTAMP WITHOUT TIME ZONE(3)[]"
+        )
 
     def test_missing_brackets_rejected(self):
         with pytest.raises(ValueError, match="must end with"):
@@ -362,6 +389,26 @@ class TestValidateArraySqlType:
     def test_numeric_with_too_many_args_rejected(self):
         with pytest.raises(ValueError, match="malformed length/precision"):
             _validate_array_sql_type("NUMERIC(10,2,3)[]")
+
+    def test_uuid_with_length_rejected(self):
+        with pytest.raises(ValueError, match="does not allow length/precision"):
+            _validate_array_sql_type("UUID(1)[]")
+
+    def test_text_with_length_rejected(self):
+        with pytest.raises(ValueError, match="does not allow length/precision"):
+            _validate_array_sql_type("TEXT(10)[]")
+
+    def test_jsonb_with_length_rejected(self):
+        with pytest.raises(ValueError, match="does not allow length/precision"):
+            _validate_array_sql_type("JSONB(1)[]")
+
+    def test_boolean_with_length_rejected(self):
+        with pytest.raises(ValueError, match="does not allow length/precision"):
+            _validate_array_sql_type("BOOLEAN(1)[]")
+
+    def test_integer_with_length_rejected(self):
+        with pytest.raises(ValueError, match="does not allow length/precision"):
+            _validate_array_sql_type("INTEGER(10)[]")
 
     def test_numeric_with_unsafe_sql_rejected(self):
         with pytest.raises(ValueError, match="unsafe characters"):

--- a/tests/migrations/test_v0550_p2b_guardrails.py
+++ b/tests/migrations/test_v0550_p2b_guardrails.py
@@ -306,6 +306,15 @@ class TestValidateArraySqlType:
     def test_varchar_with_length_passes(self):
         assert _validate_array_sql_type("VARCHAR(255)[]") == "VARCHAR(255)[]"
 
+    def test_numeric_with_precision_scale_passes(self):
+        assert _validate_array_sql_type("NUMERIC(10,2)[]") == "NUMERIC(10,2)[]"
+
+    def test_numeric_with_spaced_precision_scale_preserves_spacing(self):
+        assert _validate_array_sql_type("numeric(10, 2)[]") == "NUMERIC(10, 2)[]"
+
+    def test_decimal_with_precision_scale_passes(self):
+        assert _validate_array_sql_type("DECIMAL(12,4)[]") == "DECIMAL(12,4)[]"
+
     def test_timestamp_with_time_zone_passes(self):
         assert _validate_array_sql_type("TIMESTAMP WITH TIME ZONE[]") == "TIMESTAMP WITH TIME ZONE[]"
 
@@ -346,6 +355,18 @@ class TestValidateArraySqlType:
     def test_numeric_array_passes(self):
         assert _validate_array_sql_type("NUMERIC[]") == "NUMERIC[]"
 
+    def test_numeric_with_non_numeric_scale_rejected(self):
+        with pytest.raises(ValueError, match="malformed length/precision"):
+            _validate_array_sql_type("NUMERIC(10,x)[]")
+
+    def test_numeric_with_too_many_args_rejected(self):
+        with pytest.raises(ValueError, match="malformed length/precision"):
+            _validate_array_sql_type("NUMERIC(10,2,3)[]")
+
+    def test_numeric_with_unsafe_sql_rejected(self):
+        with pytest.raises(ValueError, match="unsafe characters"):
+            _validate_array_sql_type("NUMERIC(10); DROP TABLE x;--[]")
+
 
 class TestArrayFieldSqlTypeValidation:
     def test_default_text_array_accepted(self):
@@ -359,6 +380,10 @@ class TestArrayFieldSqlTypeValidation:
     def test_lowercase_normalised(self):
         f = ArrayField(sql_type="uuid[]")
         assert f.sql_type == "UUID[]"
+
+    def test_numeric_precision_scale_accepted_at_construction(self):
+        f = ArrayField(sql_type="numeric(10,2)[]")
+        assert f.sql_type == "NUMERIC(10,2)[]"
 
     def test_invalid_type_raises_at_construction(self):
         with pytest.raises(ValueError):

--- a/tests/migrations/test_v0550_p2c_unification.py
+++ b/tests/migrations/test_v0550_p2c_unification.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from click.testing import CliRunner
 
-from aksara.cli.main import cli
+from aksara.cli.main import _display_pending_skipped, cli
 
 
 runner = CliRunner()
@@ -101,6 +101,36 @@ class TestCLIMigrateDelegation:
         )
         assert result.exit_code == 0
         apply_mock.assert_awaited_once()
+
+    def test_canonical_path_does_not_pre_ensure_migrations_table(
+        self, tmp_path, monkeypatch
+    ):
+        from aksara.conf import settings
+        from contextlib import ExitStack
+
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        migration_path = migrations_dir / "0001_init.py"
+        migration_path.write_text("# migration")
+
+        monkeypatch.setattr(
+            settings, "database_url", "postgresql://localhost/test", raising=False
+        )
+        monkeypatch.setattr(settings, "migrations_dir", str(migrations_dir), raising=False)
+
+        patches = _cli_patches(
+            tmp_path, migration_path, apply_result=_apply_result(applied=["0001_init"])
+        )
+        with ExitStack() as stack:
+            mocks = [stack.enter_context(p) for p in patches]
+            ensure_mock = mocks[3]
+            apply_mock = mocks[-1]
+
+            result = runner.invoke(cli, ["migrate"])
+
+        assert result.exit_code == 0
+        apply_mock.assert_awaited_once()
+        ensure_mock.assert_not_awaited()
 
     def test_apply_migrations_receives_db_and_path(self, tmp_path, monkeypatch):
         result, apply_mock = self._run(
@@ -220,6 +250,41 @@ class TestCLIMigrateOutput:
         assert result.exit_code != 0
         assert "0002_add_field" in result.output
         assert "0003_add_index" in result.output
+
+    def test_pending_skipped_display_uses_helper(self, tmp_path, monkeypatch):
+        from aksara.conf import settings
+        from contextlib import ExitStack
+
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        migration_path = migrations_dir / "0001_init.py"
+        migration_path.write_text("# migration")
+
+        monkeypatch.setattr(
+            settings, "database_url", "postgresql://localhost/test", raising=False
+        )
+        monkeypatch.setattr(settings, "migrations_dir", str(migrations_dir), raising=False)
+
+        patches = _cli_patches(
+            tmp_path,
+            migration_path,
+            apply_result=_apply_result(
+                errors=[("0001_init", "boom")],
+                pending_skipped=["0002_add_field", "0003_add_index"],
+            ),
+        )
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            with patch(
+                "aksara.cli.main._display_pending_skipped",
+                wraps=_display_pending_skipped,
+            ) as mock_display:
+                result = runner.invoke(cli, ["migrate"])
+
+        assert result.exit_code != 0
+        mock_display.assert_called_once()
+        assert mock_display.call_args.args[1] == ["0002_add_field", "0003_add_index"]
 
     def test_exit_nonzero_on_errors(self, tmp_path, monkeypatch):
         result = self._invoke(

--- a/tests/migrations/test_v0550_p2c_unification.py
+++ b/tests/migrations/test_v0550_p2c_unification.py
@@ -333,6 +333,65 @@ class TestApplyTestMigrationsDelegation:
             assert call_kwargs.get("include_internal") is True
 
     @pytest.mark.asyncio
+    async def test_no_errors_result_does_not_raise(self, tmp_path, monkeypatch):
+        from aksara.conf import settings
+        from aksara.testing import _apply_test_migrations
+
+        monkeypatch.setattr(settings, "migrations_dir", str(tmp_path / "migrations"),
+                            raising=False)
+
+        with patch(
+            "aksara.migrations.executor.apply_migrations",
+            new_callable=AsyncMock,
+            return_value={
+                "applied": ["0001_init"],
+                "skipped": [],
+                "pending_skipped": [],
+                "errors": [],
+                "total_discovered": 1,
+            },
+        ) as mock_apply, patch("aksara.db.Database") as mock_db_cls:
+            mock_db = AsyncMock()
+            mock_db_cls.return_value = mock_db
+
+            await _apply_test_migrations("postgresql://localhost/test")
+
+            mock_apply.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_error_result_raises_runtime_error_with_pending_skipped(
+        self, tmp_path, monkeypatch
+    ):
+        from aksara.conf import settings
+        from aksara.testing import _apply_test_migrations
+
+        monkeypatch.setattr(settings, "migrations_dir", str(tmp_path / "migrations"),
+                            raising=False)
+
+        with patch(
+            "aksara.migrations.executor.apply_migrations",
+            new_callable=AsyncMock,
+            return_value={
+                "applied": [],
+                "skipped": [],
+                "pending_skipped": ["0002_add_field", "0003_add_index"],
+                "errors": [("0001_init", "syntax error near DROP")],
+                "total_discovered": 3,
+            },
+        ), patch("aksara.db.Database") as mock_db_cls:
+            mock_db = AsyncMock()
+            mock_db_cls.return_value = mock_db
+
+            with pytest.raises(RuntimeError) as exc_info:
+                await _apply_test_migrations("postgresql://localhost/test")
+
+        message = str(exc_info.value)
+        assert "0001_init" in message
+        assert "syntax error near DROP" in message
+        assert "0002_add_field" in message
+        assert "0003_add_index" in message
+
+    @pytest.mark.asyncio
     async def test_no_longer_calls_record_migration_directly(self, tmp_path, monkeypatch):
         """The testing helper must not bypass apply_migrations with its own record calls."""
         from aksara.conf import settings

--- a/tests/migrations/test_v0550_p2c_unification.py
+++ b/tests/migrations/test_v0550_p2c_unification.py
@@ -1,0 +1,397 @@
+"""
+v0.5.50 P2-C-lite: Migration Execution Path Unification — Regression Tests
+
+Covers:
+  1. CLI migrate delegates to executor.apply_migrations() — not a manual loop
+  2. CLI migrate output reflects the apply_migrations() result dict
+  3. CLI migrate exits non-zero on executor errors
+  4. CLI migrate shows pending_skipped after a failure
+  5. CLI migrate fake mode uses apply_migrations(fake=True)
+  6. testing._apply_test_migrations delegates to apply_migrations()
+  7. testing helper no longer records NULL checksums (uses canonical path)
+"""
+
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+from click.testing import CliRunner
+
+from aksara.cli.main import cli
+
+
+runner = CliRunner()
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+class _FakeDatabase:
+    async def connect(self) -> None: ...
+    async def disconnect(self) -> None: ...
+    async def execute(self, *a, **kw) -> None: ...
+
+
+def _apply_result(**overrides):
+    """Build a minimal apply_migrations() result dict."""
+    base = {
+        "applied": [],
+        "skipped": [],
+        "pending_skipped": [],
+        "errors": [],
+        "total_discovered": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+def _cli_patches(tmp_path, migration_path, *, apply_result):
+    """Return a list of patch contexts for a typical migrate invocation."""
+    return [
+        patch("aksara.db.Database", return_value=_FakeDatabase()),
+        patch("aksara.migrations.executor.discover_migrations",
+              return_value=[("0001_init", migration_path)]),
+        patch("aksara.migrations.executor.build_migration_graph",
+              return_value=MagicMock()),
+        patch("aksara.migrations.executor.ensure_migrations_table",
+              new_callable=AsyncMock),
+        patch("aksara.migrations.executor.get_applied_migrations",
+              new_callable=AsyncMock, return_value=[]),
+        patch("aksara.migrations.executor.check_migration_conflicts",
+              return_value=[]),
+        patch("aksara.migrations.executor.apply_migrations",
+              new_callable=AsyncMock, return_value=apply_result),
+    ]
+
+
+# =============================================================================
+# Task 1: CLI migrate delegates to apply_migrations()
+# =============================================================================
+
+class TestCLIMigrateDelegation:
+    def _run(self, tmp_path, *, apply_result, monkeypatch, extra_args=()):
+        from aksara.conf import settings
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        migration_path = migrations_dir / "0001_init.py"
+        migration_path.write_text("# migration")
+
+        monkeypatch.setattr(settings, "database_url", "postgresql://localhost/test",
+                            raising=False)
+        monkeypatch.setattr(settings, "migrations_dir", str(migrations_dir),
+                            raising=False)
+
+        patches = _cli_patches(tmp_path, migration_path, apply_result=apply_result)
+        # Stack all patches
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            mocks = [stack.enter_context(p) for p in patches]
+            apply_mock = mocks[-1]  # last patch is apply_migrations
+            result = runner.invoke(cli, ["migrate"] + list(extra_args))
+            return result, apply_mock
+
+    def test_apply_migrations_is_called(self, tmp_path, monkeypatch):
+        result, apply_mock = self._run(
+            tmp_path, apply_result=_apply_result(applied=["0001_init"]),
+            monkeypatch=monkeypatch,
+        )
+        assert result.exit_code == 0
+        apply_mock.assert_awaited_once()
+
+    def test_apply_migrations_receives_db_and_path(self, tmp_path, monkeypatch):
+        result, apply_mock = self._run(
+            tmp_path, apply_result=_apply_result(applied=["0001_init"]),
+            monkeypatch=monkeypatch,
+        )
+        assert apply_mock.await_count == 1
+        # Second positional arg is the migrations path
+        call_args = apply_mock.call_args
+        # apply_migrations(db, mig_dir, fake=..., verbose=..., include_internal=...)
+        assert call_args.kwargs.get("fake") is False
+        assert call_args.kwargs.get("include_internal") is True
+
+    def test_fake_flag_passed_through(self, tmp_path, monkeypatch):
+        result, apply_mock = self._run(
+            tmp_path,
+            apply_result=_apply_result(applied=["0001_init"]),
+            monkeypatch=monkeypatch,
+            extra_args=["--fake"],
+        )
+        assert apply_mock.await_count == 1
+        assert apply_mock.call_args.kwargs.get("fake") is True
+
+    def test_no_manual_op_apply_called(self, tmp_path, monkeypatch):
+        """The CLI must not call op.apply() directly — that lives inside apply_migrations."""
+        from contextlib import ExitStack
+        from aksara.conf import settings
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        migration_path = migrations_dir / "0001_init.py"
+        migration_path.write_text("# migration")
+
+        monkeypatch.setattr(settings, "database_url", "postgresql://localhost/test",
+                            raising=False)
+        monkeypatch.setattr(settings, "migrations_dir", str(migrations_dir),
+                            raising=False)
+
+        patches = _cli_patches(tmp_path, migration_path,
+                               apply_result=_apply_result(applied=["0001_init"]))
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            with patch("aksara.migrations.executor.load_migration_module") as mock_load:
+                runner.invoke(cli, ["migrate"])
+                # load_migration_module should NOT be called in the non-dry-run path
+                mock_load.assert_not_called()
+
+
+# =============================================================================
+# Task 2: CLI output reflects apply_migrations() result dict
+# =============================================================================
+
+class TestCLIMigrateOutput:
+    def _invoke(self, tmp_path, monkeypatch, apply_result, extra_args=()):
+        from aksara.conf import settings
+        from contextlib import ExitStack
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        migration_path = migrations_dir / "0001_init.py"
+        migration_path.write_text("# migration")
+
+        monkeypatch.setattr(settings, "database_url", "postgresql://localhost/test",
+                            raising=False)
+        monkeypatch.setattr(settings, "migrations_dir", str(migrations_dir),
+                            raising=False)
+        patches = _cli_patches(tmp_path, migration_path, apply_result=apply_result)
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            return runner.invoke(cli, ["migrate"] + list(extra_args))
+
+    def test_applied_names_shown(self, tmp_path, monkeypatch):
+        result = self._invoke(
+            tmp_path, monkeypatch,
+            apply_result=_apply_result(applied=["0001_init", "0002_add_field"]),
+        )
+        assert result.exit_code == 0
+        assert "0001_init" in result.output
+        assert "0002_add_field" in result.output
+
+    def test_all_applied_shows_success_message(self, tmp_path, monkeypatch):
+        result = self._invoke(
+            tmp_path, monkeypatch,
+            apply_result=_apply_result(applied=[], skipped=["0001_init"]),
+        )
+        assert result.exit_code == 0
+        assert "All migrations already applied!" in result.output
+
+    def test_fake_mode_output(self, tmp_path, monkeypatch):
+        result = self._invoke(
+            tmp_path, monkeypatch,
+            apply_result=_apply_result(applied=["0001_init"]),
+            extra_args=["--fake"],
+        )
+        assert result.exit_code == 0
+        assert "marked as applied" in result.output
+
+    def test_error_shown_in_output(self, tmp_path, monkeypatch):
+        result = self._invoke(
+            tmp_path, monkeypatch,
+            apply_result=_apply_result(
+                errors=[("0001_init", "syntax error near DROP")],
+            ),
+        )
+        assert result.exit_code != 0
+        assert "0001_init" in result.output
+        assert "syntax error" in result.output
+
+    def test_pending_skipped_shown_after_error(self, tmp_path, monkeypatch):
+        result = self._invoke(
+            tmp_path, monkeypatch,
+            apply_result=_apply_result(
+                errors=[("0001_init", "boom")],
+                pending_skipped=["0002_add_field", "0003_add_index"],
+            ),
+        )
+        assert result.exit_code != 0
+        assert "0002_add_field" in result.output
+        assert "0003_add_index" in result.output
+
+    def test_exit_nonzero_on_errors(self, tmp_path, monkeypatch):
+        result = self._invoke(
+            tmp_path, monkeypatch,
+            apply_result=_apply_result(
+                errors=[("0001_init", "table does not exist")],
+            ),
+        )
+        assert result.exit_code != 0
+
+    def test_exit_zero_on_success(self, tmp_path, monkeypatch):
+        result = self._invoke(
+            tmp_path, monkeypatch,
+            apply_result=_apply_result(applied=["0001_init"]),
+        )
+        assert result.exit_code == 0
+
+
+# =============================================================================
+# Task 3: Dry-run path uses load_migration_module, not apply_migrations
+# =============================================================================
+
+class TestCLIMigrateDryRun:
+    def test_dry_run_does_not_call_apply_migrations(self, tmp_path, monkeypatch):
+        from aksara.conf import settings
+        from contextlib import ExitStack
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        migration_path = migrations_dir / "0001_init.py"
+        migration_path.write_text("# migration")
+
+        monkeypatch.setattr(settings, "database_url", "postgresql://localhost/test",
+                            raising=False)
+        monkeypatch.setattr(settings, "migrations_dir", str(migrations_dir),
+                            raising=False)
+        patches = _cli_patches(tmp_path, migration_path,
+                               apply_result=_apply_result())
+        # Patch get_applied_migrations to return empty so dry-run shows pending
+        patches[4] = patch("aksara.migrations.executor.get_applied_migrations",
+                           new_callable=AsyncMock, return_value=[])
+        # Patch get_pending_migrations for the dry-run path
+        patches.append(
+            patch("aksara.migrations.executor.get_pending_migrations",
+                  return_value=[("0001_init", migration_path)])
+        )
+
+        with ExitStack() as stack:
+            mocks = [stack.enter_context(p) for p in patches]
+            apply_mock = mocks[6]  # apply_migrations
+            result = runner.invoke(cli, ["migrate", "--dry-run"])
+            apply_mock.assert_not_awaited()
+
+    def test_dry_run_shows_would_apply(self, tmp_path, monkeypatch):
+        from aksara.conf import settings
+        from contextlib import ExitStack
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        migration_path = migrations_dir / "0001_init.py"
+        migration_path.write_text("# migration")
+
+        monkeypatch.setattr(settings, "database_url", "postgresql://localhost/test",
+                            raising=False)
+        monkeypatch.setattr(settings, "migrations_dir", str(migrations_dir),
+                            raising=False)
+        patches = _cli_patches(tmp_path, migration_path, apply_result=_apply_result())
+        patches[4] = patch("aksara.migrations.executor.get_applied_migrations",
+                           new_callable=AsyncMock, return_value=[])
+        patches.append(
+            patch("aksara.migrations.executor.get_pending_migrations",
+                  return_value=[("0001_init", migration_path)])
+        )
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            with patch("aksara.migrations.executor.load_migration_module") as mock_load:
+                mock_mig = MagicMock()
+                mock_mig.operations = []
+                mock_load.return_value = type("M", (), {"operations": [], "__call__": lambda s: mock_mig})
+                result = runner.invoke(cli, ["migrate", "--dry-run"])
+        assert "DRY RUN" in result.output
+
+
+# =============================================================================
+# Task 4: testing._apply_test_migrations delegates to apply_migrations()
+# =============================================================================
+
+class TestApplyTestMigrationsDelegation:
+    @pytest.mark.asyncio
+    async def test_delegates_to_apply_migrations(self, tmp_path, monkeypatch):
+        from aksara.conf import settings
+        from aksara.testing import _apply_test_migrations
+
+        monkeypatch.setattr(settings, "migrations_dir", str(tmp_path / "migrations"),
+                            raising=False)
+
+        with patch("aksara.migrations.executor.apply_migrations",
+                   new_callable=AsyncMock) as mock_apply, \
+             patch("aksara.db.Database") as mock_db_cls:
+            mock_db = AsyncMock()
+            mock_db_cls.return_value = mock_db
+            mock_apply.return_value = {
+                "applied": [], "skipped": [], "pending_skipped": [],
+                "errors": [], "total_discovered": 0,
+            }
+
+            await _apply_test_migrations("postgresql://localhost/test")
+
+            mock_apply.assert_awaited_once()
+            call_kwargs = mock_apply.call_args.kwargs
+            assert call_kwargs.get("fake") is False
+            assert call_kwargs.get("include_internal") is True
+
+    @pytest.mark.asyncio
+    async def test_no_longer_calls_record_migration_directly(self, tmp_path, monkeypatch):
+        """The testing helper must not bypass apply_migrations with its own record calls."""
+        from aksara.conf import settings
+        from aksara.testing import _apply_test_migrations
+
+        monkeypatch.setattr(settings, "migrations_dir", str(tmp_path / "migrations"),
+                            raising=False)
+
+        with patch("aksara.migrations.executor.apply_migrations",
+                   new_callable=AsyncMock,
+                   return_value={"applied": [], "skipped": [], "pending_skipped": [],
+                                 "errors": [], "total_discovered": 0}), \
+             patch("aksara.db.Database") as mock_db_cls, \
+             patch("aksara.migrations.executor.record_migration",
+                   new_callable=AsyncMock) as mock_record:
+            mock_db = AsyncMock()
+            mock_db_cls.return_value = mock_db
+
+            await _apply_test_migrations("postgresql://localhost/test")
+
+            mock_record.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_db_connect_and_disconnect_called(self, tmp_path, monkeypatch):
+        from aksara.conf import settings
+        from aksara.testing import _apply_test_migrations
+
+        monkeypatch.setattr(settings, "migrations_dir", str(tmp_path / "migrations"),
+                            raising=False)
+
+        with patch("aksara.migrations.executor.apply_migrations",
+                   new_callable=AsyncMock,
+                   return_value={"applied": [], "skipped": [], "pending_skipped": [],
+                                 "errors": [], "total_discovered": 0}), \
+             patch("aksara.db.Database") as mock_db_cls:
+            mock_db = AsyncMock()
+            mock_db_cls.return_value = mock_db
+
+            await _apply_test_migrations("postgresql://localhost/test")
+
+            mock_db.connect.assert_awaited_once()
+            mock_db.disconnect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_called_even_if_apply_raises(self, tmp_path, monkeypatch):
+        from aksara.conf import settings
+        from aksara.testing import _apply_test_migrations
+
+        monkeypatch.setattr(settings, "migrations_dir", str(tmp_path / "migrations"),
+                            raising=False)
+
+        with patch("aksara.migrations.executor.apply_migrations",
+                   new_callable=AsyncMock,
+                   side_effect=RuntimeError("lock held")), \
+             patch("aksara.db.Database") as mock_db_cls:
+            mock_db = AsyncMock()
+            mock_db_cls.return_value = mock_db
+
+            with pytest.raises(RuntimeError):
+                await _apply_test_migrations("postgresql://localhost/test")
+
+            mock_db.disconnect.assert_awaited_once()

--- a/tests/migrations/test_v0550_safety.py
+++ b/tests/migrations/test_v0550_safety.py
@@ -210,6 +210,24 @@ class TestSplitSqlStatements:
         assert len(parts) == 1
         assert "--" not in parts[0]
 
+    def test_crlf_line_comments_split_correctly(self):
+        sql = "-- create table\r\nCREATE TABLE foo (id SERIAL);\r\n-- done\r\n"
+        parts = _split_sql_statements(sql)
+        assert parts == ["CREATE TABLE foo (id SERIAL)"]
+
+    def test_cr_only_line_comments_split_correctly(self):
+        sql = "-- create table\rCREATE TABLE foo (id SERIAL);\r-- done\r"
+        parts = _split_sql_statements(sql)
+        assert parts == ["CREATE TABLE foo (id SERIAL)"]
+
+    def test_cr_only_comment_does_not_drop_following_statement(self):
+        sql = "-- first\rCREATE TABLE a (id int);\rCREATE TABLE b (id int);"
+        parts = _split_sql_statements(sql)
+        assert parts == [
+            "CREATE TABLE a (id int)",
+            "CREATE TABLE b (id int)",
+        ]
+
     def test_blank_lines_ignored(self):
         sql = "\n\nCREATE TABLE foo (id SERIAL);\n\n"
         parts = _split_sql_statements(sql)
@@ -226,6 +244,11 @@ class TestSplitSqlStatements:
 
     def test_only_comments(self):
         sql = "-- nothing here\n-- still nothing\n"
+        parts = _split_sql_statements(sql)
+        assert parts == []
+
+    def test_only_comments_with_cr_only_returns_empty(self):
+        sql = "-- nothing here\r-- still nothing\r"
         parts = _split_sql_statements(sql)
         assert parts == []
 

--- a/tests/migrations/test_v0550_safety.py
+++ b/tests/migrations/test_v0550_safety.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch, call
 from aksara.migrations import operations as op
 from aksara.migrations.graph import MigrationGraph, MigrationNode
 from aksara.migrations.executor import (
+    _compute_file_checksum,
     _split_sql_statements,
     apply_migration,
     apply_migrations,
@@ -683,6 +684,7 @@ class TestMissingFromDiskWarning:
         internal_name = "aksara_internal_present"
         internal_file = tmp_path / f"{internal_name}.py"
         internal_file.write_text("# internal migration")
+        internal_checksum = _compute_file_checksum(internal_file)
         user_file = tmp_path / "0002_user.py"
         user_file.write_text("# user migration")
         graph = MagicMock()
@@ -692,11 +694,11 @@ class TestMissingFromDiskWarning:
         conn.fetchval = AsyncMock(return_value=True)
         conn.execute = AsyncMock()
 
-        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock) as ensure_mock, \
              patch(
                  "aksara.migrations.executor.get_applied_migration_records",
                  new_callable=AsyncMock,
-                 return_value={internal_name: "abc123"},
+                 return_value={internal_name: internal_checksum},
              ), \
              patch(
                  "aksara.migrations.executor.discover_all_migrations",
@@ -729,8 +731,10 @@ class TestMissingFromDiskWarning:
         ]
         assert missing_warnings == []
         assert result["applied"] == ["0002_user"]
+        ensure_mock.assert_awaited_once()
         assert apply_mock.await_count == 1
         assert apply_mock.await_args.args[1] == "0002_user"
+        assert apply_mock.await_args.kwargs["ensure_table"] is False
         assert discover_mock.call_args_list[0].kwargs["include_internal"] is False
         assert discover_mock.call_args_list[1].kwargs["include_internal"] is True
 

--- a/tests/migrations/test_v0550_safety.py
+++ b/tests/migrations/test_v0550_safety.py
@@ -66,7 +66,7 @@ class TestArrayCodegen:
         assert "op.ArrayField" in code, (
             "Array field must generate op.ArrayField, not op.TextField"
         )
-        assert "op.TextField" not in code or "op.ArrayField" in code
+        assert "op.TextField" not in code
         assert "TEXT[]" in code
 
     def test_array_int_maps_to_integer_array(self):

--- a/tests/migrations/test_v0550_safety.py
+++ b/tests/migrations/test_v0550_safety.py
@@ -235,6 +235,26 @@ class TestSplitSqlStatements:
         parts = _split_sql_statements(sql)
         assert len(parts) == 2
 
+    def test_unterminated_block_comment_raises(self):
+        sql = "CREATE TABLE a(id int); /* unterminated"
+        with pytest.raises(ValueError, match="Unterminated block comment in SQL migration"):
+            _split_sql_statements(sql)
+
+    def test_unterminated_single_quoted_string_raises(self):
+        sql = "INSERT INTO t (v) VALUES ('unterminated);"
+        with pytest.raises(ValueError, match="Unterminated single-quoted string in SQL migration"):
+            _split_sql_statements(sql)
+
+    def test_unterminated_double_quoted_identifier_raises(self):
+        sql = 'CREATE TABLE "unterminated (id int);'
+        with pytest.raises(ValueError, match="Unterminated double-quoted identifier in SQL migration"):
+            _split_sql_statements(sql)
+
+    def test_unterminated_dollar_quoted_block_raises(self):
+        sql = "CREATE FUNCTION f() RETURNS void AS $$ BEGIN NULL; END;"
+        with pytest.raises(ValueError, match="Unterminated dollar-quoted block in SQL migration"):
+            _split_sql_statements(sql)
+
     def test_semicolon_inside_single_quoted_string(self):
         sql = "INSERT INTO t (v) VALUES ('hello; world');"
         parts = _split_sql_statements(sql)
@@ -253,16 +273,35 @@ class TestSplitSqlStatements:
         parts = _split_sql_statements(sql)
         assert len(parts) == 1
 
+    def test_tagged_dollar_quoted_function_body_with_semicolons_is_one_statement(self):
+        sql = (
+            "CREATE FUNCTION f() RETURNS void AS $body$ "
+            "BEGIN PERFORM 1; PERFORM 2; END; $body$ LANGUAGE plpgsql;"
+        )
+        parts = _split_sql_statements(sql)
+        assert parts == [sql.rstrip(";")]
+
     def test_block_comment_with_semicolon_ignored(self):
         sql = "/* ignore this; */ CREATE TABLE x (id int);"
         parts = _split_sql_statements(sql)
         assert len(parts) == 1
         assert "ignore" not in parts[0]
 
+    def test_valid_block_comment_still_works(self):
+        sql = "CREATE TABLE x (id int) /* valid comment */;"
+        parts = _split_sql_statements(sql)
+        assert len(parts) == 1
+        assert parts[0].startswith("CREATE TABLE x (id int)")
+
     def test_block_comment_preserves_token_separator(self):
         sql = "SELECT/*x*/1;"
         parts = _split_sql_statements(sql)
         assert parts == ["SELECT 1"]
+
+    def test_block_comment_between_tokens_preserves_spacing(self):
+        sql = "SELECT/* comment */FROM dual;"
+        parts = _split_sql_statements(sql)
+        assert parts == ["SELECT FROM dual"]
 
     def test_block_comment_between_statements_splits_cleanly(self):
         sql = "CREATE TABLE a(id int); /* comment */ CREATE TABLE b(id int);"
@@ -501,6 +540,27 @@ class Migration(Migration):
         # record_migration called inside same transaction
         rm.assert_awaited_once()
         conn.transaction.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sql_migration_with_unterminated_block_comment_fails_before_record(self, tmp_path):
+        sql = "CREATE TABLE a(id int); /* unterminated"
+        f = tmp_path / "0001_init.sql"
+        f.write_text(sql)
+
+        conn, tx = self._make_connection()
+
+        with patch("aksara.migrations.executor.record_migration", new_callable=AsyncMock) as rm:
+            with pytest.raises(ValueError, match="Unterminated block comment in SQL migration"):
+                await apply_migration(conn, "0001_init", f, fake=False, verbose=False)
+
+        conn.transaction.assert_not_called()
+        migration_executes = [
+            call.args[0]
+            for call in conn.execute.await_args_list
+            if call.args and call.args[0].startswith("CREATE TABLE a")
+        ]
+        assert migration_executes == []
+        rm.assert_not_awaited()
 
 
 # =============================================================================

--- a/tests/migrations/test_v0550_safety.py
+++ b/tests/migrations/test_v0550_safety.py
@@ -182,8 +182,43 @@ class TestSplitSqlStatements:
 
     def test_only_comments(self):
         sql = "-- nothing here\n-- still nothing\n"
-        parts = _split_sql_statements("")
+        parts = _split_sql_statements(sql)
         assert parts == []
+
+    def test_inline_two_statements_same_line(self):
+        # Regression: old line-based splitter missed semicolons mid-line.
+        sql = "CREATE TABLE a (id int); CREATE TABLE b (id int);"
+        parts = _split_sql_statements(sql)
+        assert len(parts) == 2
+
+    def test_semicolon_inside_single_quoted_string(self):
+        sql = "INSERT INTO t (v) VALUES ('hello; world');"
+        parts = _split_sql_statements(sql)
+        assert len(parts) == 1
+
+    def test_semicolon_inside_double_quoted_identifier(self):
+        sql = 'CREATE TABLE "my;table" (id int);'
+        parts = _split_sql_statements(sql)
+        assert len(parts) == 1
+
+    def test_semicolon_inside_dollar_quoted_block(self):
+        sql = (
+            "CREATE FUNCTION f() RETURNS void AS $$ "
+            "BEGIN NULL; END; $$ LANGUAGE plpgsql;"
+        )
+        parts = _split_sql_statements(sql)
+        assert len(parts) == 1
+
+    def test_block_comment_with_semicolon_ignored(self):
+        sql = "/* ignore this; */ CREATE TABLE x (id int);"
+        parts = _split_sql_statements(sql)
+        assert len(parts) == 1
+        assert "ignore" not in parts[0]
+
+    def test_escaped_single_quote_in_string(self):
+        sql = "INSERT INTO t (v) VALUES ('it''s fine; ok');"
+        parts = _split_sql_statements(sql)
+        assert len(parts) == 1
 
 
 # =============================================================================
@@ -451,3 +486,66 @@ class TestAdvisoryLock:
         unlock_calls = [c for c in conn.execute.call_args_list
                         if "pg_advisory_unlock" in str(c)]
         assert unlock_calls, "pg_advisory_unlock must be called even when an error occurs"
+
+
+# =============================================================================
+# Missing-from-disk warning
+# =============================================================================
+
+class TestMissingFromDiskWarning:
+    @pytest.mark.asyncio
+    async def test_applied_migration_missing_from_disk_warns(self, tmp_path, caplog):
+        import logging
+
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=True)  # advisory lock acquired
+        conn.execute = AsyncMock()
+
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch(
+                 "aksara.migrations.executor.get_applied_migration_records",
+                 new_callable=AsyncMock,
+                 return_value={"0001_deleted": "abc123"},
+             ), \
+             patch("aksara.migrations.executor.discover_all_migrations", return_value=[]), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]), \
+             caplog.at_level(logging.WARNING, logger="aksara.migrations.executor"):
+            await apply_migrations(conn, tmp_path, verbose=True)
+
+        assert any(
+            "0001_deleted" in record.message
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+        ), "Expected a WARNING mentioning the missing migration name"
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_all_applied_are_on_disk(self, tmp_path, caplog):
+        import logging
+
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=True)
+        conn.execute = AsyncMock()
+
+        mig_file = tmp_path / "0001_present.py"
+        mig_file.write_text("# migration")
+
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch(
+                 "aksara.migrations.executor.get_applied_migration_records",
+                 new_callable=AsyncMock,
+                 # None = applied before checksums were introduced; verification skipped
+                 return_value={"0001_present": None},
+             ), \
+             patch(
+                 "aksara.migrations.executor.discover_all_migrations",
+                 return_value=[("0001_present", mig_file)],
+             ), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]), \
+             caplog.at_level(logging.WARNING, logger="aksara.migrations.executor"):
+            await apply_migrations(conn, tmp_path, verbose=True)
+
+        missing_warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "not found on disk" in r.message
+        ]
+        assert missing_warnings == [], "No missing-from-disk warnings expected"

--- a/tests/migrations/test_v0550_safety.py
+++ b/tests/migrations/test_v0550_safety.py
@@ -488,8 +488,15 @@ class Migration(Migration):
         with patch("aksara.migrations.executor.record_migration", new_callable=AsyncMock) as rm:
             await apply_migration(conn, "0001_init", f, fake=False, verbose=False)
 
-        # execute() must have been called twice — once per statement
-        assert conn.execute.await_count == 2
+        statement_calls = [
+            call.args[0]
+            for call in conn.execute.await_args_list
+            if call.args and call.args[0].startswith("CREATE TABLE ")
+        ]
+        assert statement_calls == [
+            "CREATE TABLE a (id SERIAL)",
+            "CREATE TABLE b (id SERIAL)",
+        ]
         # record_migration called inside same transaction
         rm.assert_awaited_once()
         conn.transaction.assert_called_once()
@@ -666,6 +673,131 @@ class TestMissingFromDiskWarning:
             for record in caplog.records
             if record.levelno == logging.WARNING
         ), "Expected a WARNING mentioning the missing migration name"
+
+    @pytest.mark.asyncio
+    async def test_include_internal_false_does_not_warn_for_present_internal_or_apply_it(
+        self, tmp_path, caplog
+    ):
+        import logging
+
+        internal_name = "aksara_internal_present"
+        internal_file = tmp_path / f"{internal_name}.py"
+        internal_file.write_text("# internal migration")
+        user_file = tmp_path / "0002_user.py"
+        user_file.write_text("# user migration")
+        graph = MagicMock()
+        graph.execution_order.return_value = [type("Node", (), {"name": "0002_user"})()]
+
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=True)
+        conn.execute = AsyncMock()
+
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch(
+                 "aksara.migrations.executor.get_applied_migration_records",
+                 new_callable=AsyncMock,
+                 return_value={internal_name: "abc123"},
+             ), \
+             patch(
+                 "aksara.migrations.executor.discover_all_migrations",
+                 side_effect=[
+                     [("0002_user", user_file)],
+                     [(internal_name, internal_file), ("0002_user", user_file)],
+                 ],
+             ) as discover_mock, \
+             patch(
+                 "aksara.migrations.executor.get_pending_migrations",
+                 return_value=[("0002_user", user_file)],
+             ), \
+             patch("aksara.migrations.executor.build_migration_graph", return_value=graph), \
+             patch(
+                 "aksara.migrations.executor.apply_migration",
+                 new_callable=AsyncMock,
+             ) as apply_mock, \
+             caplog.at_level(logging.WARNING, logger="aksara.migrations.executor"):
+            result = await apply_migrations(
+                conn,
+                tmp_path,
+                verbose=False,
+                include_internal=False,
+            )
+
+        missing_warnings = [
+            record.message
+            for record in caplog.records
+            if record.levelno == logging.WARNING and "not found on disk" in record.message
+        ]
+        assert missing_warnings == []
+        assert result["applied"] == ["0002_user"]
+        assert apply_mock.await_count == 1
+        assert apply_mock.await_args.args[1] == "0002_user"
+        assert discover_mock.call_args_list[0].kwargs["include_internal"] is False
+        assert discover_mock.call_args_list[1].kwargs["include_internal"] is True
+
+    @pytest.mark.asyncio
+    async def test_include_internal_false_still_warns_for_missing_user_migration(
+        self, tmp_path, caplog
+    ):
+        import logging
+
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=True)
+        conn.execute = AsyncMock()
+
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch(
+                 "aksara.migrations.executor.get_applied_migration_records",
+                 new_callable=AsyncMock,
+                 return_value={"0001_deleted": "abc123"},
+             ), \
+             patch(
+                 "aksara.migrations.executor.discover_all_migrations",
+                 side_effect=[[], []],
+             ) as discover_mock, \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]), \
+             caplog.at_level(logging.WARNING, logger="aksara.migrations.executor"):
+            await apply_migrations(conn, tmp_path, verbose=False, include_internal=False)
+
+        assert any(
+            "0001_deleted" in record.message and "not found on disk" in record.message
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+        )
+        assert discover_mock.call_args_list[0].kwargs["include_internal"] is False
+        assert discover_mock.call_args_list[1].kwargs["include_internal"] is True
+
+    @pytest.mark.asyncio
+    async def test_include_internal_false_warns_for_truly_missing_internal_migration(
+        self, tmp_path, caplog
+    ):
+        import logging
+
+        missing_internal = "aksara_internal_deleted"
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=True)
+        conn.execute = AsyncMock()
+
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch(
+                 "aksara.migrations.executor.get_applied_migration_records",
+                 new_callable=AsyncMock,
+                 return_value={missing_internal: "abc123"},
+             ), \
+             patch(
+                 "aksara.migrations.executor.discover_all_migrations",
+                 side_effect=[[], []],
+             ) as discover_mock, \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]), \
+             caplog.at_level(logging.WARNING, logger="aksara.migrations.executor"):
+            await apply_migrations(conn, tmp_path, verbose=False, include_internal=False)
+
+        assert any(
+            missing_internal in record.message and "not found on disk" in record.message
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+        )
+        assert discover_mock.call_args_list[0].kwargs["include_internal"] is False
+        assert discover_mock.call_args_list[1].kwargs["include_internal"] is True
 
     @pytest.mark.asyncio
     async def test_missing_from_disk_warning_uses_parameterized_delete(self, tmp_path, caplog):

--- a/tests/migrations/test_v0550_safety.py
+++ b/tests/migrations/test_v0550_safety.py
@@ -570,16 +570,22 @@ class Migration(Migration):
 class TestAdvisoryLock:
     @pytest.mark.asyncio
     async def test_advisory_lock_acquired_and_released(self, tmp_path):
+        import logging
+
         conn = AsyncMock()
-        # First fetchval = lock acquired (True), subsequent = empty list for applied
-        conn.fetchval = AsyncMock(side_effect=[True])
-        conn.fetch = AsyncMock(return_value=[])
-        conn.execute = AsyncMock()
+        conn.fetchval = AsyncMock(side_effect=[True, True])
 
         with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
-             patch("aksara.migrations.executor.get_applied_migrations", new_callable=AsyncMock, return_value=[]), \
+             patch(
+                 "aksara.migrations.executor.get_applied_migration_records",
+                 new_callable=AsyncMock,
+                 return_value={},
+             ), \
              patch("aksara.migrations.executor.discover_all_migrations", return_value=[]), \
-             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]):
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]), \
+             patch(
+                 "aksara.migrations.executor.logger.warning",
+             ) as warning_mock:
             await apply_migrations(conn, tmp_path, verbose=False)
 
         # Verify advisory lock was acquired
@@ -588,15 +594,15 @@ class TestAdvisoryLock:
         assert lock_calls, "pg_try_advisory_lock must be called"
 
         # Verify advisory lock was released in finally block
-        unlock_calls = [c for c in conn.execute.call_args_list
+        unlock_calls = [c for c in conn.fetchval.call_args_list
                         if "pg_advisory_unlock" in str(c)]
         assert unlock_calls, "pg_advisory_unlock must be called in finally"
+        warning_mock.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_lock_not_acquired_raises(self, tmp_path):
         conn = AsyncMock()
         conn.fetchval = AsyncMock(return_value=False)  # lock NOT acquired
-        conn.execute = AsyncMock()
 
         with pytest.raises(RuntimeError) as exc_info:
             await apply_migrations(conn, tmp_path, verbose=False)
@@ -610,8 +616,7 @@ class TestAdvisoryLock:
     @pytest.mark.asyncio
     async def test_lock_released_on_exception(self, tmp_path):
         conn = AsyncMock()
-        conn.fetchval = AsyncMock(return_value=True)  # lock acquired
-        conn.execute = AsyncMock()
+        conn.fetchval = AsyncMock(side_effect=[True, True])  # acquire then release
 
         with patch("aksara.migrations.executor.ensure_migrations_table",
                    new_callable=AsyncMock, side_effect=RuntimeError("db down")), \
@@ -619,17 +624,37 @@ class TestAdvisoryLock:
             await apply_migrations(conn, tmp_path, verbose=False)
 
         # Even though ensure_migrations_table raised, the lock must be released
-        unlock_calls = [c for c in conn.execute.call_args_list
+        unlock_calls = [c for c in conn.fetchval.call_args_list
                         if "pg_advisory_unlock" in str(c)]
         assert unlock_calls, "pg_advisory_unlock must be called even when an error occurs"
+
+    @pytest.mark.asyncio
+    async def test_unlock_false_logs_warning(self, tmp_path, caplog):
+        import logging
+
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(side_effect=[True, False])
+
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch(
+                 "aksara.migrations.executor.get_applied_migration_records",
+                 new_callable=AsyncMock,
+                 return_value={},
+             ), \
+             patch("aksara.migrations.executor.discover_all_migrations", return_value=[]), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]), \
+             caplog.at_level(logging.WARNING, logger="aksara.migrations.executor"):
+            result = await apply_migrations(conn, tmp_path, verbose=False)
+
+        assert result["errors"] == []
+        assert "could not be released by this session" in caplog.text
 
     @pytest.mark.asyncio
     async def test_unlock_failure_does_not_mask_original_error(self, tmp_path, caplog):
         import logging
 
         conn = AsyncMock()
-        conn.fetchval = AsyncMock(return_value=True)
-        conn.execute = AsyncMock(side_effect=RuntimeError("unlock failed"))
+        conn.fetchval = AsyncMock(side_effect=[True, RuntimeError("unlock failed")])
 
         with patch("aksara.migrations.executor.ensure_migrations_table",
                    new_callable=AsyncMock, side_effect=RuntimeError("primary failure")), \
@@ -645,8 +670,7 @@ class TestAdvisoryLock:
         import logging
 
         conn = AsyncMock()
-        conn.fetchval = AsyncMock(return_value=True)
-        conn.execute = AsyncMock(side_effect=RuntimeError("unlock failed"))
+        conn.fetchval = AsyncMock(side_effect=[True, RuntimeError("unlock failed")])
 
         with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
              patch(
@@ -661,7 +685,7 @@ class TestAdvisoryLock:
 
         assert result["errors"] == []
         assert "unlock failed" in caplog.text
-        unlock_calls = [c for c in conn.execute.call_args_list
+        unlock_calls = [c for c in conn.fetchval.call_args_list
                         if "pg_advisory_unlock" in str(c)]
         assert unlock_calls, "pg_advisory_unlock must still be attempted"
 
@@ -675,8 +699,7 @@ class TestAdvisoryLock:
         graph.execution_order.return_value = [type("Node", (), {"name": "0001_fail"})()]
 
         conn = AsyncMock()
-        conn.fetchval = AsyncMock(return_value=True)
-        conn.execute = AsyncMock(side_effect=RuntimeError("unlock failed"))
+        conn.fetchval = AsyncMock(side_effect=[True, RuntimeError("unlock failed")])
 
         with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
              patch(

--- a/tests/migrations/test_v0550_safety.py
+++ b/tests/migrations/test_v0550_safety.py
@@ -1,0 +1,446 @@
+"""
+v0.5.50 Migration-Safety Patch — Regression Tests
+
+Covers all 7 P0 fixes:
+  1+2. Per-migration transaction wrapping with record_migration inside
+  3.   Advisory lock in apply_migrations()
+  4.   Multi-statement SQL via _split_sql_statements()
+  5.   Cycle detection in execution_order()
+  6.   ArrayField present in operations.__all__
+  7.   model_to_create_table() Array codegen uses op.ArrayField, not op.TextField
+"""
+
+import os
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+from aksara.migrations import operations as op
+from aksara.migrations.graph import MigrationGraph, MigrationNode
+from aksara.migrations.executor import (
+    _split_sql_statements,
+    apply_migration,
+    apply_migrations,
+    model_to_create_table,
+)
+
+
+# =============================================================================
+# Fix 6: ArrayField in __all__
+# =============================================================================
+
+class TestArrayFieldInAll:
+    def test_array_field_in_all(self):
+        assert "ArrayField" in op.__all__, (
+            "ArrayField must be exported from operations.__all__ so that "
+            "'from aksara.migrations.operations import *' includes it"
+        )
+
+    def test_array_field_importable(self):
+        assert hasattr(op, "ArrayField")
+        assert issubclass(op.ArrayField, op.FieldOp)
+
+
+# =============================================================================
+# Fix 7: model_to_create_table() Array codegen
+# =============================================================================
+
+class TestArrayCodegen:
+    def _clear_registry(self):
+        from aksara.registry import ModelRegistry
+        ModelRegistry._models.clear()
+
+    def test_array_str_generates_array_field(self):
+        from aksara.model.base import Model
+        from aksara import fields
+        self._clear_registry()
+
+        class TaggedModel(Model):
+            id = fields.UUID(primary_key=True)
+            tags = fields.Array(item_type=str)
+
+        code = model_to_create_table(TaggedModel)
+        self._clear_registry()
+
+        assert "op.ArrayField" in code, (
+            "Array field must generate op.ArrayField, not op.TextField"
+        )
+        assert "op.TextField" not in code or "op.ArrayField" in code
+        assert "TEXT[]" in code
+
+    def test_array_int_maps_to_integer_array(self):
+        from aksara.model.base import Model
+        from aksara import fields
+        self._clear_registry()
+
+        class ScoreModel(Model):
+            id = fields.UUID(primary_key=True)
+            scores = fields.Array(item_type=int)
+
+        code = model_to_create_table(ScoreModel)
+        self._clear_registry()
+
+        assert "op.ArrayField" in code
+        assert "INTEGER[]" in code
+
+    def test_array_float_maps_to_double_precision_array(self):
+        from aksara.model.base import Model
+        from aksara import fields
+        self._clear_registry()
+
+        class MetricModel(Model):
+            id = fields.UUID(primary_key=True)
+            values = fields.Array(item_type=float)
+
+        code = model_to_create_table(MetricModel)
+        self._clear_registry()
+
+        assert "op.ArrayField" in code
+        assert "DOUBLE PRECISION[]" in code
+
+    def test_array_bool_maps_to_boolean_array(self):
+        from aksara.model.base import Model
+        from aksara import fields
+        self._clear_registry()
+
+        class FlagModel(Model):
+            id = fields.UUID(primary_key=True)
+            flags = fields.Array(item_type=bool)
+
+        code = model_to_create_table(FlagModel)
+        self._clear_registry()
+
+        assert "op.ArrayField" in code
+        assert "BOOLEAN[]" in code
+
+    def test_array_no_item_type_kwarg_in_generated_code(self):
+        """Generated code must not pass item_type= to ArrayField (invalid param)."""
+        from aksara.model.base import Model
+        from aksara import fields
+        self._clear_registry()
+
+        class M(Model):
+            id = fields.UUID(primary_key=True)
+            items = fields.Array(item_type=str)
+
+        code = model_to_create_table(M)
+        self._clear_registry()
+
+        assert "item_type=" not in code, (
+            "op.ArrayField has no item_type parameter; codegen must not emit it"
+        )
+
+
+# =============================================================================
+# Fix 4: _split_sql_statements()
+# =============================================================================
+
+class TestSplitSqlStatements:
+    def test_single_statement(self):
+        sql = "CREATE TABLE foo (id SERIAL);"
+        parts = _split_sql_statements(sql)
+        assert len(parts) == 1
+        assert "CREATE TABLE foo" in parts[0]
+
+    def test_two_statements(self):
+        sql = "CREATE TABLE a (id SERIAL);\nCREATE TABLE b (id SERIAL);"
+        parts = _split_sql_statements(sql)
+        assert len(parts) == 2
+
+    def test_three_statements(self):
+        sql = (
+            "CREATE TABLE x (id SERIAL);\n"
+            "CREATE TABLE y (id SERIAL);\n"
+            "CREATE TABLE z (id SERIAL);\n"
+        )
+        parts = _split_sql_statements(sql)
+        assert len(parts) == 3
+
+    def test_comments_stripped(self):
+        sql = (
+            "-- create table\n"
+            "CREATE TABLE foo (id SERIAL);\n"
+            "-- done\n"
+        )
+        parts = _split_sql_statements(sql)
+        assert len(parts) == 1
+        assert "--" not in parts[0]
+
+    def test_blank_lines_ignored(self):
+        sql = "\n\nCREATE TABLE foo (id SERIAL);\n\n"
+        parts = _split_sql_statements(sql)
+        assert len(parts) == 1
+
+    def test_no_trailing_semicolon(self):
+        sql = "CREATE TABLE foo (id SERIAL)"
+        parts = _split_sql_statements(sql)
+        assert len(parts) == 1
+
+    def test_empty_string(self):
+        parts = _split_sql_statements("")
+        assert parts == []
+
+    def test_only_comments(self):
+        sql = "-- nothing here\n-- still nothing\n"
+        parts = _split_sql_statements("")
+        assert parts == []
+
+
+# =============================================================================
+# Fix 5: Cycle detection in execution_order()
+# =============================================================================
+
+class TestCycleDetection:
+    def _graph_with_nodes(self, *node_specs):
+        """node_specs: list of (app, name, deps) tuples."""
+        g = MigrationGraph()
+        for app, name, deps in node_specs:
+            node = MigrationNode(app_label=app, name=name, dependencies=deps)
+            g.add_node(node)
+        return g
+
+    def test_linear_chain_no_cycle(self):
+        g = self._graph_with_nodes(
+            ("app", "0001", []),
+            ("app", "0002", [("app", "0001")]),
+            ("app", "0003", [("app", "0002")]),
+        )
+        order = g.execution_order()
+        names = [n.name for n in order]
+        assert names.index("0001") < names.index("0002")
+        assert names.index("0002") < names.index("0003")
+
+    def test_no_dependencies_no_cycle(self):
+        g = self._graph_with_nodes(
+            ("app", "0001", []),
+            ("app", "0002", []),
+        )
+        order = g.execution_order()
+        assert len(order) == 2
+
+    def test_direct_self_cycle_raises(self):
+        g = self._graph_with_nodes(
+            ("app", "0001", [("app", "0001")]),
+        )
+        with pytest.raises(ValueError, match="cycle"):
+            g.execution_order()
+
+    def test_two_node_cycle_raises(self):
+        g = self._graph_with_nodes(
+            ("app", "0001", [("app", "0002")]),
+            ("app", "0002", [("app", "0001")]),
+        )
+        with pytest.raises(ValueError, match="cycle"):
+            g.execution_order()
+
+    def test_three_node_cycle_raises(self):
+        g = self._graph_with_nodes(
+            ("app", "0001", [("app", "0003")]),
+            ("app", "0002", [("app", "0001")]),
+            ("app", "0003", [("app", "0002")]),
+        )
+        with pytest.raises(ValueError, match="cycle"):
+            g.execution_order()
+
+    def test_cycle_error_message_contains_migration_names(self):
+        g = self._graph_with_nodes(
+            ("app", "alpha", [("app", "beta")]),
+            ("app", "beta", [("app", "alpha")]),
+        )
+        with pytest.raises(ValueError) as exc_info:
+            g.execution_order()
+        msg = str(exc_info.value)
+        assert "alpha" in msg or "beta" in msg
+
+    def test_diamond_no_cycle(self):
+        g = self._graph_with_nodes(
+            ("app", "base", []),
+            ("app", "left", [("app", "base")]),
+            ("app", "right", [("app", "base")]),
+            ("app", "merge", [("app", "left"), ("app", "right")]),
+        )
+        order = g.execution_order()
+        names = [n.name for n in order]
+        assert names.index("base") < names.index("left")
+        assert names.index("base") < names.index("right")
+        assert names.index("left") < names.index("merge")
+        assert names.index("right") < names.index("merge")
+
+
+# =============================================================================
+# Fix 1+2: Transaction wrapping + record_migration inside transaction
+# =============================================================================
+
+class TestApplyMigrationTransactionWrapping:
+    """Unit tests using mocks — no real DB needed."""
+
+    def _make_connection(self):
+        conn = AsyncMock()
+        # connection.transaction() must return an async context manager
+        tx = AsyncMock()
+        tx.__aenter__ = AsyncMock(return_value=tx)
+        tx.__aexit__ = AsyncMock(return_value=False)
+        conn.transaction = MagicMock(return_value=tx)
+        conn.execute = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=None)
+        return conn, tx
+
+    @pytest.mark.asyncio
+    async def test_py_migration_uses_transaction(self, tmp_path):
+        migration_code = '''
+from aksara.migrations.base import Migration
+from aksara.migrations import operations as op
+
+class Migration(Migration):
+    operations = [
+        op.CreateTable(
+            name="t",
+            fields=[("id", op.UUIDField(primary_key=True))],
+        ),
+    ]
+'''
+        f = tmp_path / "0001_init.py"
+        f.write_text(migration_code)
+
+        conn, tx = self._make_connection()
+
+        op_mock = AsyncMock()
+        op_mock.describe = MagicMock(return_value="CreateTable t")
+
+        with patch("aksara.migrations.executor.load_migration_module") as lm, \
+             patch("aksara.migrations.executor.record_migration", new_callable=AsyncMock) as rm:
+            mock_mig = MagicMock()
+            mock_mig.return_value.operations = [op_mock]
+            lm.return_value = mock_mig
+
+            await apply_migration(conn, "0001_init", f, fake=False, verbose=False)
+
+        # transaction() must have been called once
+        conn.transaction.assert_called_once()
+        # op and record_migration must have been called inside __aenter__ context
+        op_mock.apply.assert_awaited_once()
+        rm.assert_awaited_once_with(conn, "0001_init")
+
+    @pytest.mark.asyncio
+    async def test_py_migration_fake_no_transaction_no_ops(self, tmp_path):
+        f = tmp_path / "0001_init.py"
+        f.write_text("")
+
+        conn, tx = self._make_connection()
+        op_mock = AsyncMock()
+        op_mock.describe = MagicMock(return_value="CreateTable t")
+
+        with patch("aksara.migrations.executor.load_migration_module") as lm, \
+             patch("aksara.migrations.executor.record_migration", new_callable=AsyncMock) as rm:
+            mock_mig = MagicMock()
+            mock_mig.return_value.operations = [op_mock]
+            lm.return_value = mock_mig
+
+            await apply_migration(conn, "0001_init", f, fake=True, verbose=False)
+
+        # No transaction when fake=True
+        conn.transaction.assert_not_called()
+        # No ops run
+        op_mock.apply.assert_not_awaited()
+        # But record_migration is still called
+        rm.assert_awaited_once_with(conn, "0001_init")
+
+    @pytest.mark.asyncio
+    async def test_py_migration_op_failure_rolls_back(self, tmp_path):
+        """If an op raises, the transaction rolls back and record_migration is NOT called."""
+        f = tmp_path / "0001_init.py"
+        f.write_text("")
+
+        conn = AsyncMock()
+        tx = AsyncMock()
+        tx.__aenter__ = AsyncMock(return_value=tx)
+        tx.__aexit__ = AsyncMock(return_value=False)
+        conn.transaction = MagicMock(return_value=tx)
+
+        exploding_op = AsyncMock()
+        exploding_op.apply.side_effect = RuntimeError("boom")
+        exploding_op.describe = MagicMock(return_value="BrokenOp")
+
+        with patch("aksara.migrations.executor.load_migration_module") as lm, \
+             patch("aksara.migrations.executor.record_migration", new_callable=AsyncMock) as rm:
+            mock_mig = MagicMock()
+            mock_mig.return_value.operations = [exploding_op]
+            lm.return_value = mock_mig
+
+            with pytest.raises(RuntimeError, match="boom"):
+                await apply_migration(conn, "0001_init", f, fake=False, verbose=False)
+
+        # record_migration must NOT have been called (it's inside the transaction which rolled back)
+        rm.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sql_migration_splits_statements(self, tmp_path):
+        sql = "CREATE TABLE a (id SERIAL);\nCREATE TABLE b (id SERIAL);"
+        f = tmp_path / "0001_init.sql"
+        f.write_text(sql)
+
+        conn, tx = self._make_connection()
+
+        with patch("aksara.migrations.executor.record_migration", new_callable=AsyncMock) as rm:
+            await apply_migration(conn, "0001_init", f, fake=False, verbose=False)
+
+        # execute() must have been called twice — once per statement
+        assert conn.execute.await_count == 2
+        # record_migration called inside same transaction
+        rm.assert_awaited_once()
+        conn.transaction.assert_called_once()
+
+
+# =============================================================================
+# Fix 3: Advisory lock in apply_migrations()
+# =============================================================================
+
+class TestAdvisoryLock:
+    @pytest.mark.asyncio
+    async def test_advisory_lock_acquired_and_released(self, tmp_path):
+        conn = AsyncMock()
+        # First fetchval = lock acquired (True), subsequent = empty list for applied
+        conn.fetchval = AsyncMock(side_effect=[True])
+        conn.fetch = AsyncMock(return_value=[])
+        conn.execute = AsyncMock()
+
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch("aksara.migrations.executor.get_applied_migrations", new_callable=AsyncMock, return_value=[]), \
+             patch("aksara.migrations.executor.discover_all_migrations", return_value=[]), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]):
+            await apply_migrations(conn, tmp_path, verbose=False)
+
+        # Verify advisory lock was acquired
+        lock_calls = [c for c in conn.fetchval.call_args_list
+                      if "pg_try_advisory_lock" in str(c)]
+        assert lock_calls, "pg_try_advisory_lock must be called"
+
+        # Verify advisory lock was released in finally block
+        unlock_calls = [c for c in conn.execute.call_args_list
+                        if "pg_advisory_unlock" in str(c)]
+        assert unlock_calls, "pg_advisory_unlock must be called in finally"
+
+    @pytest.mark.asyncio
+    async def test_lock_not_acquired_raises(self, tmp_path):
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=False)  # lock NOT acquired
+        conn.execute = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="advisory lock"):
+            await apply_migrations(conn, tmp_path, verbose=False)
+
+    @pytest.mark.asyncio
+    async def test_lock_released_on_exception(self, tmp_path):
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=True)  # lock acquired
+        conn.execute = AsyncMock()
+
+        with patch("aksara.migrations.executor.ensure_migrations_table",
+                   new_callable=AsyncMock, side_effect=RuntimeError("db down")), \
+             pytest.raises(RuntimeError, match="db down"):
+            await apply_migrations(conn, tmp_path, verbose=False)
+
+        # Even though ensure_migrations_table raised, the lock must be released
+        unlock_calls = [c for c in conn.execute.call_args_list
+                        if "pg_advisory_unlock" in str(c)]
+        assert unlock_calls, "pg_advisory_unlock must be called even when an error occurs"

--- a/tests/migrations/test_v0550_safety.py
+++ b/tests/migrations/test_v0550_safety.py
@@ -549,6 +549,87 @@ class TestAdvisoryLock:
                         if "pg_advisory_unlock" in str(c)]
         assert unlock_calls, "pg_advisory_unlock must be called even when an error occurs"
 
+    @pytest.mark.asyncio
+    async def test_unlock_failure_does_not_mask_original_error(self, tmp_path, caplog):
+        import logging
+
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=True)
+        conn.execute = AsyncMock(side_effect=RuntimeError("unlock failed"))
+
+        with patch("aksara.migrations.executor.ensure_migrations_table",
+                   new_callable=AsyncMock, side_effect=RuntimeError("primary failure")), \
+             caplog.at_level(logging.WARNING, logger="aksara.migrations.executor"), \
+             pytest.raises(RuntimeError, match="primary failure"):
+            await apply_migrations(conn, tmp_path, verbose=False)
+
+        assert "unlock failed" in caplog.text
+        assert "Failed to release migration advisory lock" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_unlock_failure_logged_on_success_path(self, tmp_path, caplog):
+        import logging
+
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=True)
+        conn.execute = AsyncMock(side_effect=RuntimeError("unlock failed"))
+
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch(
+                 "aksara.migrations.executor.get_applied_migration_records",
+                 new_callable=AsyncMock,
+                 return_value={},
+             ), \
+             patch("aksara.migrations.executor.discover_all_migrations", return_value=[]), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]), \
+             caplog.at_level(logging.WARNING, logger="aksara.migrations.executor"):
+            result = await apply_migrations(conn, tmp_path, verbose=False)
+
+        assert result["errors"] == []
+        assert "unlock failed" in caplog.text
+        unlock_calls = [c for c in conn.execute.call_args_list
+                        if "pg_advisory_unlock" in str(c)]
+        assert unlock_calls, "pg_advisory_unlock must still be attempted"
+
+    @pytest.mark.asyncio
+    async def test_unlock_failure_preserves_migration_result_error(self, tmp_path, caplog):
+        import logging
+
+        migration_path = tmp_path / "0001_fail.py"
+        migration_path.write_text("# migration")
+        graph = MagicMock()
+        graph.execution_order.return_value = [type("Node", (), {"name": "0001_fail"})()]
+
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=True)
+        conn.execute = AsyncMock(side_effect=RuntimeError("unlock failed"))
+
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch(
+                 "aksara.migrations.executor.get_applied_migration_records",
+                 new_callable=AsyncMock,
+                 return_value={},
+             ), \
+             patch(
+                 "aksara.migrations.executor.discover_all_migrations",
+                 return_value=[("0001_fail", migration_path)],
+             ), \
+             patch(
+                 "aksara.migrations.executor.get_pending_migrations",
+                 return_value=[("0001_fail", migration_path)],
+             ), \
+             patch("aksara.migrations.executor.build_migration_graph", return_value=graph), \
+             patch(
+                 "aksara.migrations.executor.apply_migration",
+                 new_callable=AsyncMock,
+                 side_effect=RuntimeError("migration failed"),
+             ), \
+             caplog.at_level(logging.WARNING, logger="aksara.migrations.executor"):
+            result = await apply_migrations(conn, tmp_path, verbose=False)
+
+        assert result["errors"] == [("0001_fail", "migration failed")]
+        assert "unlock failed" in caplog.text
+
 
 # =============================================================================
 # Missing-from-disk warning
@@ -579,6 +660,35 @@ class TestMissingFromDiskWarning:
             for record in caplog.records
             if record.levelno == logging.WARNING
         ), "Expected a WARNING mentioning the missing migration name"
+
+    @pytest.mark.asyncio
+    async def test_missing_from_disk_warning_uses_parameterized_delete(self, tmp_path, caplog):
+        import logging
+
+        missing_name = "0001_o'hai"
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=True)
+        conn.execute = AsyncMock()
+
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch(
+                 "aksara.migrations.executor.get_applied_migration_records",
+                 new_callable=AsyncMock,
+                 return_value={missing_name: "abc123"},
+             ), \
+             patch("aksara.migrations.executor.discover_all_migrations", return_value=[]), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]), \
+             caplog.at_level(logging.WARNING, logger="aksara.migrations.executor"):
+            await apply_migrations(conn, tmp_path, verbose=True)
+
+        warning = next(
+            record.message
+            for record in caplog.records
+            if record.levelno == logging.WARNING and "not found on disk" in record.message
+        )
+        assert "DELETE FROM aksara_migrations WHERE name = $1;" in warning
+        assert f"WHERE name = '{missing_name}'" not in warning
+        assert missing_name in warning
 
     @pytest.mark.asyncio
     async def test_no_warning_when_all_applied_are_on_disk(self, tmp_path, caplog):

--- a/tests/migrations/test_v0550_safety.py
+++ b/tests/migrations/test_v0550_safety.py
@@ -530,8 +530,14 @@ class TestAdvisoryLock:
         conn.fetchval = AsyncMock(return_value=False)  # lock NOT acquired
         conn.execute = AsyncMock()
 
-        with pytest.raises(RuntimeError, match="advisory lock"):
+        with pytest.raises(RuntimeError) as exc_info:
             await apply_migrations(conn, tmp_path, verbose=False)
+
+        message = str(exc_info.value)
+        assert "Another migration process" in message
+        assert "Wait for that process to finish" in message
+        assert "pg_locks/pg_stat_activity" in message
+        assert "pg_advisory_unlock" not in message
 
     @pytest.mark.asyncio
     async def test_lock_released_on_exception(self, tmp_path):

--- a/tests/migrations/test_v0550_safety.py
+++ b/tests/migrations/test_v0550_safety.py
@@ -130,6 +130,49 @@ class TestArrayCodegen:
             "op.ArrayField has no item_type parameter; codegen must not emit it"
         )
 
+    def test_array_nullable_false_is_emitted(self):
+        from aksara.model.base import Model
+        from aksara import fields
+        self._clear_registry()
+
+        class RequiredTagsModel(Model):
+            id = fields.UUID(primary_key=True)
+            tags = fields.Array(item_type=str, nullable=False)
+
+        code = model_to_create_table(RequiredTagsModel)
+        self._clear_registry()
+
+        assert "op.ArrayField(sql_type='TEXT[]', nullable=False)" in code
+
+    def test_array_nullable_true_uses_default_codegen(self):
+        from aksara.model.base import Model
+        from aksara import fields
+        self._clear_registry()
+
+        class OptionalTagsModel(Model):
+            id = fields.UUID(primary_key=True)
+            tags = fields.Array(item_type=str, nullable=True)
+
+        code = model_to_create_table(OptionalTagsModel)
+        self._clear_registry()
+
+        assert "op.ArrayField(sql_type='TEXT[]')" in code
+        assert "nullable=True" not in code
+
+    def test_array_non_callable_default_is_preserved(self):
+        from aksara.model.base import Model
+        from aksara import fields
+        self._clear_registry()
+
+        class DefaultTagsModel(Model):
+            id = fields.UUID(primary_key=True)
+            tags = fields.Array(item_type=str, default=["alpha", "beta"])
+
+        code = model_to_create_table(DefaultTagsModel)
+        self._clear_registry()
+
+        assert "default=['alpha', 'beta']" in code
+
 
 # =============================================================================
 # Fix 4: _split_sql_statements()
@@ -214,6 +257,25 @@ class TestSplitSqlStatements:
         parts = _split_sql_statements(sql)
         assert len(parts) == 1
         assert "ignore" not in parts[0]
+
+    def test_block_comment_preserves_token_separator(self):
+        sql = "SELECT/*x*/1;"
+        parts = _split_sql_statements(sql)
+        assert parts == ["SELECT 1"]
+
+    def test_block_comment_between_statements_splits_cleanly(self):
+        sql = "CREATE TABLE a(id int); /* comment */ CREATE TABLE b(id int);"
+        parts = _split_sql_statements(sql)
+        assert parts == [
+            "CREATE TABLE a(id int)",
+            "CREATE TABLE b(id int)",
+        ]
+
+    def test_block_comment_inside_quoted_string_is_preserved(self):
+        sql = "INSERT INTO t (v) VALUES ('keep /* not a comment */ text');"
+        parts = _split_sql_statements(sql)
+        assert len(parts) == 1
+        assert "/* not a comment */" in parts[0]
 
     def test_escaped_single_quote_in_string(self):
         sql = "INSERT INTO t (v) VALUES ('it''s fine; ok');"

--- a/tests/migrations/test_v0550_safety.py
+++ b/tests/migrations/test_v0550_safety.py
@@ -750,13 +750,16 @@ class TestMissingFromDiskWarning:
              patch("aksara.migrations.executor.discover_all_migrations", return_value=[]), \
              patch("aksara.migrations.executor.get_pending_migrations", return_value=[]), \
              caplog.at_level(logging.WARNING, logger="aksara.migrations.executor"):
-            await apply_migrations(conn, tmp_path, verbose=True)
+            result = await apply_migrations(conn, tmp_path, verbose=True)
 
         assert any(
             "0001_deleted" in record.message
             for record in caplog.records
             if record.levelno == logging.WARNING
         ), "Expected a WARNING mentioning the missing migration name"
+        assert result["skipped"] == []
+        assert result["total_discovered"] == 0
+        assert len(result["skipped"]) <= result["total_discovered"]
 
     @pytest.mark.asyncio
     async def test_include_internal_false_does_not_warn_for_present_internal_or_apply_it(
@@ -814,12 +817,44 @@ class TestMissingFromDiskWarning:
         ]
         assert missing_warnings == []
         assert result["applied"] == ["0002_user"]
+        assert result["skipped"] == []
+        assert result["total_discovered"] == 1
+        assert len(result["skipped"]) <= result["total_discovered"]
         ensure_mock.assert_awaited_once()
         assert apply_mock.await_count == 1
         assert apply_mock.await_args.args[1] == "0002_user"
         assert apply_mock.await_args.kwargs["ensure_table"] is False
         assert discover_mock.call_args_list[0].kwargs["include_internal"] is False
         assert discover_mock.call_args_list[1].kwargs["include_internal"] is True
+
+    @pytest.mark.asyncio
+    async def test_discovered_applied_user_migration_is_included_in_skipped_only_once(
+        self, tmp_path
+    ):
+        user_name = "0001_present"
+        user_file = tmp_path / f"{user_name}.py"
+        user_file.write_text("# migration")
+
+        conn = AsyncMock()
+        conn.fetchval = AsyncMock(return_value=True)
+        conn.execute = AsyncMock()
+
+        with patch("aksara.migrations.executor.ensure_migrations_table", new_callable=AsyncMock), \
+             patch(
+                 "aksara.migrations.executor.get_applied_migration_records",
+                 new_callable=AsyncMock,
+                 return_value={user_name: _compute_file_checksum(user_file), "0001_deleted": "abc123"},
+             ), \
+             patch(
+                 "aksara.migrations.executor.discover_all_migrations",
+                 return_value=[(user_name, user_file)],
+             ), \
+             patch("aksara.migrations.executor.get_pending_migrations", return_value=[]):
+            result = await apply_migrations(conn, tmp_path, verbose=False)
+
+        assert result["skipped"] == [user_name]
+        assert result["total_discovered"] == 1
+        assert len(result["skipped"]) <= result["total_discovered"]
 
     @pytest.mark.asyncio
     async def test_include_internal_false_still_warns_for_missing_user_migration(

--- a/tests/migrations/test_v0550_safety.py
+++ b/tests/migrations/test_v0550_safety.py
@@ -319,7 +319,11 @@ class Migration(Migration):
         conn.transaction.assert_called_once()
         # op and record_migration must have been called inside __aenter__ context
         op_mock.apply.assert_awaited_once()
-        rm.assert_awaited_once_with(conn, "0001_init")
+        rm.assert_awaited_once()
+        call_args = rm.call_args.args
+        assert call_args[0] is conn
+        assert call_args[1] == "0001_init"
+        assert call_args[2] is not None  # checksum stored for Python migrations
 
     @pytest.mark.asyncio
     async def test_py_migration_fake_no_transaction_no_ops(self, tmp_path):
@@ -342,8 +346,11 @@ class Migration(Migration):
         conn.transaction.assert_not_called()
         # No ops run
         op_mock.apply.assert_not_awaited()
-        # But record_migration is still called
-        rm.assert_awaited_once_with(conn, "0001_init")
+        # But record_migration is still called (with checksum)
+        rm.assert_awaited_once()
+        call_args = rm.call_args.args
+        assert call_args[0] is conn
+        assert call_args[1] == "0001_init"
 
     @pytest.mark.asyncio
     async def test_py_migration_op_failure_rolls_back(self, tmp_path):

--- a/tests/test_v048_docs_lock.py
+++ b/tests/test_v048_docs_lock.py
@@ -55,9 +55,10 @@ def test_readme_mentions_launch_path(fragment):
     [
         "v0.5.49 - Security Hardening & Release Trust",
         "v0.5.48 - Launch Hardening & Golden Path",
-        "v0.5.50 - Durable AI Session Store",
-        "v0.5.51 - AI Memory Foundation",
-        "v0.5.52 - AI System Radar",
+        "v0.5.50 - Migration Safety & Correctness",
+        "v0.5.51 - Durable AI Session Store",
+        "v0.5.52 - AI Memory Foundation",
+        "v0.5.53 - AI System Radar",
         "v0.6.0 - Production Mode",
     ],
 )


### PR DESCRIPTION
## Summary

This PR prepares the unreleased `v0.5.50` migration-safety patch.

It strengthens Aksara’s migration system by making migration execution atomic, guarded against concurrent runners, checksum-verified, clearer on failures, and consistent across the CLI, executor, and testing helper paths.

This PR does **not** introduce migration metadata schema versioning, checksum backfill, or an `app_label` / `name` identity split. Those are intentionally deferred to a later design pass.

---

## What changed

### Migration execution safety

- Python migrations now run inside a single transaction.
- `record_migration()` now happens inside the same transaction as migration operations.
- SQL migration files are split and executed statement-by-statement inside a transaction.
- Migration application now uses a PostgreSQL advisory lock to prevent concurrent runners.
- Migration graph execution now detects circular dependencies instead of silently producing an invalid order.

### Migration integrity

- Python migration files now store checksums when applied.
- Already-applied migrations are verified against their stored checksums before pending migrations run.
- Historical rows with `NULL` checksums remain backward-compatible and warn instead of failing.
- Generated migrations now warn when adding a non-null field without a default.

### Failure reporting

- Migration graph loading now fails clearly on broken migration files by default.
- `apply_migrations()` now reports `pending_skipped` migrations when a failure stops the run.
- CLI migration output now shows pending migrations skipped after a failure.

### SQL-generation guardrails

- ManyToMany migration constraint names are now quoted and length-bounded.
- Long generated constraint names receive deterministic hash suffixes.
- ManyToMany source and target column references are quoted.
- `IndexOp.where` now rejects obvious unsafe SQL patterns such as semicolons, comments, and DDL/DML keywords.
- `ArrayField.sql_type` is now validated and normalized to supported PostgreSQL array types.

### Unified execution path

- `aksara migrate` now uses the canonical migration executor path.
- Migration testing helpers now use the canonical executor path.
- CLI and testing paths now benefit from transactions, advisory locks, SQL splitting, checksum recording, and checksum verification.

### Documentation

- Added user-facing migration safety documentation.
- Updated README, CLI docs, ORM migration docs, roadmap, release docs, and changelog.
- Public docs describe final product behavior, not internal implementation phases.
- Deferred migration metadata work is clearly documented.

---

## Validation

Local validation completed with the branch state:

- DB-backed full suite: `7444 passed, 4 skipped`
- Migration suite: green
- Security tests: green
- Diagnostics tests: green
- MkDocs strict build: passed
- Wheel build: passed
- Twine check: passed
- `git diff --check`: clean

---

## Compatibility notes

- `ArrayField(sql_type="text[]")` now normalizes to `"TEXT[]"`.
- Custom PostgreSQL array base types not on the allowlist may now raise `ValueError`.
- Existing migration rows with `NULL` checksums continue to work, but Aksara may warn that the historical checksum is unavailable.
- Migration metadata schema versioning, app-label identity split, checksum backfill, and migration verification commands are intentionally deferred.

---

## Explicitly deferred

This PR does **not** add:

- `aksara_migrations` schema versioning
- `app_label` / `name` migration identity split
- automatic checksum backfill
- migration metadata v2
- migration verify/backfill command

These require a broader metadata design and are deferred to avoid unsafe automatic backfill behavior.