### PR TITLE
fix(orm): harden primitive field coercion

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: Bug Report
+description: Report a problem with Aksara
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please do **not** use
+        this form for security issues — follow [SECURITY.md](../../blob/main/SECURITY.md) instead.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps or code that trigger the problem.
+      placeholder: |
+        1. Define a model with ...
+        2. Run `aksara ...`
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include the full traceback if there is one.
+    validations:
+      required: true
+  - type: input
+    id: aksara-version
+    attributes:
+      label: Aksara Version
+      description: Output of `aksara --version`.
+      placeholder: "0.5.50"
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python Version
+      placeholder: "3.11"
+    validations:
+      required: true
+  - type: input
+    id: postgres-version
+    attributes:
+      label: PostgreSQL Version
+      placeholder: "15"
+    validations:
+      required: false
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      placeholder: "macOS 15 / Ubuntu 24.04"
+    validations:
+      required: false
+  - type: textarea
+    id: doctor
+    attributes:
+      label: Diagnostics
+      description: If applicable, paste the output of `aksara doctor launch-check --format json`.
+      render: json
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/nagarjuna-tella/Aksara/security/advisories/new
+    about: Report security issues privately. Do not open a public issue.
+  - name: Documentation
+    url: https://nagarjuna-tella.github.io/Aksara/
+    about: Read the Aksara documentation before filing an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature Request
+description: Suggest an idea or enhancement for Aksara
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Describing the underlying problem
+        helps us evaluate the best solution — which may differ from the one you
+        have in mind.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? What's painful today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution
+      description: What would you like Aksara to do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Other approaches or workarounds you've tried or thought about.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Examples, links, or anything else that helps explain the request.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Related Issue
+
+<!-- Link the issue this addresses, e.g. "Closes #123". Open one first if it doesn't exist. -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactor / internal change
+- [ ] Other
+
+## Checklist
+
+- [ ] Tests added or updated, and `pytest` passes
+- [ ] `black`, `ruff`, and `mypy` pass
+- [ ] Docs updated where relevant (`docs/docs/`)
+- [ ] `CHANGELOG.md` updated for user-facing changes
+- [ ] No secrets, credentials, or private security details included
+
+## Notes for Reviewers
+
+<!-- Anything reviewers should focus on, trade-offs, or follow-ups. -->

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ opsdesk/
 security/security_matrix.yml
 
 .claude/
+
+orm-audit/

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ __pycache__/
 !.github/workflows/
 !.github/workflows/*.yml
 !.github/dependabot.yml
+!.github/ISSUE_TEMPLATE/
+!.github/PULL_REQUEST_TEMPLATE.md
 
 *.tape
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## Unreleased v0.5.51 — ORM Primitive Correctness
+
+### Fixed
+
+- Integer-family fields now reject non-integral numeric inputs instead of
+  truncating them with `int(value)`.
+- Integer-family fields mapped to PostgreSQL `INTEGER`, `SMALLINT`, and `BIGINT`
+  now validate database range boundaries before persistence.
+- Boolean fields now parse strict true/false forms instead of applying
+  `bool(value)` to arbitrary strings.
+- Decimal fields now enforce `max_digits` and `decimal_places` before
+  persistence and do not rely on PostgreSQL rounding.
+- Float fields now reject `NaN`, positive infinity, and negative infinity.
+- Email validation now rejects local parts that start with a dot, end with a
+  dot, or contain consecutive dots.
+
+### Known Remaining ORM Correctness Work
+
+- `NULL` filtering and `__isnull` query semantics.
+- FK alias filtering and reverse FK filters.
+- `bulk_create`/write-path consistency.
+- Relation DDL safety.
+- Array/vector/file advanced field policy.
+
+---
+
 ## v0.5.50 — Migration Safety & Correctness
 
 File-based migrations now apply safely and consistently across the CLI and test

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+# Code of Conduct
+
+## Our Commitment
+
+The Aksara community is dedicated to providing a welcoming, respectful, and
+harassment-free experience for everyone who participates, regardless of
+background or experience level.
+
+## Expected Behavior
+
+- Be respectful and considerate in all interactions.
+- Welcome differing viewpoints and give constructive feedback gracefully.
+- Focus on what is best for the community and the project.
+- Show empathy toward other community members.
+
+## Unacceptable Behavior
+
+- Harassment, insults, or derogatory comments.
+- Personal or political attacks.
+- Publishing others' private information without permission.
+- Any conduct that would reasonably be considered inappropriate in a
+  professional setting.
+
+## Scope
+
+This Code of Conduct applies in all project spaces — issues, pull requests,
+discussions, and any other community channels — and when an individual is
+representing the project in public spaces.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please report it privately
+to the maintainers through GitHub's
+[private reporting](https://github.com/nagarjuna-tella/Aksara/security/advisories/new)
+channel. All reports will be reviewed and handled confidentially.
+
+## Enforcement
+
+Maintainers are responsible for clarifying the standards above and may take
+appropriate action in response to behavior they deem inappropriate, including
+editing or removing contributions and, where necessary, restricting
+participation.
+
+## Attribution
+
+This Code of Conduct is adapted from common open-source community guidelines,
+including the [Contributor Covenant](https://www.contributor-covenant.org).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,133 @@
+# Contributing to Aksara
+
+Thanks for your interest in improving Aksara. This guide covers how to set up a
+development environment, the conventions the project follows, and what to expect
+when you open an issue or pull request.
+
+Aksara is an AI-native async backend framework for PostgreSQL. Because it
+generates REST APIs, migrations, Studio surfaces, and MCP tools from your models,
+correctness and safety matter more than feature volume — contributions are
+weighed against that bar.
+
+## Code of Conduct
+
+This project follows a [Code of Conduct](CODE_OF_CONDUCT.md). By participating,
+you agree to uphold it.
+
+## Ways to Contribute
+
+- **Report bugs** — open a bug report with steps to reproduce.
+- **Request features** — open a feature request describing the problem first.
+- **Improve docs** — fixes to anything under `docs/docs/` are always welcome.
+- **Submit code** — bug fixes and features, ideally tied to an existing issue.
+- **Report security issues** — do **not** open a public issue. Follow
+  [SECURITY.md](SECURITY.md).
+
+## Development Setup
+
+Requirements:
+
+| Dependency | Version |
+|------------|---------|
+| Python | 3.11+ |
+| PostgreSQL | 13+ |
+
+Clone and install with the development extras:
+
+```bash
+git clone https://github.com/nagarjuna-tella/Aksara.git
+cd Aksara
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+Install the git hooks so formatting and linting run before each commit:
+
+```bash
+pre-commit install
+```
+
+Verify the install:
+
+```bash
+aksara --version
+```
+
+A running PostgreSQL instance is needed for the test suite. See
+[docs/docs/getting-started/installation.md](docs/docs/getting-started/installation.md)
+for setup options (Homebrew, apt, Docker).
+
+## Running Tests
+
+The full suite uses `pytest`:
+
+```bash
+pytest
+```
+
+Useful subsets:
+
+```bash
+pytest -m security    # security hardening and regression tests
+pytest -m fuzz        # bounded adversarial / property-based tests
+pytest tests/orm      # a specific area
+```
+
+New code should ship with tests. Bug fixes should include a regression test that
+fails before the fix and passes after.
+
+## Code Quality
+
+The project uses `black`, `ruff`, and `mypy`. Run them before pushing:
+
+```bash
+black .
+ruff check .
+mypy aksara
+```
+
+`pre-commit` runs these automatically on staged files. If a hook fails, fix the
+underlying issue rather than bypassing it.
+
+## Commit Messages
+
+Follow the existing [Conventional Commits](https://www.conventionalcommits.org/)
+style used in the history:
+
+```
+feat(orm): add strict coercion for primitive fields
+fix(migrations): harden rename detection
+docs: clarify installation steps
+test: cover tenant policy edge cases
+```
+
+Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`. Keep the
+subject line concise and explain the *why* in the body when it isn't obvious.
+
+## Pull Requests
+
+1. Check for an existing issue, or open one to discuss the change first.
+2. Fork the repo and create a feature branch off `main`.
+3. Make your change with tests and updated docs where relevant.
+4. Ensure `pytest`, `black`, `ruff`, and `mypy` all pass.
+5. Open a pull request and fill out the template.
+
+Keep pull requests focused — one logical change per PR is easier to review and
+land. Larger or architectural changes are best discussed in an issue before you
+invest significant time.
+
+User-facing changes should be reflected in [CHANGELOG.md](CHANGELOG.md).
+
+## Documentation
+
+Docs are built with MkDocs and live under `docs/docs/`. Preview locally:
+
+```bash
+pip install mkdocs-material
+mkdocs serve -f docs/mkdocs.yml
+```
+
+## Questions
+
+If something here is unclear, open an issue and we'll improve this guide.

--- a/aksara/fields.py
+++ b/aksara/fields.py
@@ -76,6 +76,14 @@ EMAIL_REGEX = re.compile(
     r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
 )
 
+INTEGER_MIN = -(2**31)
+INTEGER_MAX = 2**31 - 1
+BIGINT_MIN = -(2**63)
+BIGINT_MAX = 2**63 - 1
+SMALLINT_MIN = -32_768
+SMALLINT_MAX = 32_767
+INTEGER_STRING_REGEX = re.compile(r"^[+-]?\d+$")
+
 # URL validation regex (http/https only)
 URL_REGEX = re.compile(
     r"^https?://[^\s/$.?#].[^\s]*$",
@@ -272,6 +280,76 @@ def _slugify(value: str, *, allow_unicode: bool = False) -> str:
     return value.strip('-_')
 
 
+def _coerce_strict_integer(value: Any, field_name: str) -> int:
+    """Coerce supported integer inputs without truncating fractional values."""
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} does not accept boolean values")
+
+    if isinstance(value, int):
+        return value
+
+    if isinstance(value, str):
+        text = value.strip()
+        if not INTEGER_STRING_REGEX.fullmatch(text):
+            raise ValueError(
+                f"{field_name} requires a base-10 integer string, got {value!r}"
+            )
+        return int(text, 10)
+
+    if isinstance(value, float):
+        if not math.isfinite(value) or not value.is_integer():
+            raise ValueError(f"{field_name} requires an integral value, got {value!r}")
+        return int(value)
+
+    if isinstance(value, PyDecimal):
+        if value.is_nan() or value.is_infinite() or value != value.to_integral_value():
+            raise ValueError(f"{field_name} requires an integral value, got {value!r}")
+        return int(value)
+
+    raise ValueError(
+        f"{field_name} requires an int, base-10 integer string, "
+        "integral float, or integral Decimal"
+    )
+
+
+def _validate_integer_bounds(value: int, minimum: int, maximum: int, field_name: str) -> None:
+    if not (minimum <= value <= maximum):
+        raise ValueError(
+            f"Value {value} is out of {field_name} range ({minimum}..{maximum})."
+        )
+
+
+def _coerce_strict_boolean(value: Any) -> bool:
+    """Parse booleans from explicit true/false forms only."""
+    if isinstance(value, bool):
+        return value
+
+    if isinstance(value, str):
+        text = value.strip().lower()
+        true_values = {"true", "1", "yes", "y", "on"}
+        false_values = {"false", "0", "no", "n", "off"}
+        if text in true_values:
+            return True
+        if text in false_values:
+            return False
+        raise ValueError(f"Boolean requires a strict true/false string, got {value!r}")
+
+    if isinstance(value, (int, float, PyDecimal)):
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError(f"Boolean numeric values must be 1 or 0, got {value!r}")
+        if isinstance(value, PyDecimal) and (value.is_nan() or value.is_infinite()):
+            raise ValueError(f"Boolean numeric values must be 1 or 0, got {value!r}")
+        if value == 1:
+            return True
+        if value == 0:
+            return False
+        raise ValueError(f"Boolean numeric values must be 1 or 0, got {value!r}")
+
+    raise ValueError(
+        "Boolean requires bool, numeric 1/0, or a strict true/false string"
+    )
+
+
 class String(Field):
     """
     String field mapping to VARCHAR.
@@ -428,12 +506,13 @@ class Integer(Field):
     def to_python(self, value: Any) -> Optional[int]:
         if value is None:
             return None
-        return int(value)
+        return _coerce_strict_integer(value, "Integer")
     
     def to_db(self, value: Any) -> Optional[int]:
         if value is None:
             return None
-        v = int(value)
+        v = _coerce_strict_integer(value, "Integer")
+        _validate_integer_bounds(v, INTEGER_MIN, INTEGER_MAX, "INTEGER")
         if self.min_value is not None and v < self.min_value:
             raise ValueError(
                 f"Value {v} is below the minimum of {self.min_value}"
@@ -503,12 +582,19 @@ class Boolean(Field):
     def to_python(self, value: Any) -> Optional[bool]:
         if value is None:
             return None
-        return bool(value)
+        return _coerce_strict_boolean(value)
     
     def to_db(self, value: Any) -> Optional[bool]:
         if value is None:
             return None
-        return bool(value)
+        return _coerce_strict_boolean(value)
+
+    def validate(self, value: Any) -> bool:
+        if value is None:
+            if self.nullable:
+                return None
+            raise ValueError("Boolean cannot be null")
+        return _coerce_strict_boolean(value)
 
 
 class DateTime(Field):
@@ -1329,6 +1415,14 @@ class Email(Field):
         # Validate format
         if not EMAIL_REGEX.match(email):
             raise ValueError(f"Invalid email format: {value}")
+
+        local_part = email.split("@", 1)[0]
+        if (
+            local_part.startswith(".")
+            or local_part.endswith(".")
+            or ".." in local_part
+        ):
+            raise ValueError(f"Invalid email format: {value}")
         
         # Check length
         if len(email) > self.max_length:
@@ -1490,28 +1584,40 @@ class Decimal(Field):
         
         try:
             dec = PyDecimal(str(value))
-        except InvalidOperation:
+        except (InvalidOperation, ValueError):
             raise ValueError(f"Invalid decimal value: {value}")
         
         # Reject NaN and Infinity
         if dec.is_nan() or dec.is_infinite():
             raise ValueError(f"Invalid decimal value: {value}")
         
-        # Check precision
-        sign, digits, exponent = dec.as_tuple()
-        # For values like 100000 (1E+5): digits=(1,), exponent=5 → 6 integer digits
-        # For values like 12.34: digits=(1,2,3,4), exponent=-2 → 2 integer digits
+        # Check precision and scale before persistence so PostgreSQL never
+        # silently rounds values to fit NUMERIC(precision, scale).
+        _sign, digits, exponent = dec.as_tuple()
         if exponent >= 0:
             integer_digits = len(digits) + exponent
+            fractional_digits = 0
         else:
             integer_digits = max(len(digits) + exponent, 0)
-        
+            fractional_digits = -exponent
+
+        if fractional_digits > self.decimal_places:
+            raise ValueError(
+                f"Decimal value {value} exceeds maximum decimal places "
+                f"({self.decimal_places})"
+            )
+
         if integer_digits > (self.max_digits - self.decimal_places):
             raise ValueError(
                 f"Decimal value {value} exceeds maximum integer digits "
                 f"({self.max_digits - self.decimal_places})"
             )
-        
+
+        if integer_digits + fractional_digits > self.max_digits:
+            raise ValueError(
+                f"Decimal value {value} exceeds maximum digits ({self.max_digits})"
+            )
+
         # Range validation
         if self.min_value is not None and dec < self.min_value:
             raise ValueError(
@@ -1770,6 +1876,8 @@ class Float(Field):
         if value is None:
             return None
         v = float(value)
+        if not math.isfinite(v):
+            raise ValueError("Float values must be finite")
         if self.min_value is not None and v < self.min_value:
             raise ValueError(
                 f"Value {v} is below the minimum of {self.min_value}"
@@ -1985,8 +2093,8 @@ class SmallInteger(Field):
             rating = fields.SmallIntegerField()
     """
 
-    _SMALLINT_MIN = -32_768
-    _SMALLINT_MAX = 32_767
+    _SMALLINT_MIN = SMALLINT_MIN
+    _SMALLINT_MAX = SMALLINT_MAX
 
     def __init__(
         self,
@@ -2019,17 +2127,13 @@ class SmallInteger(Field):
     def to_python(self, value: Any) -> Optional[int]:
         if value is None:
             return None
-        return int(value)
+        return _coerce_strict_integer(value, "SmallInteger")
 
     def to_db(self, value: Any) -> Optional[int]:
         if value is None:
             return None
-        v = int(value)
-        if not (self._SMALLINT_MIN <= v <= self._SMALLINT_MAX):
-            raise ValueError(
-                f"Value {v} is out of SMALLINT range "
-                f"({self._SMALLINT_MIN}..{self._SMALLINT_MAX})."
-            )
+        v = _coerce_strict_integer(value, "SmallInteger")
+        _validate_integer_bounds(v, self._SMALLINT_MIN, self._SMALLINT_MAX, "SMALLINT")
         if self._choices_valid is not None and v not in self._choices_valid:
             raise ValueError(
                 f"Value {v!r} is not a valid choice. "
@@ -2068,8 +2172,8 @@ class BigInteger(Field):
             total_views = fields.BigIntegerField(default=0)
     """
 
-    _BIGINT_MIN = -(2**63)
-    _BIGINT_MAX = 2**63 - 1
+    _BIGINT_MIN = BIGINT_MIN
+    _BIGINT_MAX = BIGINT_MAX
 
     def __init__(
         self,
@@ -2099,17 +2203,13 @@ class BigInteger(Field):
     def to_python(self, value: Any) -> Optional[int]:
         if value is None:
             return None
-        return int(value)
+        return _coerce_strict_integer(value, "BigInteger")
 
     def to_db(self, value: Any) -> Optional[int]:
         if value is None:
             return None
-        v = int(value)
-        if not (self._BIGINT_MIN <= v <= self._BIGINT_MAX):
-            raise ValueError(
-                f"Value {v} is out of BIGINT range "
-                f"({self._BIGINT_MIN}..{self._BIGINT_MAX})."
-            )
+        v = _coerce_strict_integer(value, "BigInteger")
+        _validate_integer_bounds(v, self._BIGINT_MIN, self._BIGINT_MAX, "BIGINT")
         return v
 
 
@@ -2166,16 +2266,17 @@ class PositiveInteger(Field):
     def to_python(self, value: Any) -> Optional[int]:
         if value is None:
             return None
-        return int(value)
+        return _coerce_strict_integer(value, "PositiveInteger")
 
     def to_db(self, value: Any) -> Optional[int]:
         if value is None:
             return None
-        v = int(value)
+        v = _coerce_strict_integer(value, "PositiveInteger")
         if v < 0:
             raise ValueError(
                 f"PositiveIntegerField requires a non-negative value, got {v}."
             )
+        _validate_integer_bounds(v, 0, INTEGER_MAX, "INTEGER")
         return v
 
 
@@ -2201,7 +2302,7 @@ class PositiveSmallInteger(Field):
             priority = fields.PositiveSmallIntegerField(default=0)
     """
 
-    _MAX = 32_767
+    _MAX = SMALLINT_MAX
 
     def __init__(
         self,
@@ -2231,12 +2332,12 @@ class PositiveSmallInteger(Field):
     def to_python(self, value: Any) -> Optional[int]:
         if value is None:
             return None
-        return int(value)
+        return _coerce_strict_integer(value, "PositiveSmallInteger")
 
     def to_db(self, value: Any) -> Optional[int]:
         if value is None:
             return None
-        v = int(value)
+        v = _coerce_strict_integer(value, "PositiveSmallInteger")
         if not (0 <= v <= self._MAX):
             raise ValueError(
                 f"Value {v} is out of POSITIVE SMALLINT range (0..{self._MAX})."
@@ -2293,16 +2394,17 @@ class PositiveBigInteger(Field):
     def to_python(self, value: Any) -> Optional[int]:
         if value is None:
             return None
-        return int(value)
+        return _coerce_strict_integer(value, "PositiveBigInteger")
 
     def to_db(self, value: Any) -> Optional[int]:
         if value is None:
             return None
-        v = int(value)
+        v = _coerce_strict_integer(value, "PositiveBigInteger")
         if v < 0:
             raise ValueError(
                 f"PositiveBigIntegerField requires a non-negative value, got {v}."
             )
+        _validate_integer_bounds(v, 0, BIGINT_MAX, "BIGINT")
         return v
 
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -6,6 +6,29 @@ All notable changes to Aksara.
 
 ---
 
+## Unreleased v0.5.51 — ORM Primitive Correctness
+
+### Fixed
+
+- Integer fields now reject non-integral numeric inputs instead of truncating
+  them.
+- Integer fields now validate PostgreSQL range boundaries before persistence.
+- Boolean fields now parse strict true/false forms.
+- Decimal fields now enforce `max_digits` and `decimal_places` before
+  persistence.
+- Float fields now reject `NaN`, positive infinity, and negative infinity.
+- Email validation now rejects invalid local-part dot placement.
+
+### Known Remaining ORM Correctness Work
+
+- `NULL` filtering and `__isnull` query semantics.
+- FK alias filtering and reverse FK filters.
+- `bulk_create`/write-path consistency.
+- Relation DDL safety.
+- Array/vector/file advanced field policy.
+
+---
+
 ## v0.5.50 — Migration Safety & Correctness
 
 This patch makes file-based migrations apply safely and consistently across the

--- a/tests/fields/test_primitive_correctness.py
+++ b/tests/fields/test_primitive_correctness.py
@@ -1,0 +1,265 @@
+"""Regression tests for ORM primitive field correctness."""
+
+import os
+from decimal import Decimal as D
+
+import pytest
+
+from aksara.fields import (
+    BigInteger,
+    Boolean,
+    Decimal,
+    Email,
+    Float,
+    Integer,
+    PositiveBigInteger,
+    PositiveInteger,
+    PositiveSmallInteger,
+    SmallInteger,
+)
+
+
+class TestIntegerStrictCoercion:
+    def test_rejects_non_integral_float(self):
+        with pytest.raises(ValueError):
+            Integer().to_db(1.9)
+
+    def test_rejects_non_integral_decimal(self):
+        with pytest.raises(ValueError):
+            Integer().to_db(D("1.2"))
+
+    def test_rejects_bool(self):
+        with pytest.raises(ValueError):
+            Integer().to_db(True)
+
+    def test_accepts_integral_float(self):
+        assert Integer().to_db(1.0) == 1
+
+    def test_accepts_integral_decimal(self):
+        assert Integer().to_db(D("1.0")) == 1
+
+    def test_accepts_integer_string(self):
+        assert Integer().to_db("10") == 10
+
+    def test_rejects_decimal_string(self):
+        with pytest.raises(ValueError):
+            Integer().to_db("10.5")
+
+    def test_integer_rejects_postgresql_integer_overflow(self):
+        with pytest.raises(ValueError, match="INTEGER range"):
+            Integer().to_db(2147483648)
+
+    def test_positive_integer_rejects_postgresql_integer_overflow(self):
+        with pytest.raises(ValueError, match="INTEGER range"):
+            PositiveInteger().to_db(2147483648)
+
+    def test_positive_big_integer_rejects_postgresql_bigint_overflow(self):
+        with pytest.raises(ValueError, match="BIGINT range"):
+            PositiveBigInteger().to_db(2**63)
+
+    def test_positive_integer_rejects_negative_after_coercion(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            PositiveInteger().to_db("-1")
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            SmallInteger(),
+            BigInteger(),
+            PositiveSmallInteger(),
+            PositiveBigInteger(),
+        ],
+    )
+    def test_extended_integer_fields_reject_bool(self, field):
+        with pytest.raises(ValueError):
+            field.to_db(False)
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            SmallInteger(),
+            BigInteger(),
+            PositiveSmallInteger(),
+            PositiveBigInteger(),
+        ],
+    )
+    def test_extended_integer_fields_reject_non_integral_values(self, field):
+        with pytest.raises(ValueError):
+            field.to_db(D("2.5"))
+
+
+class TestBooleanStrictCoercion:
+    @pytest.mark.parametrize("value", ["False", "0", "no", "off", "N"])
+    def test_false_strings(self, value):
+        assert Boolean().to_db(value) is False
+
+    @pytest.mark.parametrize("value", ["true", "1", "yes", "y", "on"])
+    def test_true_strings(self, value):
+        assert Boolean().to_db(value) is True
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_accepts_bool_directly(self, value):
+        assert Boolean().to_db(value) is value
+
+    @pytest.mark.parametrize("value, expected", [(1, True), (0, False), (1.0, True), (D("0"), False)])
+    def test_accepts_numeric_one_zero_only(self, value, expected):
+        assert Boolean().to_db(value) is expected
+
+    @pytest.mark.parametrize("value", ["maybe", "truthy", "", "none", 2, -1])
+    def test_rejects_ambiguous_values(self, value):
+        with pytest.raises(ValueError):
+            Boolean().to_db(value)
+
+
+class TestDecimalPrecisionScale:
+    def test_accepts_value_that_fits(self):
+        value = Decimal(max_digits=5, decimal_places=2).to_db("1.23")
+        assert isinstance(value, D)
+        assert value == D("1.23")
+
+    def test_rejects_too_many_fractional_digits(self):
+        with pytest.raises(ValueError, match="decimal places"):
+            Decimal(max_digits=5, decimal_places=2).to_db("1.234")
+
+    def test_rejects_too_many_total_digits(self):
+        with pytest.raises(ValueError):
+            Decimal(max_digits=5, decimal_places=2).to_db("1234.56")
+
+    def test_accepts_maximum_value(self):
+        assert Decimal(max_digits=5, decimal_places=2).to_db("999.99") == D("999.99")
+
+    def test_rejects_integer_digits_beyond_precision(self):
+        with pytest.raises(ValueError):
+            Decimal(max_digits=5, decimal_places=2).to_db("1000.00")
+
+
+class TestFloatFiniteValues:
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_nan_and_infinity(self, value):
+        with pytest.raises(ValueError, match="finite"):
+            Float().to_db(value)
+
+    def test_rejects_nan_before_min_value_check(self):
+        with pytest.raises(ValueError, match="finite"):
+            Float(min_value=0).to_db(float("nan"))
+
+    def test_preserves_min_value_validation(self):
+        with pytest.raises(ValueError, match="below the minimum"):
+            Float(min_value=0).to_db(-1.0)
+
+    def test_preserves_max_value_validation(self):
+        with pytest.raises(ValueError, match="exceeds the maximum"):
+            Float(max_value=10).to_db(11.0)
+
+    def test_accepts_finite_values(self):
+        assert Float().to_db(1.25) == 1.25
+
+
+class TestEmailLocalPartDots:
+    @pytest.mark.parametrize(
+        "value",
+        ["a..b@example.com", ".abc@example.com", "abc.@example.com"],
+    )
+    def test_rejects_invalid_local_part_dots(self, value):
+        with pytest.raises(ValueError, match="Invalid email format"):
+            Email().to_db(value)
+
+    @pytest.mark.parametrize("value", ["abc@example.com", "first.last@example.co"])
+    def test_accepts_valid_local_part_dots(self, value):
+        assert Email().to_db(value) == value
+
+
+@pytest.fixture
+async def primitive_db():
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        pytest.skip("DATABASE_URL not set")
+
+    from aksara.db import Database
+    from aksara.registry import ModelRegistry
+
+    ModelRegistry.clear()
+    database = Database(database_url)
+    await database.connect()
+    for table_name in [
+        "primitive_boolean_records",
+        "primitive_decimal_records",
+        "primitive_float_records",
+    ]:
+        await database.execute(f'DROP TABLE IF EXISTS "{table_name}" CASCADE')
+
+    try:
+        yield database
+    finally:
+        for table_name in [
+            "primitive_boolean_records",
+            "primitive_decimal_records",
+            "primitive_float_records",
+        ]:
+            await database.execute(f'DROP TABLE IF EXISTS "{table_name}" CASCADE')
+        await database.disconnect()
+        ModelRegistry.clear()
+
+
+class TestPrimitiveDbRoundTrip:
+    @pytest.mark.asyncio
+    async def test_boolean_create_save_round_trips_false_strings(self, primitive_db):
+        from aksara import Model, fields
+
+        class PrimitiveBooleanRecord(Model):
+            __tablename__ = "primitive_boolean_records"
+
+            flag = fields.Boolean()
+
+        await primitive_db.execute(PrimitiveBooleanRecord.get_create_table_sql())
+
+        created = await PrimitiveBooleanRecord.objects.create(flag="False")
+        fetched = await PrimitiveBooleanRecord.objects.get(id=created.id)
+        assert fetched.flag is False
+
+        fetched.flag = "0"
+        await fetched.save()
+
+        refetched = await PrimitiveBooleanRecord.objects.get(id=fetched.id)
+        assert refetched.flag is False
+
+    @pytest.mark.asyncio
+    async def test_decimal_invalid_scale_rejected_before_db_rounding(self, primitive_db):
+        from aksara import Model, fields
+        from aksara.exceptions import ValidationError
+
+        class PrimitiveDecimalRecord(Model):
+            __tablename__ = "primitive_decimal_records"
+
+            amount = fields.Decimal(max_digits=5, decimal_places=2)
+
+        await primitive_db.execute(PrimitiveDecimalRecord.get_create_table_sql())
+
+        with pytest.raises(ValidationError, match="decimal places"):
+            await PrimitiveDecimalRecord.objects.create(amount="1.234")
+
+        created = await PrimitiveDecimalRecord.objects.create(amount="999.99")
+        fetched = await PrimitiveDecimalRecord.objects.get(id=created.id)
+        assert fetched.amount == D("999.99")
+
+        fetched.amount = "1.234"
+        with pytest.raises(ValidationError, match="decimal places"):
+            await fetched.save()
+
+        refetched = await PrimitiveDecimalRecord.objects.get(id=created.id)
+        assert refetched.amount == D("999.99")
+
+    @pytest.mark.asyncio
+    async def test_finite_float_round_trips(self, primitive_db):
+        from aksara import Model, fields
+
+        class PrimitiveFloatRecord(Model):
+            __tablename__ = "primitive_float_records"
+
+            reading = fields.Float()
+
+        await primitive_db.execute(PrimitiveFloatRecord.get_create_table_sql())
+
+        created = await PrimitiveFloatRecord.objects.create(reading=1.25)
+        fetched = await PrimitiveFloatRecord.objects.get(id=created.id)
+        assert fetched.reading == 1.25

--- a/tests/test_v037_features.py
+++ b/tests/test_v037_features.py
@@ -117,15 +117,13 @@ class TestFieldValidation:
             field.validate(Decimal("12345.67"))  # 7 total digits
     
     def test_decimal_validation_too_many_decimal_places(self):
-        """Decimal places exceeding limit are handled by database (no Python error)."""
+        """Decimal places exceeding limit fail before database writes."""
         from aksara.fields import Decimal as DecimalField
         
         field = DecimalField(max_digits=10, decimal_places=2)
         
-        # Extra decimal places are truncated/rounded by DB, not validated in Python
-        # This is consistent with how NUMERIC type works in PostgreSQL
-        result = field.validate(Decimal("123.456"))
-        assert result == Decimal("123.456")  # Returned as-is, DB handles truncation
+        with pytest.raises(ValueError, match="decimal places"):
+            field.validate(Decimal("123.456"))
 
 
 class TestSerializerReadOnlyFields:


### PR DESCRIPTION
## Summary

This PR starts the v0.5.51 ORM correctness work by fixing primitive field coercion and validation issues identified in the ORM audit.

It focuses on silent wrong-value behavior in field conversion before values reach PostgreSQL.

## Changes

- Added strict integer coercion for integer-family fields.
- Rejected booleans, non-integral floats/Decimals, decimal strings, and integer/bigint overflow before DB writes.
- Replaced `bool(value)` Boolean coercion with strict true/false parsing.
- Enforced Decimal `max_digits` and `decimal_places` before persistence.
- Rejected Float `NaN`, `inf`, and `-inf`.
- Tightened Email local-part dot validation.
- Added unit and DB-backed regression coverage.
- Updated changelog entries for unreleased v0.5.51.

## Validation

- Field target with local DB: `266 passed`
- Full suite in project venv: `7617 passed, 3 skipped`
- `mkdocs build --strict -f docs/mkdocs.yml`: passed
- `.venv/bin/python -m build --wheel`: passed
- `.venv/bin/twine check dist/*.whl`: passed
- `git diff --check`: passed

## Notes

Package version remains `0.5.50`.

This PR does not attempt to fix all ORM correctness findings. Remaining planned work includes:

- NULL filtering and `__isnull` query semantics
- FK alias filtering and reverse FK filters
- bulk/create/update write-path consistency
- relation DDL safety
- Array/vector/file advanced field policy