### PR TITLE
fix(admin): harden permissions, CSRF, and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -457,7 +457,7 @@ These migration-metadata items are intentionally not part of this patch:
 
 #### Added
 
-- **DjangoFilterBackend** (`aksara/api/filters.py`): Automatic query parameter filtering with Django ORM lookup syntax support
+- **AksaraFilterBackend** (`aksara/api/filters.py`): Automatic query parameter filtering with Django ORM lookup syntax support
   - Supports 9 lookup types: `exact`, `gt`, `gte`, `lt`, `lte`, `in`, `isnull`, `icontains`, `contains`
   - Example: `?price__gte=50&category__in=tech,news&in_stock=true`
   - Automatically coerces values (booleans, None, numbers)
@@ -470,7 +470,7 @@ These migration-metadata items are intentionally not part of this patch:
   - Includes `get_paginated_response()` with `next_cursor` support
 
 - **Enhanced Filter/Search/Order Exports** (`aksara/api/__init__.py`): Centralized re-export of all pagination classes
-  - `BaseFilterBackend`, `DjangoFilterBackend`, `SearchFilter`, `OrderingFilter`
+  - `BaseFilterBackend`, `AksaraFilterBackend`, `SearchFilter`, `OrderingFilter`
   - `BasePagination`, `LimitOffsetPagination`, `PageNumberPagination`, `CursorPagination`
 
 ### Category 2: Database & ORM DX

--- a/aksara/api/__init__.py
+++ b/aksara/api/__init__.py
@@ -83,6 +83,7 @@ from aksara.api.prefetch import (
 from aksara.api.filters import (
     BaseFilterBackend,
     AksaraFilterBackend,
+    DjangoFilterBackend,
     SearchFilter,
     OrderingFilter,
 )
@@ -126,6 +127,7 @@ __all__ = [
     # Filter Backends (v0.5.44)
     "BaseFilterBackend",
     "AksaraFilterBackend",
+    "DjangoFilterBackend",
     "SearchFilter",
     "OrderingFilter",
     # Pagination Classes (v0.5.44)

--- a/aksara/api/__init__.py
+++ b/aksara/api/__init__.py
@@ -82,7 +82,7 @@ from aksara.api.prefetch import (
 )
 from aksara.api.filters import (
     BaseFilterBackend,
-    DjangoFilterBackend,
+    AksaraFilterBackend,
     SearchFilter,
     OrderingFilter,
 )
@@ -125,7 +125,7 @@ __all__ = [
     "clear_schema_cache",
     # Filter Backends (v0.5.44)
     "BaseFilterBackend",
-    "DjangoFilterBackend",
+    "AksaraFilterBackend",
     "SearchFilter",
     "OrderingFilter",
     # Pagination Classes (v0.5.44)

--- a/aksara/api/filters.py
+++ b/aksara/api/filters.py
@@ -3,7 +3,7 @@ API Filter Backends
 
 Provides DRF-style filter backends for Aksara ViewSets.
 
-v0.5.39: Added DjangoFilterBackend for automatic query parameter filtering
+v0.5.39: Added AksaraFilterBackend for automatic query parameter filtering
 following Django ORM lookup syntax (?price__gte=50&category__in=tech,news).
 """
 
@@ -53,7 +53,7 @@ class BaseFilterBackend:
         return queryset
 
 
-class DjangoFilterBackend(BaseFilterBackend):
+class AksaraFilterBackend(BaseFilterBackend):
     """
     Filter backend that automatically parses query parameters following Django ORM syntax.
     
@@ -73,7 +73,7 @@ class DjangoFilterBackend(BaseFilterBackend):
     Example:
         class ProductViewSet(ModelViewSet):
             model = Product
-            filter_backends = [DjangoFilterBackend]
+            filter_backends = [AksaraFilterBackend]
             filterable_fields = ['price', 'category', 'in_stock']
         
         # GET /products/?price__gte=50&category=electronics&in_stock=true

--- a/aksara/api/filters.py
+++ b/aksara/api/filters.py
@@ -187,6 +187,9 @@ class AksaraFilterBackend(BaseFilterBackend):
         return self._coerce_value(value)
 
 
+DjangoFilterBackend = AksaraFilterBackend
+
+
 class SearchFilter(BaseFilterBackend):
     """
     Search filter backend.

--- a/aksara/contrib/admin/__init__.py
+++ b/aksara/contrib/admin/__init__.py
@@ -26,7 +26,9 @@ The admin interface provides:
 
 from aksara.contrib.admin.site import AdminSite
 from aksara.contrib.admin.options import ModelAdmin
-from aksara.contrib.admin.urls import router as admin_router
+from aksara.contrib.admin.filters import SimpleListFilter
+from aksara.contrib.admin.actions import action
+from aksara.contrib.admin.urls import build_admin_router
 from aksara.contrib.admin.mount import include_admin
 
 # Global admin site instance
@@ -35,11 +37,17 @@ site = AdminSite()
 # Backwards compatibility alias
 admin_site = site
 
+# Default router bound to the global site (route names: "admin:*").
+admin_router = build_admin_router(site)
+
 __all__ = [
     "site",
     "admin_site",  # Alias for backwards compatibility
     "AdminSite",
     "ModelAdmin",
+    "SimpleListFilter",
+    "action",
     "admin_router",
+    "build_admin_router",
     "include_admin",
 ]

--- a/aksara/contrib/admin/actions.py
+++ b/aksara/contrib/admin/actions.py
@@ -1,0 +1,134 @@
+"""
+Admin bulk actions.
+
+Actions are operations applied to a set of selected rows from the list view.
+Declare them with the ``@action`` decorator and list their names in
+``ModelAdmin.actions``:
+
+    class PostAdmin(ModelAdmin):
+        actions = ["publish_selected"]
+
+        @action(description="Publish selected posts", permissions=["change"])
+        async def publish_selected(self, request, queryset):
+            count = await queryset.update(is_published=True)
+            self.message_user(request, f"Published {count} posts.")
+
+User-facing messages are surfaced with ``message_user`` and shown on the next
+list render via a short-lived cookie (post/redirect/get).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
+
+if TYPE_CHECKING:
+    from fastapi import Request
+    from starlette.responses import Response
+
+ADMIN_MESSAGE_COOKIE = "aksara_admin_messages"
+
+# Recognised message levels and the CSS alert class each maps to in templates.
+MESSAGE_LEVELS = {
+    "success": "alert-success",
+    "info": "alert-info",
+    "warning": "alert-warning",
+    "error": "alert-danger",
+}
+
+
+def action(
+    description: Optional[str] = None,
+    permissions: Optional[List[str]] = None,
+) -> Callable:
+    """
+    Mark a ``ModelAdmin`` method as a bulk action.
+
+    Args:
+        description: Human-readable label shown in the actions dropdown.
+        permissions: Permission names required to run the action. Each name
+            ``X`` is checked against ``has_X_permission(request)`` on the admin
+            (e.g. ``["change"]`` requires ``has_change_permission``).
+    """
+
+    def decorator(func: Callable) -> Callable:
+        func._is_admin_action = True  # type: ignore[attr-defined]
+        func.action_description = (  # type: ignore[attr-defined]
+            description or func.__name__.replace("_", " ").capitalize()
+        )
+        if permissions is not None:
+            func.allowed_permissions = list(permissions)  # type: ignore[attr-defined]
+        return func
+
+    return decorator
+
+
+@action(description="Delete selected items", permissions=["delete"])
+async def delete_selected(model_admin: Any, request: "Request", queryset: Any) -> None:
+    """Built-in action: delete every selected object."""
+    objects = await queryset.all()
+    count = 0
+    for obj in objects:
+        await model_admin.delete_model(request, obj)
+        count += 1
+    model_admin.message_user(
+        request,
+        f"Deleted {count} {model_admin.model.__name__} object(s).",
+        level="success",
+    )
+
+
+def queue_message(request: "Request", message: str, level: str = "info") -> None:
+    """Append a flash message to be shown on the next list render."""
+    if level not in MESSAGE_LEVELS:
+        level = "info"
+    store = getattr(request.state, "_admin_messages", None)
+    if store is None:
+        store = []
+        request.state._admin_messages = store
+    store.append({"level": level, "text": str(message)})
+
+
+def write_messages_cookie(request: "Request", response: "Response") -> None:
+    """Persist queued messages onto a redirect response, if any were queued."""
+    store = getattr(request.state, "_admin_messages", None)
+    if not store:
+        return
+    response.set_cookie(
+        key=ADMIN_MESSAGE_COOKIE,
+        value=json.dumps(store),
+        max_age=30,
+        httponly=True,
+        samesite="strict",
+        path="/",
+    )
+
+
+def pop_messages(request: "Request") -> List[dict]:
+    """Read and parse any flash messages from the incoming request cookie."""
+    raw = request.cookies.get(ADMIN_MESSAGE_COOKIE)
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return []
+    if not isinstance(data, list):
+        return []
+    cleaned = []
+    for item in data:
+        if isinstance(item, dict) and "text" in item:
+            level = item.get("level", "info")
+            cleaned.append(
+                {
+                    "level": level if level in MESSAGE_LEVELS else "info",
+                    "alert_class": MESSAGE_LEVELS.get(level, "alert-info"),
+                    "text": str(item["text"]),
+                }
+            )
+    return cleaned
+
+
+def clear_messages_cookie(response: "Response") -> None:
+    """Delete the flash-message cookie after it has been read."""
+    response.delete_cookie(ADMIN_MESSAGE_COOKIE, path="/")

--- a/aksara/contrib/admin/filters.py
+++ b/aksara/contrib/admin/filters.py
@@ -1,0 +1,208 @@
+"""
+Admin list filters.
+
+Provides the sidebar filtering system for admin list views:
+
+- ``SimpleListFilter`` — subclass for custom filter logic with arbitrary lookups.
+- ``FieldListFilter`` — internal helper that turns a plain field name in
+  ``ModelAdmin.list_filter`` into a set of selectable values.
+
+The list view builds a filter spec for each entry in ``list_filter`` and applies
+the selected value to the queryset before pagination.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from fastapi import Request
+    from aksara.contrib.admin.options import ModelAdmin
+
+
+# Maximum distinct values to offer for an auto-generated field filter. Beyond
+# this, a free-form field is not a useful sidebar filter.
+MAX_AUTO_FILTER_CHOICES = 50
+
+
+class SimpleListFilter:
+    """
+    Base class for custom admin list filters.
+
+    Subclass and define ``title``, ``parameter_name``, ``lookups()`` and
+    ``queryset()``:
+
+        class RecentFilter(SimpleListFilter):
+            title = "Published"
+            parameter_name = "when"
+
+            def lookups(self, request, model_admin):
+                return [("week", "This week"), ("month", "This month")]
+
+            def queryset(self, request, queryset):
+                if self.value() == "week":
+                    return queryset.filter(published_at__gte=...)
+                return queryset
+
+    The selected value is read from the request query string using
+    ``parameter_name``.
+    """
+
+    title: str = ""
+    parameter_name: str = ""
+
+    def __init__(self, request: "Request", model_admin: "ModelAdmin"):
+        self.request = request
+        self.model_admin = model_admin
+        self._value: Optional[str] = request.query_params.get(self.parameter_name)
+        self.lookup_choices: List[Tuple[str, str]] = list(
+            self.lookups(request, model_admin) or []
+        )
+
+    def value(self) -> Optional[str]:
+        """Return the selected filter value, or None if not set."""
+        return self._value
+
+    def lookups(
+        self, request: "Request", model_admin: "ModelAdmin"
+    ) -> List[Tuple[str, str]]:
+        """Return a list of (value, label) options for the sidebar."""
+        raise NotImplementedError(
+            "SimpleListFilter subclasses must implement lookups()."
+        )
+
+    def queryset(self, request: "Request", queryset: Any) -> Any:
+        """Return a filtered queryset based on the selected value."""
+        raise NotImplementedError(
+            "SimpleListFilter subclasses must implement queryset()."
+        )
+
+    def has_output(self) -> bool:
+        return len(self.lookup_choices) > 0
+
+    def choices_for_template(self) -> List[dict]:
+        """Build the option list rendered in the sidebar (incl. an 'All' reset)."""
+        current = self.value()
+        options = [
+            {"value": None, "label": "All", "selected": current in (None, "")}
+        ]
+        for value, label in self.lookup_choices:
+            options.append(
+                {
+                    "value": str(value),
+                    "label": str(label),
+                    "selected": str(value) == str(current),
+                }
+            )
+        return options
+
+
+class FieldListFilter:
+    """
+    Auto-generated filter for a plain model field named in ``list_filter``.
+
+    Boolean fields and fields with ``choices`` produce fixed options; other
+    fields offer up to ``MAX_AUTO_FILTER_CHOICES`` distinct values pulled from
+    the table. Applying the filter uses a direct ``field=value`` lookup, which
+    the ORM supports reliably for own-table columns.
+    """
+
+    def __init__(self, field_name: str, title: str, parameter_name: str):
+        self.field_name = field_name
+        self.title = title
+        self.parameter_name = parameter_name
+        self.lookup_choices: List[Tuple[str, str]] = []
+        self._value: Optional[str] = None
+        self._field_type: str = "String"
+
+    @classmethod
+    async def create(
+        cls,
+        field_name: str,
+        request: "Request",
+        model_admin: "ModelAdmin",
+    ) -> "FieldListFilter":
+        title = field_name.replace("_", " ").title()
+        instance = cls(field_name, title, field_name)
+        instance._value = request.query_params.get(field_name)
+        field = model_admin.model.meta.get_field(field_name)
+        instance._field_type = field.__class__.__name__ if field else "String"
+        instance.lookup_choices = await instance._build_choices(model_admin)
+        return instance
+
+    async def _build_choices(self, model_admin: "ModelAdmin") -> List[Tuple[str, str]]:
+        model = model_admin.model
+        field = model.meta.get_field(self.field_name)
+        if field is None:
+            return []
+
+        field_type = field.__class__.__name__
+
+        if field_type == "Boolean":
+            return [("true", "Yes"), ("false", "No")]
+
+        choices = getattr(field, "choices", None)
+        if choices:
+            return [(str(c), str(c).replace("_", " ").title()) for c in choices]
+
+        # Fall back to distinct values present in the table (bounded).
+        try:
+            objects = await model.objects.all()
+        except Exception:
+            return []
+
+        seen: List[str] = []
+        for obj in objects:
+            raw = getattr(obj, self.field_name, None)
+            if raw is None:
+                continue
+            text = str(raw)
+            if text not in seen:
+                seen.append(text)
+            if len(seen) > MAX_AUTO_FILTER_CHOICES:
+                # Too many distinct values to be a useful sidebar filter.
+                return []
+        return [(v, v) for v in seen]
+
+    def value(self) -> Optional[str]:
+        return self._value
+
+    def has_output(self) -> bool:
+        return len(self.lookup_choices) > 0
+
+    def apply(self, queryset: Any):
+        """Apply the selected value to the queryset, if any."""
+        value = self.value()
+        if value in (None, ""):
+            return queryset
+
+        parsed: Any = value
+        if self._field_type == "Boolean":
+            parsed = value in ("true", "1", "on", "yes")
+        elif self._field_type == "Integer":
+            try:
+                parsed = int(value)
+            except (TypeError, ValueError):
+                return queryset
+
+        try:
+            return queryset.filter(**{self.field_name: parsed})
+        except Exception:
+            # Unsupported lookup (e.g. relation field) — leave queryset unfiltered
+            # rather than raising a 500 in the admin.
+            return queryset
+
+    def choices_for_template(self) -> List[dict]:
+        current = self.value()
+        options = [
+            {"value": None, "label": "All", "selected": current in (None, "")}
+        ]
+        for value, label in self.lookup_choices:
+            options.append(
+                {
+                    "value": str(value),
+                    "label": str(label),
+                    "selected": str(value) == str(current),
+                }
+            )
+        return options

--- a/aksara/contrib/admin/filters.py
+++ b/aksara/contrib/admin/filters.py
@@ -25,6 +25,16 @@ if TYPE_CHECKING:
 MAX_AUTO_FILTER_CHOICES = 50
 
 
+def _normalize_choice(choice: Any) -> Tuple[str, str]:
+    """Return a template/query-safe (value, label) pair for field choices."""
+    if isinstance(choice, (tuple, list)) and len(choice) == 2:
+        value, label = choice
+        return str(value), str(label)
+
+    value = str(choice)
+    return value, value.replace("_", " ").title()
+
+
 class SimpleListFilter:
     """
     Base class for custom admin list filters.
@@ -143,11 +153,15 @@ class FieldListFilter:
 
         choices = getattr(field, "choices", None)
         if choices:
-            return [(str(c), str(c).replace("_", " ").title()) for c in choices]
+            return [_normalize_choice(choice) for choice in choices]
 
         # Fall back to distinct values present in the table (bounded).
         try:
-            objects = await model.objects.all()
+            queryset = model.objects.filter()
+            if not hasattr(queryset, "limit"):
+                return []
+            bounded_qs = queryset.limit(MAX_AUTO_FILTER_CHOICES + 1)
+            objects = await bounded_qs.all()
         except Exception:
             return []
 

--- a/aksara/contrib/admin/mount.py
+++ b/aksara/contrib/admin/mount.py
@@ -6,6 +6,7 @@ Helper function to mount admin routes on a FastAPI/Aksara app.
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import TYPE_CHECKING
 
@@ -15,6 +16,8 @@ from starlette.responses import Response
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
+
+logger = logging.getLogger("aksara.contrib.admin")
 
 
 def _get_settings():
@@ -46,8 +49,8 @@ class AdminSessionMiddleware(BaseHTTPMiddleware):
                     user = await get_user_from_session_token(db, token)
                     if user:
                         request.state.user = user
-            except Exception:
-                pass  # Session lookup failed, continue without user
+            except Exception as exc:
+                logger.warning("Admin session lookup failed: %s", exc, exc_info=True)
         
         return await call_next(request)
 
@@ -103,43 +106,63 @@ class AdminRateLimitMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-def include_admin(app: "FastAPI", prefix: str = "/admin") -> None:
+def include_admin(
+    app: "FastAPI",
+    prefix: str = "/admin",
+    site: "Any" = None,
+) -> None:
     """
-    Mount the admin interface on a FastAPI/Aksara application.
-    
+    Mount an admin interface on a FastAPI/Aksara application.
+
     Args:
         app: The FastAPI/Aksara application instance
         prefix: URL prefix for admin (default: "/admin")
-        
+        site: AdminSite to mount. Defaults to the global ``site`` singleton.
+            Pass a custom site to mount additional, independently-configured
+            admin interfaces under different prefixes.
+
     Example:
         from aksara import Aksara
         from aksara.contrib.admin import include_admin
-        
+
         app = Aksara(database_url="...")
-        include_admin(app)  # Mounts at /admin/
-        
-        # Or with custom prefix
-        include_admin(app, prefix="/dashboard")
+        include_admin(app)  # Mounts the default site at /admin/
+
+        # A second, separately-configured site
+        from aksara.contrib.admin import AdminSite
+        ops = AdminSite(name="ops", site_header="Ops Console")
+        include_admin(app, prefix="/ops", site=ops)
     """
     import os
     from starlette.staticfiles import StaticFiles
-    from aksara.contrib.admin.urls import router as admin_router
-    
-    # Add admin security middlewares
+    from aksara.contrib.admin.urls import build_admin_router
+
+    if site is None:
+        from aksara.contrib.admin import site as default_site
+        site = default_site
+
+    # Session middleware is global; add it only once even with multiple sites.
+    if not getattr(app.state, "_aksara_admin_session_mw", False):
+        app.add_middleware(AdminSessionMiddleware)
+        app.state._aksara_admin_session_mw = True
+
+    # Rate limiting is scoped to each admin prefix.
     app.add_middleware(AdminRateLimitMiddleware, prefix=prefix)
-    app.add_middleware(AdminSessionMiddleware)
-    
+
     # Mount admin static files at app level so templates can reference
-    # /static/admin/css/admin.css regardless of admin prefix.
-    # Directory layout: admin/static/admin/{css,js}/... 
-    # We mount the inner static/admin/ dir at /static/admin/
-    admin_dir = os.path.dirname(os.path.abspath(__file__))
-    static_admin_dir = os.path.join(admin_dir, "static", "admin")
-    if os.path.exists(static_admin_dir):
-        app.mount(
-            "/static/admin",
-            StaticFiles(directory=static_admin_dir),
-            name="admin_static",
-        )
-    
-    app.include_router(admin_router, prefix=prefix, include_in_schema=False)
+    # /static/admin/css/admin.css regardless of admin prefix. Shared across
+    # all sites, so mount it only once.
+    if not getattr(app.state, "_aksara_admin_static_mounted", False):
+        admin_dir = os.path.dirname(os.path.abspath(__file__))
+        static_admin_dir = os.path.join(admin_dir, "static", "admin")
+        if os.path.exists(static_admin_dir):
+            app.mount(
+                "/static/admin",
+                StaticFiles(directory=static_admin_dir),
+                name="admin_static",
+            )
+            app.state._aksara_admin_static_mounted = True
+
+    app.include_router(
+        build_admin_router(site, prefix=prefix), prefix=prefix, include_in_schema=False
+    )

--- a/aksara/contrib/admin/options.py
+++ b/aksara/contrib/admin/options.py
@@ -6,7 +6,7 @@ ModelAdmin configuration class for customizing admin behavior.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
 
 if TYPE_CHECKING:
     from aksara.model.base import Model
@@ -14,266 +14,272 @@ if TYPE_CHECKING:
     from fastapi import Request
 
 
+# A fieldset is (title_or_None, {"fields": [...], "description": str, "classes": [...]})
+Fieldset = Tuple[Optional[str], Dict[str, Any]]
+
+
 class ModelAdmin:
     """
     Configuration class for model admin behavior.
-    
+
     Subclass this to customize how a model appears and behaves in the admin.
-    
-    Attributes:
-        list_display: Fields to show in the list view (default: auto-picks up to 4)
-        search_fields: Fields to search against
-        list_filter: Fields to filter by
-        readonly_fields: Fields that cannot be edited
-        form_fields: Fields to show in forms (default: all non-pk fields)
-    
+
     Example:
+        @site.register(Article)
         class ArticleAdmin(ModelAdmin):
             list_display = ["title", "author", "created_at"]
-            search_fields = ["title", "body"]
+            list_display_links = ["title"]
             list_filter = ["status"]
+            search_fields = ["title", "body"]
+            ordering = ["-created_at"]
+            list_per_page = 25
             readonly_fields = ["created_at", "updated_at"]
-            
-        site.register(Article, ArticleAdmin)
+            actions = ["publish_selected"]
     """
-    
-    # List view configuration
+
+    # --- List view configuration ---------------------------------------------
     list_display: List[str] = []
+    list_display_links: Optional[List[str]] = None
     search_fields: List[str] = []
-    list_filter: List[str] = []
-    
-    # Form configuration
+    list_filter: List[Any] = []
+    ordering: List[str] = []
+    list_per_page: int = 100
+    list_max_show_all: int = 200
+
+    # --- Form configuration ---------------------------------------------------
     readonly_fields: List[str] = []
-    form_fields: Optional[List[str]] = None  # None means auto-infer
+    form_fields: Optional[List[str]] = None  # Legacy alias; None means auto-infer
+    fields: Optional[List[str]] = None       # Explicit ordered subset for the form
+    exclude: Optional[List[str]] = None       # Fields to drop from the default form
+    fieldsets: Optional[List[Fieldset]] = None
     formfield_overrides: Dict[str, Any] = {}  # Map field_name -> widget instance
-    
+    prepopulated_fields: Dict[str, Tuple[str, ...]] = {}  # slug -> (source, ...)
+    raw_id_fields: List[str] = []             # Relation fields rendered as a text id
+    autocomplete_fields: List[str] = []       # Relation fields rendered searchable
+
+    # --- Actions --------------------------------------------------------------
+    actions: List[Any] = []
+
+    # Fields that are always excluded from the auto-inferred form (ORM-managed).
+    AUTO_EXCLUDE_FIELDS = {"created_at", "updated_at"}
+
     def __init__(self, model: Type["Model"], site: "AdminSite"):
-        """
-        Initialize the ModelAdmin.
-        
-        Args:
-            model: The Model class this admin is for
-            site: The AdminSite instance
-        """
         self.model = model
         self.site = site
-    
+
     # -------------------------------------------------------------------------
     # Query Helpers
     # -------------------------------------------------------------------------
-    
+
     async def get_queryset(self, request: "Request") -> Any:
         """
         Get the base queryset for list views.
-        
-        Override to customize filtering based on request/user.
-        
-        Args:
-            request: The FastAPI Request object
-            
-        Returns:
-            A QuerySet (Manager.filter() result)
+
+        Override to customize filtering based on request/user. When overriding,
+        await ``super().get_queryset(request)`` and chain queryset methods:
+
+            async def get_queryset(self, request):
+                qs = await super().get_queryset(request)
+                return qs.filter(owner_id=str(request.state.user.id))
         """
         return self.model.objects.filter()
-    
+
     async def get_object(self, request: "Request", pk: str) -> "Model":
-        """
-        Get a single object by primary key.
-        
-        Args:
-            request: The FastAPI Request object
-            pk: The primary key value
-            
-        Returns:
-            The model instance
-            
-        Raises:
-            DoesNotExist: If object not found
-        """
+        """Get a single object by primary key."""
         return await self.model.objects.get(id=pk)
-    
+
+    def get_ordering(self, request: "Request") -> List[str]:
+        """Return the default ordering for the list view."""
+        return list(self.ordering or [])
+
+    def get_search_results(self, request: "Request", queryset: Any, term: str) -> Any:
+        """
+        Apply ``search_fields`` to the queryset for the given term.
+
+        Uses the ORM's OR-across-fields ``search()`` for own-table fields, which
+        is the reliably supported path. Related (``a__b``) search fields are
+        applied best-effort and skipped if the ORM cannot resolve them.
+        """
+        term = (term or "").strip()
+        if not term or not self.search_fields:
+            return queryset
+
+        direct_fields = [f for f in self.search_fields if "__" not in f]
+        related_fields = [f for f in self.search_fields if "__" in f]
+
+        if direct_fields:
+            queryset = queryset.search(term, direct_fields)
+
+        # Related-field search depends on relation filtering, which is still
+        # maturing in the ORM; apply it without letting failures break the view.
+        for field in related_fields:
+            try:
+                queryset = queryset.filter(**{f"{field}__icontains": term})
+            except Exception:
+                continue
+        return queryset
+
     # -------------------------------------------------------------------------
     # Permissions
     # -------------------------------------------------------------------------
-    
-    def has_view_permission(
-        self,
-        request: "Request",
-        obj: Optional["Model"] = None,
-    ) -> bool:
+
+    def has_module_permission(self, request: "Request") -> bool:
         """
-        Check if the user can view objects in admin.
-        
-        Args:
-            request: The FastAPI Request object
-            obj: Optional specific object being viewed
-            
-        Returns:
-            True if user has permission
-        """
-        user = getattr(request.state, "user", None)
-        return bool(user and getattr(user, "is_staff", False))
-    
-    def has_add_permission(self, request: "Request") -> bool:
-        """
-        Check if the user can add new objects.
-        
-        Args:
-            request: The FastAPI Request object
-            
-        Returns:
-            True if user has permission
+        Whether this model appears in the admin index/sidebar for the user.
+
+        Defaults to the view permission. Override to hide a model entirely.
         """
         return self.has_view_permission(request)
-    
+
+    def has_view_permission(
+        self, request: "Request", obj: Optional["Model"] = None
+    ) -> bool:
+        """Check if the user can view objects in admin."""
+        user = getattr(request.state, "user", None)
+        return bool(user and getattr(user, "is_staff", False))
+
+    def has_add_permission(self, request: "Request") -> bool:
+        """Check if the user can add new objects."""
+        return self.has_view_permission(request)
+
     def has_change_permission(
-        self,
-        request: "Request",
-        obj: Optional["Model"] = None,
+        self, request: "Request", obj: Optional["Model"] = None
     ) -> bool:
-        """
-        Check if the user can change objects.
-        
-        Args:
-            request: The FastAPI Request object
-            obj: Optional specific object being changed
-            
-        Returns:
-            True if user has permission
-        """
+        """Check if the user can change objects."""
         return self.has_view_permission(request, obj)
-    
+
     def has_delete_permission(
-        self,
-        request: "Request",
-        obj: Optional["Model"] = None,
+        self, request: "Request", obj: Optional["Model"] = None
     ) -> bool:
-        """
-        Check if the user can delete objects.
-        
-        Args:
-            request: The FastAPI Request object
-            obj: Optional specific object being deleted
-            
-        Returns:
-            True if user has permission
-        """
+        """Check if the user can delete objects."""
         return self.has_view_permission(request, obj)
-    
+
     # -------------------------------------------------------------------------
     # Field Configuration
     # -------------------------------------------------------------------------
-    
+
     def get_list_display(self, request: "Request") -> List[str]:
-        """
-        Get fields to display in list view.
-        
-        Args:
-            request: The FastAPI Request object
-            
-        Returns:
-            List of field names
-        """
+        """Get fields/columns to display in the list view."""
         if self.list_display:
-            return self.list_display
-        
-        # Fallback: id + up to 3 non-relational fields
-        names: List[str] = []
-        for field in self.model.meta.fields:
-            names.append(field.name)
-        
-        # Ensure id is first
+            return list(self.list_display)
+
+        names: List[str] = [field.name for field in self.model.meta.fields]
         if "id" in names:
             names.remove("id")
             names.insert(0, "id")
-        
         return names[:4]
-    
+
+    def get_list_display_links(
+        self, request: "Request", list_display: List[str]
+    ) -> List[str]:
+        """Return which columns link to the change view."""
+        if self.list_display_links is not None:
+            return list(self.list_display_links)
+        return [list_display[0]] if list_display else []
+
+    def is_callable_column(self, name: str) -> bool:
+        """True if ``name`` is a custom column method rather than a model field."""
+        if self.model.meta.get_field(name) is not None:
+            return False
+        if name in self.model.meta.many_to_many:
+            return False
+        attr = getattr(self, name, None)
+        return callable(attr)
+
+    def get_column_label(self, name: str) -> str:
+        """Header label for a list column (field or custom method)."""
+        if self.is_callable_column(name):
+            method = getattr(self, name)
+            label = getattr(method, "short_description", None)
+            if label:
+                return str(label)
+        return name.replace("_", " ").title()
+
+    def column_allows_html(self, name: str) -> bool:
+        if self.is_callable_column(name):
+            return bool(getattr(getattr(self, name), "allow_html", False))
+        return False
+
     def get_readonly_fields(
-        self,
-        request: "Request",
-        obj: Optional["Model"] = None,
+        self, request: "Request", obj: Optional["Model"] = None
+    ) -> List[str]:
+        """Get fields that cannot be edited."""
+        return list(self.readonly_fields or [])
+
+    def get_fields(
+        self, request: "Request", obj: Optional["Model"] = None
     ) -> List[str]:
         """
-        Get fields that cannot be edited.
-        
-        Args:
-            request: The FastAPI Request object
-            obj: Optional object being edited
-            
-        Returns:
-            List of readonly field names
+        Get the flat list of fields shown on the add/change form.
+
+        Resolution order:
+        1. Explicit ``fields`` (verbatim, ordered).
+        2. Legacy ``form_fields`` (verbatim).
+        3. Auto-inferred (non-pk, non-timestamp, non-readonly + M2M), then
+           with ``exclude`` removed.
         """
-        return self.readonly_fields or []
-    
-    # Fields that are always excluded from forms (auto-managed by the ORM)
-    AUTO_EXCLUDE_FIELDS = {"created_at", "updated_at"}
-    
-    def get_form_fields(
-        self,
-        request: "Request",
-        obj: Optional["Model"] = None,
-    ) -> List[str]:
-        """
-        Get fields to show in add/change forms.
-        
-        By default, excludes:
-        - Primary key fields
-        - Auto-managed timestamp fields (created_at, updated_at)
-        - Readonly fields
-        
-        Args:
-            request: The FastAPI Request object
-            obj: Optional object being edited
-            
-        Returns:
-            List of field names for the form
-        """
+        if self.fields is not None:
+            return list(self.fields)
         if self.form_fields is not None:
-            return self.form_fields
-        
+            return list(self.form_fields)
+
         readonly = set(self.get_readonly_fields(request, obj))
         fields: List[str] = []
-        
         for field in self.model.meta.fields:
-            # Skip primary key
             if getattr(field, "primary_key", False):
                 continue
-            # Skip auto-managed timestamp fields
             if field.name in self.AUTO_EXCLUDE_FIELDS:
                 continue
-            # Skip readonly fields
             if field.name in readonly:
                 continue
             fields.append(field.name)
-        
-        # Also include ManyToMany fields
+
         for m2m_name in self.model.meta.many_to_many.keys():
             if m2m_name not in readonly:
                 fields.append(m2m_name)
-        
+
+        if self.exclude:
+            excluded = set(self.exclude)
+            fields = [f for f in fields if f not in excluded]
         return fields
-    
+
+    def get_fieldsets(
+        self, request: "Request", obj: Optional["Model"] = None
+    ) -> List[Fieldset]:
+        """
+        Get fieldsets (grouped form sections).
+
+        If ``fieldsets`` is declared it is used as-is; otherwise a single
+        unnamed section is built from :meth:`get_fields`.
+        """
+        if self.fieldsets:
+            return list(self.fieldsets)
+        return [(None, {"fields": self.get_fields(request, obj)})]
+
+    def get_form_fields(
+        self, request: "Request", obj: Optional["Model"] = None
+    ) -> List[str]:
+        """Flat list of field names the form parses and saves."""
+        if self.fieldsets:
+            names: List[str] = []
+            for _title, opts in self.fieldsets:
+                names.extend(opts.get("fields", []))
+            return names
+        return self.get_fields(request, obj)
+
     def get_field_type(self, field_name: str) -> str:
-        """
-        Get the HTML input type for a field.
-        
-        Args:
-            field_name: Name of the field
-            
-        Returns:
-            HTML input type string
-        """
-        # Check if it's a ManyToMany field first
+        """Get the HTML input type for a field."""
         if field_name in self.model.meta.many_to_many:
             return "multiselect"
-        
+
+        if field_name in self.raw_id_fields:
+            return "text"
+
         field = self.model.meta.get_field(field_name)
         if not field:
             return "text"
-        
+
         field_type = field.__class__.__name__
-        
         type_map = {
             "Email": "email",
             "URL": "url",
@@ -288,109 +294,106 @@ class ModelAdmin:
             "JSON": "textarea",
             "ForeignKey": "select",
         }
-        
         return type_map.get(field_type, "text")
-    
+
     def get_widget(self, field_name: str, field: Any) -> Optional[Any]:
-        """
-        Get custom widget for a field if configured.
-        
-        Checks formfield_overrides for explicit widget assignment,
-        then auto-selects widgets for JSON and Array fields.
-        
-        Args:
-            field_name: Name of the field
-            field: The field instance
-            
-        Returns:
-            Widget instance or None for default rendering
-        """
-        # Check for explicit override
+        """Get custom widget for a field if configured."""
         if field_name in self.formfield_overrides:
             return self.formfield_overrides[field_name]
-        
-        # Auto-select widgets for known field types
+
         field_type = field.__class__.__name__
-        
         if field_type == "JSON":
             from aksara.contrib.admin.widgets.json import JSONAdminWidget
             return JSONAdminWidget()
         elif field_type == "Array":
             from aksara.contrib.admin.widgets.array import ArrayAdminWidget
             return ArrayAdminWidget()
-        
         return None
-    
+
     async def get_field_choices(
-        self,
-        field_name: str,
-        request: "Request",
+        self, field_name: str, request: "Request"
     ) -> List[tuple]:
-        """
-        Get choices for a ForeignKey or ManyToMany field.
-        
-        Returns list of (value, label) tuples for the select dropdown.
-        
-        Args:
-            field_name: Name of the FK or M2M field
-            request: The FastAPI Request object
-            
-        Returns:
-            List of (id, display_string) tuples
-        """
-        from aksara.fields import ForeignKey, ManyToMany
-        
-        # Check for ManyToMany field first
+        """Get (value, label) choices for a ForeignKey or ManyToMany field."""
+        from aksara.fields import ForeignKey
+
         m2m_fields = self.model.meta.many_to_many
         if field_name in m2m_fields:
-            m2m_field = m2m_fields[field_name]
-            related_model = m2m_field.to_model
+            related_model = m2m_fields[field_name].to_model
             objects = await related_model.objects.all()
             return [(str(obj.id), self._get_object_display(obj)) for obj in objects]
-        
-        # Check for ForeignKey field
+
         field = self.model.meta.get_field(field_name)
         if not field or not isinstance(field, ForeignKey):
             return []
-        
-        # Get the related model
+
         related_model = field.to_model
-        
-        # Fetch all related objects
         objects = await related_model.objects.all()
-        
-        choices = []
-        for obj in objects:
-            # Try to get a good display string
-            label = self._get_object_display(obj)
-            choices.append((str(obj.id), label))
-        
-        return choices
-    
+        return [(str(obj.id), self._get_object_display(obj)) for obj in objects]
+
     def _get_object_display(self, obj: "Model") -> str:
-        """
-        Get a display string for a model instance.
-        
-        Tries __str__, then common field names, then falls back to ID.
-        """
-        # Try __str__ if it's been customized
+        """Display string for a model instance (custom __str__, then common fields)."""
         str_repr = str(obj)
         if str_repr and not str_repr.startswith("<"):
             return str_repr
-        
-        # Try common display fields
+
         for attr in ["name", "title", "email", "username", "label", "description"]:
             val = getattr(obj, attr, None)
             if val:
                 return str(val)
-        
-        # Fall back to ID
         return str(obj.id)
-    
+
+    # -------------------------------------------------------------------------
+    # Actions
+    # -------------------------------------------------------------------------
+
+    def get_actions(self, request: "Request") -> Dict[str, Dict[str, Any]]:
+        """
+        Resolve declared actions into an ordered mapping.
+
+        Each entry: name -> {"func": callable, "description": str,
+        "allowed_permissions": [..]}. The callable is invoked as
+        ``func(self, request, queryset)``.
+        """
+        from aksara.contrib.admin.actions import delete_selected
+
+        resolved: Dict[str, Dict[str, Any]] = {}
+        for entry in self.actions or []:
+            func = None
+            name = None
+            if isinstance(entry, str):
+                if entry == "delete_selected":
+                    func, name = delete_selected, "delete_selected"
+                else:
+                    candidate = getattr(self, entry, None)
+                    if candidate is None:
+                        continue
+                    func, name = candidate, entry
+            elif callable(entry):
+                func, name = entry, getattr(entry, "__name__", "action")
+
+            if func is None:
+                continue
+
+            resolved[name] = {
+                "func": func,
+                "description": getattr(
+                    func, "action_description", name.replace("_", " ").capitalize()
+                ),
+                "allowed_permissions": list(getattr(func, "allowed_permissions", [])),
+            }
+        return resolved
+
+    def message_user(
+        self, request: "Request", message: str, level: str = "info"
+    ) -> None:
+        """Queue a flash message shown on the next list render."""
+        from aksara.contrib.admin.actions import queue_message
+        queue_message(request, message, level)
+
     # -------------------------------------------------------------------------
     # Save / Delete Hooks
     # -------------------------------------------------------------------------
-    
+
     async def save_model(
         self,
         request: "Request",
@@ -399,58 +402,51 @@ class ModelAdmin:
         is_created: bool,
     ) -> None:
         """
-        Save the model instance.
-        
-        Override for custom save behavior.
-        
-        Args:
-            request: The FastAPI Request object
-            obj: The model instance
-            form_data: Form data dict
-            is_created: True if this is a new object
+        Save the model instance and its many-to-many relations.
+
+        Raises ``ValueError`` if any submitted M2M id does not resolve, so the
+        form can surface the problem instead of silently dropping selections.
         """
         m2m_fields = self.model.meta.many_to_many
-        m2m_data = {}
-        
-        # Separate M2M data from regular field data
+        m2m_data: Dict[str, Any] = {}
+        related_by_field: Dict[str, List[Any]] = {}
+
         for name, value in form_data.items():
             if name in m2m_fields:
                 m2m_data[name] = value
             else:
                 setattr(obj, name, value)
-        
-        # Save the object first (required for M2M relations)
-        await obj.save()
-        
-        # Now handle M2M relations
+
         for m2m_name, related_ids in m2m_data.items():
-            m2m_manager = getattr(obj, m2m_name)
             related_model = m2m_fields[m2m_name].to_model
-            
-            # Clear existing relations and set new ones
-            await m2m_manager.clear()
-            
-            if related_ids:
-                # Fetch the related objects by IDs
-                related_objects = []
-                for rid in related_ids:
-                    try:
-                        related_obj = await related_model.objects.get(id=rid)
-                        related_objects.append(related_obj)
-                    except Exception:
-                        pass  # Skip invalid IDs
-                
+            related_objects = []
+            missing: List[str] = []
+            for rid in related_ids or []:
+                try:
+                    related_objects.append(await related_model.objects.get(id=rid))
+                except Exception:
+                    missing.append(str(rid))
+            if missing:
+                raise ValueError(
+                    f"{m2m_name}: could not find related "
+                    f"{related_model.__name__} for id(s): {', '.join(missing)}"
+                )
+            related_by_field[m2m_name] = related_objects
+
+        if not m2m_data:
+            await obj.save()
+            return
+
+        from aksara.db.transaction import atomic
+
+        async with atomic():
+            await obj.save()
+            for m2m_name, related_objects in related_by_field.items():
+                m2m_manager = getattr(obj, m2m_name)
+                await m2m_manager.clear()
                 if related_objects:
                     await m2m_manager.add(*related_objects)
-    
+
     async def delete_model(self, request: "Request", obj: "Model") -> None:
-        """
-        Delete the model instance.
-        
-        Override for custom delete behavior.
-        
-        Args:
-            request: The FastAPI Request object
-            obj: The model instance to delete
-        """
+        """Delete the model instance."""
         await obj.delete()

--- a/aksara/contrib/admin/site.py
+++ b/aksara/contrib/admin/site.py
@@ -1,218 +1,234 @@
 """
 Admin Site
 
-Central AdminSite class for managing model registrations.
+Central AdminSite class for managing model registrations and admin-wide
+configuration (branding, theme, access control, custom dashboard).
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Optional, Type
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type
 
 if TYPE_CHECKING:
     from aksara.model.base import Model
     from aksara.contrib.admin.options import ModelAdmin
+    from fastapi import Request
 
 
 class AdminSite:
     """
-    Central admin site managing model registrations.
-    
-    Provides model registration and lookup functionality for the admin interface.
-    
+    Central admin site managing model registrations and presentation.
+
     Usage:
         from aksara.contrib.admin import site, ModelAdmin
         from myapp.models import Article
-        
-        # Simple registration
+
         site.register(Article)
-        
-        # Custom admin class
+
+        @site.register(Article)
         class ArticleAdmin(ModelAdmin):
             list_display = ["title", "author", "created_at"]
-            search_fields = ["title", "body"]
-        
-        site.register(Article, ArticleAdmin)
+
+    A custom site can be created and mounted independently:
+
+        from aksara.contrib.admin import AdminSite, include_admin
+
+        ops = AdminSite(name="ops", site_header="Ops Console")
+        ops.register(Incident)
+        include_admin(app, prefix="/ops", site=ops)
     """
-    
-    def __init__(self, name: str = "admin"):
+
+    def __init__(
+        self,
+        name: str = "admin",
+        *,
+        title: str = "Aksara Admin",
+        site_header: str = "Aksara Admin",
+        index_title: str = "Dashboard",
+        login_url: Optional[str] = None,
+        logout_url: Optional[str] = None,
+        theme: str = "default",
+        index_template: Optional[str] = None,
+        extra_css: Optional[List[str]] = None,
+        permission_classes: Optional[List[Any]] = None,
+    ):
         """
-        Initialize the admin site.
-        
         Args:
-            name: Name identifier for this admin site (default: "admin")
+            name: Identifier for this site (used in route names).
+            title: Browser tab text.
+            site_header: Header shown on every admin page.
+            index_title: Heading on the dashboard.
+            login_url / logout_url: Override auth redirect targets.
+            theme: "default" or "dark".
+            index_template: Custom dashboard template path.
+            extra_css: Additional stylesheet URLs to include.
+            permission_classes: Optional BasePermission list gating site access.
+                When provided, it replaces the default staff-only gate.
         """
         self.name = name
+        self.title = title
+        self.site_header = site_header
+        self.index_title = index_title
+        self.login_url = login_url
+        self.logout_url = logout_url
+        self.theme = theme
+        self.index_template = index_template
+        self.extra_css = list(extra_css or [])
+        self.permission_classes = list(permission_classes or [])
         self._registry: Dict[Type["Model"], "ModelAdmin"] = {}
-    
+        self._index_view_func: Optional[Callable] = None
+
+    # -------------------------------------------------------------------------
+    # Registration
+    # -------------------------------------------------------------------------
+
     def register(
         self,
-        model: Type["Model"],
+        *models: Any,
         admin_class: Optional[Type["ModelAdmin"]] = None,
     ):
         """
-        Register a model with the admin site.
-        
-        Can be used as a direct method call or as a decorator:
-        
-        Direct call (without custom admin):
-            site.register(Book)
-        
-        Direct call (with custom admin):
-            site.register(Book, BookAdmin)
-        
-        As a decorator:
-            @site.register(Book)
-            class BookAdmin(ModelAdmin):
-                list_display = ["title", "author"]
-        
-        Args:
-            model: The Model class to register
-            admin_class: Optional ModelAdmin subclass for customization
-            
-        Returns:
-            When used as a decorator, returns a function that accepts the admin class.
-            When used directly, returns None.
-            
+        Register one or more models with the admin site.
+
+        Direct call:        site.register(Book)
+        With custom admin:  site.register(Book, BookAdmin)
+        As a decorator:     @site.register(Book)
+                            class BookAdmin(ModelAdmin): ...
+        Several models:     @site.register(Post, Draft)
+                            class ContentAdmin(ModelAdmin): ...
+
         Raises:
-            ValueError: If the model is already registered
+            ValueError: If a model is already registered, or no model is given.
         """
+        from aksara.model.base import Model
         from aksara.contrib.admin.options import ModelAdmin as DefaultModelAdmin
-        
-        def decorator(admin_cls: Type["ModelAdmin"]) -> Type["ModelAdmin"]:
-            """Inner decorator that registers the admin class."""
+
+        model_classes: List[Type["Model"]] = []
+        inline_admin: Optional[Type["ModelAdmin"]] = admin_class
+
+        for arg in models:
+            if isinstance(arg, type) and issubclass(arg, DefaultModelAdmin):
+                inline_admin = arg
+            elif isinstance(arg, type) and issubclass(arg, Model):
+                model_classes.append(arg)
+            else:
+                raise TypeError(
+                    f"register() expects Model and ModelAdmin classes, got {arg!r}"
+                )
+
+        if not model_classes:
+            raise ValueError("register() requires at least one model.")
+
+        def _register_one(model: Type["Model"], cls: Type["ModelAdmin"]) -> None:
             if model in self._registry:
                 raise ValueError(f"Model {model.__name__} is already registered.")
-            self._registry[model] = admin_cls(model, self)
-            return admin_cls
-        
-        # If admin_class is provided, register directly
-        if admin_class is not None:
-            if model in self._registry:
-                raise ValueError(f"Model {model.__name__} is already registered.")
-            self._registry[model] = admin_class(model, self)
+            self._registry[model] = cls(model, self)
+
+        if inline_admin is not None:
+            for model in model_classes:
+                _register_one(model, inline_admin)
             return None
-        
-        # Check if this is likely decorator usage (model is actually _just_ a model reference)
-        # Decorator usage: @site.register(MyModel) followed by class definition
-        # Direct usage: site.register(MyModel) as a standalone call
-        # 
-        # The key insight is that when used as @decorator(arg), Python first calls
-        # register(MyModel) which returns the decorator function, then Python calls
-        # that decorator with the class being decorated.
-        #
-        # When used directly as site.register(MyModel), the return value is ignored,
-        # but we still need to register the model with a default admin.
-        #
-        # Unfortunately, we can't distinguish between these at call time.
-        # The solution is to return a decorator that ALSO registers with default
-        # if not called as a decorator within a reasonable time.
-        #
-        # Simpler approach: always return a decorator, but if it's used directly,
-        # it won't matter since the return value is ignored. For direct usage with
-        # default admin, we need to register immediately.
-        
-        # Return a decorator that can be used with @syntax
-        # BUT also register with default admin for direct-call usage compatibility
-        if model in self._registry:
-            raise ValueError(f"Model {model.__name__} is already registered.")
-        
-        # Register with default admin immediately (for direct call usage)
-        self._registry[model] = DefaultModelAdmin(model, self)
-        
-        # Return decorator for @syntax usage (it will re-register, overwriting default)
-        def decorating_register(admin_cls: Type["ModelAdmin"]) -> Type["ModelAdmin"]:
-            """Re-register with the actual admin class when used as decorator."""
-            self._registry[model] = admin_cls(model, self)
+
+        # No admin class yet. Register each model with the default admin now so
+        # direct calls work, and return a decorator that re-registers with the
+        # decorated class for @decorator usage.
+        for model in model_classes:
+            _register_one(model, DefaultModelAdmin)
+
+        def decorator(admin_cls: Type["ModelAdmin"]) -> Type["ModelAdmin"]:
+            for model in model_classes:
+                self._registry[model] = admin_cls(model, self)
             return admin_cls
-        
-        return decorating_register
-    
+
+        return decorator
+
     def unregister(self, model: Type["Model"]) -> None:
-        """
-        Unregister a model from the admin site.
-        
-        Args:
-            model: The Model class to unregister
-        """
+        """Unregister a model from the admin site."""
         self._registry.pop(model, None)
-    
+
     def is_registered(self, model: Type["Model"]) -> bool:
-        """
-        Check if a model is registered.
-        
-        Args:
-            model: The Model class to check
-            
-        Returns:
-            True if the model is registered
-        """
+        """Check if a model is registered."""
         return model in self._registry
-    
+
     @property
     def registry(self) -> Dict[Type["Model"], "ModelAdmin"]:
-        """
-        Get the model registry.
-        
-        Returns:
-            Dictionary mapping Model classes to ModelAdmin instances
-        """
+        """The model registry (Model class -> ModelAdmin instance)."""
         return self._registry
-    
+
     def get_model_admin(self, model: Type["Model"]) -> Optional["ModelAdmin"]:
-        """
-        Get the ModelAdmin for a registered model.
-        
-        Args:
-            model: The Model class to look up
-            
-        Returns:
-            The ModelAdmin instance or None if not registered
-        """
+        """Get the ModelAdmin for a registered model."""
         return self._registry.get(model)
-    
+
     def get_model_by_name(
-        self,
-        app_label: str,
-        model_name: str,
+        self, app_label: str, model_name: str
     ) -> Optional[Type["Model"]]:
-        """
-        Look up a registered model by app_label and model name.
-        
-        Args:
-            app_label: The app_label (from Model.meta.app_label)
-            model_name: The model class name (case-insensitive)
-            
-        Returns:
-            The Model class or None if not found
-        """
+        """Look up a registered model by app_label and model name."""
         model_name_lower = model_name.lower()
-        
         for model in self._registry:
             model_app_label = model.meta.app_label or "default"
-            if model_app_label == app_label and model.__name__.lower() == model_name_lower:
+            if (
+                model_app_label == app_label
+                and model.__name__.lower() == model_name_lower
+            ):
                 return model
-        
         return None
-    
+
     def get_app_list(self) -> Dict[str, list]:
-        """
-        Get models grouped by app_label.
-        
-        Returns:
-            Dictionary mapping app_label to list of Model classes
-        """
+        """Get models grouped by app_label."""
         apps: Dict[str, list] = {}
-        
         for model in self._registry:
             app_label = model.meta.app_label or "default"
             apps.setdefault(app_label, []).append(model)
-        
         return apps
-    
+
     def clear(self) -> None:
-        """
-        Clear all registered models.
-        
-        Useful for testing.
-        """
+        """Clear all registered models (useful for testing)."""
         self._registry.clear()
+
+    # -------------------------------------------------------------------------
+    # Presentation / access
+    # -------------------------------------------------------------------------
+
+    def index_view(self, func: Callable) -> Callable:
+        """
+        Decorator to register a custom dashboard context provider.
+
+        The decorated function receives the request and returns a dict that is
+        merged into the index template context:
+
+            @site.index_view
+            async def dashboard(request):
+                return {"total_users": await User.objects.count()}
+        """
+        self._index_view_func = func
+        return func
+
+    def base_context(self, request: "Request") -> Dict[str, Any]:
+        """Common template context for every admin page (branding/theme)."""
+        return {
+            "site_name": self.site_header,
+            "site_title": self.title,
+            "site_header": self.site_header,
+            "index_title": self.index_title,
+            "admin_theme": self.theme,
+            "extra_css": self.extra_css,
+        }
+
+    def check_site_permission(
+        self, request: "Request"
+    ) -> Tuple[bool, Optional[str]]:
+        """
+        Evaluate site-level access.
+
+        Returns (allowed, message). When ``permission_classes`` is set it is the
+        authority; otherwise access requires an authenticated staff user.
+        """
+        if self.permission_classes:
+            from aksara.permissions import check_permissions
+
+            return check_permissions(self.permission_classes, request)
+
+        user = getattr(request.state, "user", None)
+        if user and getattr(user, "is_staff", False):
+            return True, None
+        return False, "Admin access forbidden. Staff access required."

--- a/aksara/contrib/admin/templates/admin/app_index.html
+++ b/aksara/contrib/admin/templates/admin/app_index.html
@@ -1,10 +1,10 @@
 {% extends "admin/base_new.html" %}
 
-{% block title %}{{ app_label }} - {{ site_name }}{% endblock %}
+{% block title %}{{ app_label }} - {{ site_title }}{% endblock %}
 
 {% block breadcrumb %}
 <nav class="admin-breadcrumb" aria-label="Breadcrumb">
-    <a href="{{ request.url_for('admin:index') }}" class="breadcrumb-link">Home</a>
+    <a href="{{ request.url_for(url_namespace ~ ':index') }}" class="breadcrumb-link">Home</a>
     <span class="breadcrumb-separator">
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <path d="m9 18 6-6-6-6"/>
@@ -26,7 +26,7 @@
     <ul class="model-list">
         {% for model in models %}
         <li class="model-item">
-            <a href="{{ request.url_for('admin:model_list', app_label=app_label, model_name=model.__name__|lower) }}" class="model-link">
+            <a href="{{ request.url_for(url_namespace ~ ':model_list', app_label=app_label, model_name=model.__name__|lower) }}" class="model-link">
                 <svg class="model-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
                     <path d="M3 9h18M9 21V9"/>

--- a/aksara/contrib/admin/templates/admin/base.html
+++ b/aksara/contrib/admin/templates/admin/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}{{ site_name }}{% endblock %}</title>
+    <title>{% block title %}{{ site_title }}{% endblock %}</title>
     <style>
         * {
             margin: 0;
@@ -617,13 +617,13 @@
             <svg class="logo" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon>
             </svg>
-            <a href="{{ request.url_for('admin:index') }}">{{ site_name }}</a>
+            <a href="{{ request.url_for(url_namespace ~ ':index') }}">{{ site_name }}</a>
             {% if debug %}<span class="debug-badge">DEBUG</span>{% endif %}
         </div>
         <div class="admin-user">
             {% if user %}
                 <span>{{ user.email or user.id }}</span>
-                <form method="post" action="{{ request.url_for('admin:logout') }}" style="display: inline; margin: 0;">
+                <form method="post" action="{{ request.url_for(url_namespace ~ ':logout') }}" style="display: inline; margin: 0;">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <button type="submit" class="logout-link" style="background: none; border: 0; padding: 0; cursor: pointer;">Logout</button>
                 </form>

--- a/aksara/contrib/admin/templates/admin/base_new.html
+++ b/aksara/contrib/admin/templates/admin/base_new.html
@@ -1,13 +1,16 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="en" data-theme="{{ 'dark' if admin_theme == 'dark' else 'light' }}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}{{ site_name }}{% endblock %}</title>
+    <title>{% block title %}{{ site_title }}{% endblock %}</title>
     
     <!-- Modern Admin CSS -->
     <link rel="stylesheet" href="/static/admin/css/admin.css">
     
+    {% for css_href in extra_css %}
+    <link rel="stylesheet" href="{{ css_href }}">
+    {% endfor %}
     {% block extra_css %}{% endblock %}
 </head>
 <body>
@@ -15,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="admin-sidebar" id="adminSidebar">
             <!-- Brand -->
-            <a href="{{ request.url_for('admin:index') }}" class="sidebar-brand">
+            <a href="{{ request.url_for(url_namespace ~ ':index') }}" class="sidebar-brand">
                 <div class="sidebar-brand-icon">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="100%" height="100%">
                         <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon>
@@ -31,7 +34,7 @@
                     <div class="sidebar-section-title">Dashboard</div>
                     <ul class="sidebar-menu">
                         <li class="sidebar-menu-item">
-                            <a href="{{ request.url_for('admin:index') }}" class="sidebar-menu-link active">
+                            <a href="{{ request.url_for(url_namespace ~ ':index') }}" class="sidebar-menu-link active">
                                 <svg class="sidebar-menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                     <path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
                                 </svg>
@@ -48,7 +51,7 @@
                         {% for app_label, models in apps.items() %}
                             {% for model in models %}
                             <li class="sidebar-menu-item">
-                                <a href="{{ request.url_for('admin:model_list', app_label=app_label, model_name=model.__name__|lower) }}" 
+                                <a href="{{ request.url_for(url_namespace ~ ':model_list', app_label=app_label, model_name=model.__name__|lower) }}" 
                                    class="sidebar-menu-link">
                                     <svg class="sidebar-menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                         <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
@@ -126,7 +129,7 @@
                             {% if user.email %}{{ user.email[0]|upper }}{% else %}{{ (user.id|string)[0]|upper }}{% endif %}
                         </div>
                         <span>{{ user.email or user.id }}</span>
-                        <form method="post" action="{{ request.url_for('admin:logout') }}" style="display: inline; margin: 0;">
+                        <form method="post" action="{{ request.url_for(url_namespace ~ ':logout') }}" style="display: inline; margin: 0;">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                             <button type="submit" class="btn btn-sm btn-ghost">Logout</button>
                         </form>
@@ -142,7 +145,7 @@
                 {% block messages %}
                 {% if messages %}
                     {% for message in messages %}
-                    <div class="alert alert-{{ message.type }}">
+                    <div class="alert {{ message.alert_class }}">
                         {{ message.text }}
                     </div>
                     {% endfor %}

--- a/aksara/contrib/admin/templates/admin/index.html
+++ b/aksara/contrib/admin/templates/admin/index.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_new.html" %}
 
-{% block title %}Dashboard - {{ site_name }}{% endblock %}
+{% block title %}{{ index_title }} - {{ site_title }}{% endblock %}
 
 {% block breadcrumb %}
 <nav class="admin-breadcrumb" aria-label="Breadcrumb">
@@ -11,7 +11,7 @@
 {% block content %}
 <div class="page-header">
     <div class="page-header-content">
-        <h1>Admin Dashboard</h1>
+        <h1>{{ index_title }}</h1>
         <p class="page-subtitle text-muted">Manage your application data</p>
     </div>
 </div>
@@ -32,7 +32,7 @@
                 <ul class="model-list">
                     {% for model in models %}
                     <li class="model-item">
-                        <a href="{{ request.url_for('admin:model_list', app_label=app_label, model_name=model.__name__|lower) }}" class="model-link">
+                        <a href="{{ request.url_for(url_namespace ~ ':model_list', app_label=app_label, model_name=model.__name__|lower) }}" class="model-link">
                             <svg class="model-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                 <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
                                 <path d="M3 9h18M9 21V9"/>

--- a/aksara/contrib/admin/templates/admin/login.html
+++ b/aksara/contrib/admin/templates/admin/login.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Login | {{ site_name }}</title>
+    <title>Login | {{ site_title }}</title>
     <style>
         * {
             margin: 0;
@@ -366,7 +366,7 @@
             </div>
             {% endif %}
             
-            <form method="POST" action="{{ request.url_for('admin:login') }}">
+            <form method="POST" action="{{ request.url_for(url_namespace ~ ':login') }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <div class="form-group">
                     <label for="username" class="form-label">Email Address</label>

--- a/aksara/contrib/admin/templates/admin/model_form.html
+++ b/aksara/contrib/admin/templates/admin/model_form.html
@@ -1,27 +1,15 @@
 {% extends "admin/base_new.html" %}
 
-{% block title %}{% if is_add %}Add{% else %}Change{% endif %} {{ model_name }} - {{ site_name }}{% endblock %}
+{% block title %}{% if is_add %}Add{% else %}Change{% endif %} {{ model_name }} - {{ site_title }}{% endblock %}
 
 {% block breadcrumb %}
 <nav class="admin-breadcrumb" aria-label="Breadcrumb">
-    <a href="{{ request.url_for('admin:index') }}" class="breadcrumb-link">Home</a>
-    <span class="breadcrumb-separator">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="m9 18 6-6-6-6"/>
-        </svg>
-    </span>
-    <a href="{{ request.url_for('admin:app_index', app_label=app_label) }}" class="breadcrumb-link">{{ app_label }}</a>
-    <span class="breadcrumb-separator">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="m9 18 6-6-6-6"/>
-        </svg>
-    </span>
-    <a href="{{ request.url_for('admin:model_list', app_label=app_label, model_name=model_name|lower) }}" class="breadcrumb-link">{{ model_name }}</a>
-    <span class="breadcrumb-separator">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="m9 18 6-6-6-6"/>
-        </svg>
-    </span>
+    <a href="{{ request.url_for(url_namespace ~ ':index') }}" class="breadcrumb-link">Home</a>
+    <span class="breadcrumb-separator">/</span>
+    <a href="{{ request.url_for(url_namespace ~ ':app_index', app_label=app_label) }}" class="breadcrumb-link">{{ app_label }}</a>
+    <span class="breadcrumb-separator">/</span>
+    <a href="{{ request.url_for(url_namespace ~ ':model_list', app_label=app_label, model_name=model_name|lower) }}" class="breadcrumb-link">{{ model_name }}</a>
+    <span class="breadcrumb-separator">/</span>
     <span class="breadcrumb-current">{% if is_add %}Add{% else %}Edit{% endif %}</span>
 </nav>
 {% endblock %}
@@ -38,160 +26,75 @@
 
 {% if errors and errors.__all__ %}
 <div class="alert alert-danger">
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <circle cx="12" cy="12" r="10"/>
-        <line x1="12" y1="8" x2="12" y2="12"/>
-        <line x1="12" y1="16" x2="12.01" y2="16"/>
-    </svg>
     <span>{{ errors.__all__ }}</span>
 </div>
 {% endif %}
 
 <div class="card form-card">
-    <form method="post" class="admin-form">
+    <form method="post" class="admin-form" id="admin-model-form">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-        <div class="form-body">
-            {% for field in fields %}
-            <div class="form-group {% if errors and field.name in errors %}has-error{% endif %}">
-                <label for="{{ field.name }}" class="form-label">
-                    {{ field.label }}
-                    {% if field.required %}<span class="required-indicator">*</span>{% endif %}
-                </label>
-                
-                {% if field.widget_html %}
-                    {# Use custom widget HTML if provided #}
-                    {{ field.widget_html|safe }}
-                {% elif field.type == "checkbox" %}
-                    <div class="checkbox-wrapper">
-                        <input 
-                            type="checkbox" 
-                            id="{{ field.name }}" 
-                            name="{{ field.name }}"
-                            {% if field.value %}checked{% endif %}
-                            {% if field.readonly %}disabled{% endif %}
-                            class="form-checkbox"
-                        >
-                        <label for="{{ field.name }}" class="checkbox-label">{{ field.help_text or 'Enabled' }}</label>
-                    </div>
-                {% elif field.type == "textarea" %}
-                    <textarea 
-                        id="{{ field.name }}" 
-                        name="{{ field.name }}" 
-                        class="form-input form-textarea"
-                        {% if field.readonly %}readonly{% endif %}
-                        {% if field.required %}required{% endif %}
-                        rows="{{ field.rows|default(5) }}"
-                        placeholder="{% if field.help_text %}{{ field.help_text }}{% endif %}"
-                    >{{ field.value }}</textarea>
-                    {% if field.help_text %}
-                    <small class="form-help">{{ field.help_text }}</small>
+
+        {% for section in fieldsets %}
+        <fieldset class="form-fieldset {% if 'collapse' in section.classes %}is-collapsible{% endif %}">
+            {% if section.title %}
+            <legend class="form-fieldset-title">{{ section.title }}</legend>
+            {% endif %}
+            {% if section.description %}
+            <p class="form-fieldset-description">{{ section.description }}</p>
+            {% endif %}
+            <div class="form-body">
+                {% for field in section.fields %}
+                <div class="form-group {% if errors and field.name in errors %}has-error{% endif %}">
+                    <label for="{{ field.name }}" class="form-label">
+                        {{ field.label }}
+                        {% if field.required %}<span class="required-indicator">*</span>{% endif %}
+                    </label>
+
+                    {% if field.widget_html %}
+                        {{ field.widget_html|safe }}
+                    {% elif field.type == "checkbox" %}
+                        <div class="checkbox-wrapper">
+                            <input type="checkbox" id="{{ field.name }}" name="{{ field.name }}" {% if field.value %}checked{% endif %} {% if field.readonly %}disabled{% endif %} class="form-checkbox">
+                        </div>
+                    {% elif field.type == "textarea" %}
+                        <textarea id="{{ field.name }}" name="{{ field.name }}" class="form-input form-textarea" {% if field.readonly %}readonly{% endif %} {% if field.required %}required{% endif %} rows="5">{{ field.value }}</textarea>
+                    {% elif field.type == "select" %}
+                        <select id="{{ field.name }}" name="{{ field.name }}" class="form-input form-select" {% if field.readonly %}disabled{% endif %} {% if field.required %}required{% endif %}>
+                            <option value="">Select {{ field.label }}...</option>
+                            {% for choice_value, choice_label in field.choices %}
+                            <option value="{{ choice_value }}" {% if field.value == choice_value %}selected{% endif %}>{{ choice_label }}</option>
+                            {% endfor %}
+                        </select>
+                    {% elif field.type == "multiselect" %}
+                        <select id="{{ field.name }}" name="{{ field.name }}" class="form-input form-select multiselect" multiple {% if field.readonly %}disabled{% endif %}>
+                            {% for choice_value, choice_label in field.choices %}
+                            <option value="{{ choice_value }}" {% if choice_value in field.value %}selected{% endif %}>{{ choice_label }}</option>
+                            {% endfor %}
+                        </select>
+                        <small class="form-help">Hold Ctrl/Cmd to select multiple items</small>
+                    {% else %}
+                        <input type="{{ field.type }}" id="{{ field.name }}" name="{{ field.name }}" value="{{ field.value }}" class="form-input" {% if field.readonly %}readonly{% endif %} {% if field.required %}required{% endif %} {% if field.type == "number" %}step="any"{% endif %}>
                     {% endif %}
-                {% elif field.type == "select" %}
-                    <select
-                        id="{{ field.name }}"
-                        name="{{ field.name }}"
-                        class="form-input form-select"
-                        {% if field.readonly %}disabled{% endif %}
-                        {% if field.required %}required{% endif %}
-                    >
-                        <option value="">Select {{ field.label }}...</option>
-                        {% for choice_value, choice_label in field.choices %}
-                        <option value="{{ choice_value }}" {% if field.value == choice_value %}selected{% endif %}>
-                            {{ choice_label }}
-                        </option>
-                        {% endfor %}
-                    </select>
-                    {% if field.help_text %}
-                    <small class="form-help">{{ field.help_text }}</small>
+
+                    {% if errors and field.name in errors %}
+                    <div class="form-error">{{ errors[field.name] }}</div>
                     {% endif %}
-                {% elif field.type == "multiselect" %}
-                    <select
-                        id="{{ field.name }}"
-                        name="{{ field.name }}"
-                        class="form-input form-select multiselect"
-                        multiple
-                        {% if field.readonly %}disabled{% endif %}
-                    >
-                        {% for choice_value, choice_label in field.choices %}
-                        <option value="{{ choice_value }}" {% if choice_value in field.value %}selected{% endif %}>
-                            {{ choice_label }}
-                        </option>
-                        {% endfor %}
-                    </select>
-                    <small class="form-help">
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <circle cx="12" cy="12" r="10"/>
-                            <line x1="12" y1="16" x2="12" y2="12"/>
-                            <line x1="12" y1="8" x2="12.01" y2="8"/>
-                        </svg>
-                        Hold Ctrl/Cmd to select multiple items
-                    </small>
-                {% else %}
-                    <input 
-                        type="{{ field.type }}" 
-                        id="{{ field.name }}" 
-                        name="{{ field.name }}" 
-                        value="{{ field.value }}"
-                        class="form-input"
-                        {% if field.readonly %}readonly{% endif %}
-                        {% if field.required %}required{% endif %}
-                        {% if field.type == "number" %}step="any"{% endif %}
-                        {% if field.help_text and field.type == "text" %}placeholder="{{ field.help_text }}"{% endif %}
-                    >
-                    {% if field.help_text and field.type != "text" %}
-                    <small class="form-help">{{ field.help_text }}</small>
-                    {% endif %}
-                {% endif %}
-                
-                {% if errors and field.name in errors %}
-                <div class="form-error">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <circle cx="12" cy="12" r="10"/>
-                        <line x1="12" y1="8" x2="12" y2="12"/>
-                        <line x1="12" y1="16" x2="12.01" y2="16"/>
-                    </svg>
-                    {{ errors[field.name] }}
                 </div>
-                {% endif %}
+                {% endfor %}
             </div>
-            {% endfor %}
-        </div>
-        
+        </fieldset>
+        {% endfor %}
+
         <div class="form-actions sticky-actions">
             <div class="form-actions-left">
-                <button type="submit" class="btn btn-primary">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
-                        <polyline points="17 21 17 13 7 13 7 21"/>
-                        <polyline points="7 3 7 8 15 8"/>
-                    </svg>
-                    {% if is_add %}Create{% else %}Save{% endif %}
-                </button>
-                <a href="{{ request.url_for('admin:model_list', app_label=app_label, model_name=model_name|lower) }}" class="btn btn-ghost">
-                    Cancel
-                </a>
+                <button type="submit" class="btn btn-primary">{% if is_add %}Create{% else %}Save{% endif %}</button>
+                <a href="{{ request.url_for(url_namespace ~ ':model_list', app_label=app_label, model_name=model_name|lower) }}" class="btn btn-ghost">Cancel</a>
             </div>
-            
-            {% if not is_add and can_delete %}
-            <div class="form-actions-right">
-                <button 
-                    type="button" 
-                    class="btn btn-danger-outline"
-                    onclick="if(confirm('Are you sure you want to delete this {{ model_name }}?')) { document.getElementById('delete-form').submit(); }"
-                >
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <polyline points="3 6 5 6 21 6"/>
-                        <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
-                    </svg>
-                    Delete
-                </button>
-            </div>
-            {% endif %}
         </div>
     </form>
-    
+
     {% if not is_add and can_delete %}
-    <form id="delete-form" method="post" action="{{ request.url_for('admin:model_delete', app_label=app_label, model_name=model_name|lower, pk=obj.id|string) }}" style="display: none;">
+    <form id="delete-form" method="post" action="{{ request.url_for(url_namespace ~ ':model_delete', app_label=app_label, model_name=model_name|lower, pk=obj.id|string) }}" style="display: none;">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
     </form>
     {% endif %}
@@ -199,32 +102,45 @@
 
 {% if not is_add and can_delete %}
 <div class="card danger-zone">
-    <div class="danger-zone-header">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
-            <line x1="12" y1="9" x2="12" y2="13"/>
-            <line x1="12" y1="17" x2="12.01" y2="17"/>
-        </svg>
-        <h2>Danger Zone</h2>
-    </div>
-    <p class="text-muted">
-        Permanently delete this {{ model_name }}. This action cannot be undone.
-    </p>
-    <form method="post" action="{{ request.url_for('admin:model_delete', app_label=app_label, model_name=model_name|lower, pk=obj.id|string) }}">
+    <h2>Danger Zone</h2>
+    <p class="text-muted">Permanently delete this {{ model_name }}. This action cannot be undone.</p>
+    <form method="post" action="{{ request.url_for(url_namespace ~ ':model_delete', app_label=app_label, model_name=model_name|lower, pk=obj.id|string) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-        <button 
-            type="submit" 
-            class="btn btn-danger" 
-            onclick="return confirm('Are you sure you want to delete this {{ model_name }}? This action cannot be undone.')"
-        >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <polyline points="3 6 5 6 21 6"/>
-                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
-            </svg>
-            Delete {{ model_name }}
-        </button>
+        <button type="submit" class="btn btn-danger" onclick="return confirm('Delete this {{ model_name }}? This cannot be undone.')">Delete {{ model_name }}</button>
     </form>
 </div>
 {% endif %}
 
+{% if prepopulated %}
+<script>
+(function () {
+    var config = {{ prepopulated|tojson }};
+    function slugify(value) {
+        return value.toString().toLowerCase().trim()
+            .replace(/[^a-z0-9\s-]/g, '')
+            .replace(/[\s_-]+/g, '-')
+            .replace(/^-+|-+$/g, '');
+    }
+    Object.keys(config).forEach(function (target) {
+        var targetEl = document.getElementById(target);
+        if (!targetEl) return;
+        var sources = config[target];
+        var edited = false;
+        targetEl.addEventListener('input', function () { edited = true; });
+        function recompute() {
+            if (edited) return;
+            var parts = sources.map(function (name) {
+                var el = document.getElementById(name);
+                return el ? el.value : '';
+            }).filter(Boolean);
+            targetEl.value = slugify(parts.join(' '));
+        }
+        sources.forEach(function (name) {
+            var el = document.getElementById(name);
+            if (el) el.addEventListener('input', recompute);
+        });
+    });
+})();
+</script>
+{% endif %}
 {% endblock %}

--- a/aksara/contrib/admin/templates/admin/model_list.html
+++ b/aksara/contrib/admin/templates/admin/model_list.html
@@ -1,21 +1,13 @@
 {% extends "admin/base_new.html" %}
 
-{% block title %}{{ model_name }} - {{ site_name }}{% endblock %}
+{% block title %}{{ model_name }} - {{ site_title }}{% endblock %}
 
 {% block breadcrumb %}
 <nav class="admin-breadcrumb" aria-label="Breadcrumb">
-    <a href="{{ request.url_for('admin:index') }}" class="breadcrumb-link">Home</a>
-    <span class="breadcrumb-separator">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="m9 18 6-6-6-6"/>
-        </svg>
-    </span>
-    <a href="{{ request.url_for('admin:app_index', app_label=app_label) }}" class="breadcrumb-link">{{ app_label }}</a>
-    <span class="breadcrumb-separator">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="m9 18 6-6-6-6"/>
-        </svg>
-    </span>
+    <a href="{{ request.url_for(url_namespace ~ ':index') }}" class="breadcrumb-link">Home</a>
+    <span class="breadcrumb-separator">/</span>
+    <a href="{{ request.url_for(url_namespace ~ ':app_index', app_label=app_label) }}" class="breadcrumb-link">{{ app_label }}</a>
+    <span class="breadcrumb-separator">/</span>
     <span class="breadcrumb-current">{{ model_name }}</span>
 </nav>
 {% endblock %}
@@ -24,18 +16,12 @@
 <div class="page-header">
     <div class="page-header-content">
         <h1>{{ model_name }}</h1>
-        {% if objects %}
-        <span class="badge badge-secondary">{{ objects|length }} record{% if objects|length != 1 %}s{% endif %}</span>
-        {% endif %}
+        <span class="badge badge-secondary">{{ pagination.total }} record{% if pagination.total != 1 %}s{% endif %}</span>
     </div>
     <div class="page-actions">
         {% if can_add %}
-        <a href="{{ request.url_for('admin:model_add', app_label=app_label, model_name=model_name|lower) }}" class="btn btn-primary">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <line x1="12" y1="5" x2="12" y2="19"/>
-                <line x1="5" y1="12" x2="19" y2="12"/>
-            </svg>
-            Add {{ model_name }}
+        <a href="{{ request.url_for(url_namespace ~ ':model_add', app_label=app_label, model_name=model_name|lower) }}" class="btn btn-primary">
+            + Add {{ model_name }}
         </a>
         {% endif %}
     </div>
@@ -45,134 +31,170 @@
 <div class="card search-card">
     <form method="get" class="search-form">
         <div class="search-input-group">
-            <svg class="search-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <circle cx="11" cy="11" r="8"/>
-                <path d="m21 21-4.35-4.35"/>
-            </svg>
-            <input 
-                type="search" 
-                name="q" 
-                value="{{ search_query }}" 
-                placeholder="Search {{ model_name }}..." 
-                class="form-input search-input"
-            >
+            <input type="search" name="q" value="{{ search_query }}" placeholder="Search {{ model_name }}..." class="form-input search-input">
             <button type="submit" class="btn btn-primary">Search</button>
             {% if search_query %}
-            <a href="{{ request.url_for('admin:model_list', app_label=app_label, model_name=model_name|lower) }}" class="btn btn-ghost">Clear</a>
+            <a href="{{ clear_url }}" class="btn btn-ghost">Clear</a>
             {% endif %}
         </div>
     </form>
 </div>
 {% endif %}
 
-{% if search_query %}
-<div class="alert alert-info">
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <circle cx="12" cy="12" r="10"/>
-        <line x1="12" y1="16" x2="12" y2="12"/>
-        <line x1="12" y1="8" x2="12.01" y2="8"/>
-    </svg>
-    <span>Showing {{ objects|length }} result{% if objects|length != 1 %}s{% endif %} for "{{ search_query }}"</span>
-</div>
-{% endif %}
+<div class="admin-list-layout">
+    <div class="admin-list-main">
+        <div class="card" style="padding: 0; overflow: hidden;">
+            {% if rows %}
+            <form method="post" action="{{ request.url.path }}" class="admin-actions-form">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                {% if actions %}
+                <div class="admin-actions-bar">
+                    <label for="action-select" class="sr-only">Action</label>
+                    <select name="action" id="action-select" class="form-input form-select">
+                        <option value="">— Action —</option>
+                        {% for act in actions %}
+                        <option value="{{ act.name }}">{{ act.description }}</option>
+                        {% endfor %}
+                    </select>
+                    <button type="submit" class="btn btn-secondary">Go</button>
+                    <span class="admin-actions-hint" data-selected-count>0 selected</span>
+                </div>
+                {% endif %}
 
-<div class="card" style="padding: 0; overflow: hidden;">
-    {% if objects %}
-    <div class="table-responsive">
-        <table class="data-table">
-            <thead>
-                <tr>
-                    {% for field_name in list_display %}
-                    <th>{{ field_name.replace('_', ' ').title() }}</th>
-                    {% endfor %}
-                    <th class="actions-column">Actions</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for row in objects %}
-                <tr>
-                    {% for value in row["values"] %}
-                    <td>
-                        {% if loop.first %}
-                        <a href="{{ request.url_for('admin:model_change', app_label=app_label, model_name=model_name|lower, pk=row['obj'].id|string) }}" class="table-link-primary">
-                            {{ value if value and value != '-' else '—' }}
-                        </a>
-                        {% elif value == '✓' %}
-                        <span class="value-badge value-badge-success">
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
-                                <polyline points="20 6 9 17 4 12"/>
-                            </svg>
-                            Yes
-                        </span>
-                        {% elif value == '✗' %}
-                        <span class="value-badge value-badge-danger">
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
-                                <line x1="18" y1="6" x2="6" y2="18"/>
-                                <line x1="6" y1="6" x2="18" y2="18"/>
-                            </svg>
-                            No
-                        </span>
-                        {% elif value == '-' or not value %}
-                        <span class="value-null">—</span>
-                        {% elif value and '...' in value|string and value|string|length <= 12 %}
-                        <code class="value-code">{{ value }}</code>
-                        {% else %}
-                        {{ value }}
-                        {% endif %}
-                    </td>
-                    {% endfor %}
-                    <td class="actions-cell">
-                        <a href="{{ request.url_for('admin:model_change', app_label=app_label, model_name=model_name|lower, pk=row['obj'].id|string) }}" 
-                           class="btn btn-sm btn-ghost" title="Edit">
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
-                                <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
-                            </svg>
-                            Edit
-                        </a>
-                    </td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
-    {% else %}
-    <div class="empty-state">
-        {% if search_query %}
-        <div class="empty-state-icon">
-            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                <circle cx="11" cy="11" r="8"/>
-                <path d="m21 21-4.35-4.35"/>
-                <line x1="8" y1="8" x2="14" y2="14"/>
-                <line x1="14" y1="8" x2="8" y2="14"/>
-            </svg>
+                <div class="table-responsive">
+                    <table class="data-table">
+                        <thead>
+                            <tr>
+                                {% if actions %}
+                                <th class="select-column"><input type="checkbox" data-select-all aria-label="Select all"></th>
+                                {% endif %}
+                                {% for header in list_headers %}
+                                <th>
+                                    {% if header.sort_url %}
+                                    <a href="{{ header.sort_url }}" class="sortable-header">
+                                        {{ header.label }}{% if header.sort_dir == 'asc' %} ▲{% elif header.sort_dir == 'desc' %} ▼{% endif %}
+                                    </a>
+                                    {% else %}
+                                    {{ header.label }}
+                                    {% endif %}
+                                </th>
+                                {% endfor %}
+                                <th class="actions-column">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in rows %}
+                            <tr>
+                                {% if actions %}
+                                <td class="select-column"><input type="checkbox" name="_selected" value="{{ row.obj.id }}" data-row-select></td>
+                                {% endif %}
+                                {% for cell in row.cells %}
+                                <td>
+                                    {% if cell.is_link %}
+                                    <a href="{{ request.url_for(url_namespace ~ ':model_change', app_label=app_label, model_name=model_name|lower, pk=row.obj.id|string) }}" class="table-link-primary">
+                                        {% if cell.is_html %}{{ cell.value|safe }}{% else %}{{ cell.value if cell.value and cell.value != '-' else '—' }}{% endif %}
+                                    </a>
+                                    {% elif cell.is_html %}
+                                    {{ cell.value|safe }}
+                                    {% elif cell.value == '✓' %}
+                                    <span class="value-badge value-badge-success">Yes</span>
+                                    {% elif cell.value == '✗' %}
+                                    <span class="value-badge value-badge-danger">No</span>
+                                    {% elif cell.value == '-' or not cell.value %}
+                                    <span class="value-null">—</span>
+                                    {% else %}
+                                    {{ cell.value }}
+                                    {% endif %}
+                                </td>
+                                {% endfor %}
+                                <td class="actions-cell">
+                                    <a href="{{ request.url_for(url_namespace ~ ':model_change', app_label=app_label, model_name=model_name|lower, pk=row.obj.id|string) }}" class="btn btn-sm btn-ghost">Edit</a>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </form>
+            {% else %}
+            <div class="empty-state">
+                {% if search_query %}
+                <h3>No results found</h3>
+                <p class="text-muted">No {{ model_name }} objects match "{{ search_query }}".</p>
+                <a href="{{ clear_url }}" class="btn btn-secondary">Clear Search</a>
+                {% else %}
+                <h3>No {{ model_name }} objects yet</h3>
+                <p class="text-muted">Get started by creating your first {{ model_name }}.</p>
+                {% if can_add %}
+                <a href="{{ request.url_for(url_namespace ~ ':model_add', app_label=app_label, model_name=model_name|lower) }}" class="btn btn-primary">+ Add {{ model_name }}</a>
+                {% endif %}
+                {% endif %}
+            </div>
+            {% endif %}
         </div>
-        <h3>No results found</h3>
-        <p class="text-muted">No {{ model_name }} objects match "{{ search_query }}".</p>
-        <a href="{{ request.url_for('admin:model_list', app_label=app_label, model_name=model_name|lower) }}" class="btn btn-secondary">
-            Clear Search
-        </a>
-        {% else %}
-        <div class="empty-state-icon">
-            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
-                <line x1="3" y1="9" x2="21" y2="9"/>
-                <line x1="9" y1="21" x2="9" y2="9"/>
-            </svg>
+
+        {% if pagination.num_pages > 1 or pagination.show_all %}
+        <div class="admin-pagination">
+            <div class="admin-pagination-info">
+                {% if pagination.show_all %}
+                Showing all {{ pagination.total }}
+                {% else %}
+                Page {{ pagination.page }} of {{ pagination.num_pages }} ({{ pagination.total }} total)
+                {% endif %}
+            </div>
+            <div class="admin-pagination-controls">
+                {% if pagination.has_prev %}
+                <a href="{{ pagination.prev_url }}" class="btn btn-sm btn-ghost">‹ Prev</a>
+                {% endif %}
+                {% if pagination.has_next %}
+                <a href="{{ pagination.next_url }}" class="btn btn-sm btn-ghost">Next ›</a>
+                {% endif %}
+                {% if pagination.show_all_url %}
+                <a href="{{ pagination.show_all_url }}" class="btn btn-sm btn-ghost">Show all</a>
+                {% endif %}
+            </div>
         </div>
-        <h3>No {{ model_name }} objects yet</h3>
-        <p class="text-muted">Get started by creating your first {{ model_name }}.</p>
-        {% if can_add %}
-        <a href="{{ request.url_for('admin:model_add', app_label=app_label, model_name=model_name|lower) }}" class="btn btn-primary">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <line x1="12" y1="5" x2="12" y2="19"/>
-                <line x1="5" y1="12" x2="19" y2="12"/>
-            </svg>
-            Add {{ model_name }}
-        </a>
-        {% endif %}
         {% endif %}
     </div>
+
+    {% if filters %}
+    <aside class="admin-list-filters">
+        <div class="card">
+            <h3 class="filter-heading">Filters</h3>
+            {% for filter in filters %}
+            <div class="filter-group">
+                <div class="filter-group-title">{{ filter.title }}</div>
+                <ul class="filter-options">
+                    {% for choice in filter.choices %}
+                    <li class="filter-option {% if choice.selected %}is-selected{% endif %}">
+                        <a href="{{ choice.url }}">{{ choice.label }}</a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endfor %}
+        </div>
+    </aside>
     {% endif %}
 </div>
+
+<script>
+(function () {
+    var selectAll = document.querySelector('[data-select-all]');
+    var rowBoxes = Array.prototype.slice.call(document.querySelectorAll('[data-row-select]'));
+    var counter = document.querySelector('[data-selected-count]');
+    function updateCount() {
+        if (!counter) return;
+        var n = rowBoxes.filter(function (b) { return b.checked; }).length;
+        counter.textContent = n + ' selected';
+    }
+    if (selectAll) {
+        selectAll.addEventListener('change', function () {
+            rowBoxes.forEach(function (b) { b.checked = selectAll.checked; });
+            updateCount();
+        });
+    }
+    rowBoxes.forEach(function (b) { b.addEventListener('change', updateCount); });
+})();
+</script>
 {% endblock %}

--- a/aksara/contrib/admin/urls.py
+++ b/aksara/contrib/admin/urls.py
@@ -1,11 +1,16 @@
 """
 Admin URL Router
 
-Defines routes for the admin interface.
+Builds the route table for an admin site. Each site gets its own router whose
+route names are namespaced by ``site.name`` (e.g. ``admin:index``), so multiple
+admin sites can be mounted on one app without route-name collisions.
 """
 
-import os
-from fastapi import APIRouter
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Request
 
 from aksara.contrib.admin.views import (
     admin_index,
@@ -18,67 +23,101 @@ from aksara.contrib.admin.views import (
     model_delete,
 )
 
-# Create the admin router
-router = APIRouter(tags=["Admin"])
+if TYPE_CHECKING:
+    from aksara.contrib.admin.site import AdminSite
 
-# Note: Admin static files are mounted at the app level in include_admin()
-# so templates can reference /static/admin/... regardless of admin prefix.
 
-# Auth routes (must be before the catch-all routes)
-router.add_api_route(
-    "/login/",
-    admin_login,
-    methods=["GET", "POST"],
-    name="admin:login",
-)
+def _normalise_cookie_path(prefix: str) -> str:
+    """Return a stable cookie path for an admin router prefix."""
+    path = (prefix or "/admin").strip() or "/admin"
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return path.rstrip("/") or "/"
 
-router.add_api_route(
-    "/logout/",
-    admin_logout,
-    methods=["POST"],
-    name="admin:logout",
-)
 
-# Index routes
-router.add_api_route(
-    "/",
-    admin_index,
-    methods=["GET"],
-    name="admin:index",
-)
+def build_admin_router(site: "AdminSite", prefix: str = "/admin") -> APIRouter:
+    """Create an APIRouter bound to ``site`` with namespaced route names."""
+    router = APIRouter(tags=["Admin"])
+    ns = site.name
+    csrf_cookie_path = _normalise_cookie_path(prefix)
 
-router.add_api_route(
-    "/{app_label}/",
-    app_index,
-    methods=["GET"],
-    name="admin:app_index",
-)
+    def bind_request(request: Request) -> None:
+        request.state.admin_csrf_cookie_path = csrf_cookie_path
 
-# Model CRUD routes
-router.add_api_route(
-    "/{app_label}/{model_name}/",
-    model_list,
-    methods=["GET"],
-    name="admin:model_list",
-)
+    async def login_view(request: Request):
+        bind_request(request)
+        return await admin_login(request, site)
 
-router.add_api_route(
-    "/{app_label}/{model_name}/add/",
-    model_add,
-    methods=["GET", "POST"],
-    name="admin:model_add",
-)
+    async def logout_view(request: Request):
+        bind_request(request)
+        return await admin_logout(request, site)
 
-router.add_api_route(
-    "/{app_label}/{model_name}/{pk}/change/",
-    model_change,
-    methods=["GET", "POST"],
-    name="admin:model_change",
-)
+    async def index_view(request: Request):
+        bind_request(request)
+        return await admin_index(request, site)
 
-router.add_api_route(
-    "/{app_label}/{model_name}/{pk}/delete/",
-    model_delete,
-    methods=["POST"],
-    name="admin:model_delete",
-)
+    async def app_index_view(request: Request, app_label: str):
+        bind_request(request)
+        return await app_index(request, app_label, site)
+
+    async def model_list_view(request: Request, app_label: str, model_name: str):
+        bind_request(request)
+        return await model_list(request, app_label, model_name, site)
+
+    async def model_add_view(request: Request, app_label: str, model_name: str):
+        bind_request(request)
+        return await model_add(request, app_label, model_name, site)
+
+    async def model_change_view(
+        request: Request, app_label: str, model_name: str, pk: str
+    ):
+        bind_request(request)
+        return await model_change(request, app_label, model_name, pk, site)
+
+    async def model_delete_view(
+        request: Request, app_label: str, model_name: str, pk: str
+    ):
+        bind_request(request)
+        return await model_delete(request, app_label, model_name, pk, site)
+
+    # Auth routes (must be before the catch-all model routes)
+    router.add_api_route(
+        "/login/", login_view, methods=["GET", "POST"], name=f"{ns}:login"
+    )
+    router.add_api_route(
+        "/logout/", logout_view, methods=["POST"], name=f"{ns}:logout"
+    )
+
+    # Index routes
+    router.add_api_route("/", index_view, methods=["GET"], name=f"{ns}:index")
+    router.add_api_route(
+        "/{app_label}/", app_index_view, methods=["GET"], name=f"{ns}:app_index"
+    )
+
+    # Model CRUD routes
+    router.add_api_route(
+        "/{app_label}/{model_name}/",
+        model_list_view,
+        methods=["GET", "POST"],
+        name=f"{ns}:model_list",
+    )
+    router.add_api_route(
+        "/{app_label}/{model_name}/add/",
+        model_add_view,
+        methods=["GET", "POST"],
+        name=f"{ns}:model_add",
+    )
+    router.add_api_route(
+        "/{app_label}/{model_name}/{pk}/change/",
+        model_change_view,
+        methods=["GET", "POST"],
+        name=f"{ns}:model_change",
+    )
+    router.add_api_route(
+        "/{app_label}/{model_name}/{pk}/delete/",
+        model_delete_view,
+        methods=["POST"],
+        name=f"{ns}:model_delete",
+    )
+
+    return router

--- a/aksara/contrib/admin/views.py
+++ b/aksara/contrib/admin/views.py
@@ -146,7 +146,33 @@ def _with_params(request: Request, **changes: Any) -> str:
 # Auth
 # -----------------------------------------------------------------------------
 
-def require_admin_user(
+async def _check_site_permission(
+    site: "AdminSite",
+    request: Request,
+) -> Tuple[bool, Optional[str]]:
+    """Evaluate admin site access, including async permission classes."""
+    if not site.permission_classes:
+        return site.check_site_permission(request)
+
+    for permission in site.permission_classes:
+        perm = permission() if isinstance(permission, type) else permission
+        allowed = await _maybe_await(perm.has_permission(request, None))
+        if not allowed:
+            return False, getattr(perm, "message", "Permission denied.")
+    return True, None
+
+
+async def _check_site_permission_for_user(
+    site: "AdminSite",
+    request: Request,
+    user: Any,
+) -> Tuple[bool, Optional[str]]:
+    """Evaluate site access for an authenticated login candidate."""
+    request.state.user = user
+    return await _check_site_permission(site, request)
+
+
+async def require_admin_user(
     request: Request, site: "AdminSite"
 ) -> Tuple[Any, Optional[RedirectResponse]]:
     """
@@ -156,7 +182,7 @@ def require_admin_user(
     Access is governed by the site's ``permission_classes`` if set, otherwise by
     the default staff-only rule.
     """
-    allowed, _message = site.check_site_permission(request)
+    allowed, _message = await _check_site_permission(site, request)
     if allowed:
         return getattr(request.state, "user", None), None
 
@@ -311,7 +337,7 @@ async def _visible_models_by_app(
 async def admin_index(request: Request, site: "AdminSite" = None) -> HTMLResponse:
     """Admin dashboard showing accessible apps and models. Route: GET /admin/"""
     site = _resolve_site(site)
-    user, redirect = require_admin_user(request, site)
+    user, redirect = await require_admin_user(request, site)
     if redirect:
         return redirect
 
@@ -337,7 +363,7 @@ async def app_index(
 ) -> HTMLResponse:
     """Show accessible models for a specific app. Route: GET /admin/{app_label}/"""
     site = _resolve_site(site)
-    user, redirect = require_admin_user(request, site)
+    user, redirect = await require_admin_user(request, site)
     if redirect:
         return redirect
 
@@ -503,7 +529,7 @@ async def model_list(
 ) -> HTMLResponse:
     """List objects for a model. Route: GET, POST /admin/{app_label}/{model_name}/"""
     site = _resolve_site(site)
-    user, redirect = require_admin_user(request, site)
+    user, redirect = await require_admin_user(request, site)
     if redirect:
         return redirect
 
@@ -677,7 +703,7 @@ async def model_add(
 ) -> HTMLResponse:
     """Add a new object. Route: GET, POST /admin/{app_label}/{model_name}/add/"""
     site = _resolve_site(site)
-    user, redirect = require_admin_user(request, site)
+    user, redirect = await require_admin_user(request, site)
     if redirect:
         return redirect
 
@@ -740,7 +766,7 @@ async def model_change(
 ) -> HTMLResponse:
     """Edit an object. Route: GET, POST /admin/{app_label}/{model_name}/{pk}/change/"""
     site = _resolve_site(site)
-    user, redirect = require_admin_user(request, site)
+    user, redirect = await require_admin_user(request, site)
     if redirect:
         return redirect
 
@@ -813,7 +839,7 @@ async def model_delete(
 ) -> RedirectResponse:
     """Delete an object. Route: POST /admin/{app_label}/{model_name}/{pk}/delete/"""
     site = _resolve_site(site)
-    user, redirect = require_admin_user(request, site)
+    user, redirect = await require_admin_user(request, site)
     if redirect:
         return redirect
 
@@ -990,6 +1016,9 @@ async def _build_field_info(
             value = form_data[field_name]
         elif obj is not None:
             value = getattr(obj, field_name, "")
+        elif field_type == "checkbox":
+            default = getattr(field, "default", None)
+            value = default() if callable(default) else default
         else:
             value = ""
 
@@ -1003,7 +1032,9 @@ async def _build_field_info(
                 except (ValueError, AttributeError):
                     pass
 
-        if not isinstance(value, list):
+        if field_type == "checkbox":
+            value = value in (True, "true", "True", "1", "on", 1)
+        elif not isinstance(value, list):
             value = str(value) if value is not None else ""
 
     field_info: Dict[str, Any] = {
@@ -1079,8 +1110,10 @@ async def admin_login(request: Request, site: "AdminSite" = None) -> HTMLRespons
     )
 
     user = getattr(request.state, "user", None)
-    if user and getattr(user, "is_staff", False):
-        return RedirectResponse(url=next_url, status_code=status.HTTP_302_FOUND)
+    if user:
+        allowed, _message = await _check_site_permission(site, request)
+        if allowed:
+            return RedirectResponse(url=next_url, status_code=status.HTTP_302_FOUND)
 
     if request.method == "POST":
         form_data = await _read_admin_form(request)
@@ -1096,7 +1129,10 @@ async def admin_login(request: Request, site: "AdminSite" = None) -> HTMLRespons
                     request.app.db, username=username, password=password
                 )
                 if user:
-                    if not getattr(user, "is_staff", False):
+                    allowed, _message = await _check_site_permission_for_user(
+                        site, request, user
+                    )
+                    if not allowed:
                         error = (
                             "You don't have permission to access the admin. "
                             "Staff access required."

--- a/aksara/contrib/admin/views.py
+++ b/aksara/contrib/admin/views.py
@@ -1,26 +1,36 @@
 """
 Admin Views
 
-Server-rendered views for the admin interface.
+Server-rendered views for the admin interface. Each view receives the
+``AdminSite`` it belongs to so multiple sites can be mounted independently.
 """
 
 from __future__ import annotations
 
 import hmac
+import inspect
 import logging
 import secrets
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode, urlparse, urlsplit, urlunsplit, parse_qsl
 
 from fastapi import HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from starlette import status
 
+from aksara.contrib.admin.actions import (
+    clear_messages_cookie,
+    pop_messages,
+    write_messages_cookie,
+)
+from aksara.contrib.admin.filters import FieldListFilter, SimpleListFilter
+
 if TYPE_CHECKING:
     from aksara.model.base import Model
     from aksara.contrib.admin.options import ModelAdmin
+    from aksara.contrib.admin.site import AdminSite
 
 # Resolve templates directory within the package
 _package_dir = Path(__file__).parent
@@ -33,122 +43,163 @@ ADMIN_CSRF_FORM_FIELD = "csrf_token"
 logger = logging.getLogger("aksara.contrib.admin")
 
 
-def _validate_next_url(url: str) -> str:
-    """
-    Validate a redirect URL to prevent open-redirect attacks.
+# -----------------------------------------------------------------------------
+# Small async/sync helpers
+# -----------------------------------------------------------------------------
 
-    Only relative paths starting with '/' are allowed.
-    Any absolute URL (with scheme or netloc) is rejected and replaced
-    with the safe default '/admin/'.
-    """
-    if not url:
-        return "/admin/"
-    parsed = urlparse(url)
-    # Reject absolute URLs: must have no scheme and no netloc
-    if parsed.scheme or parsed.netloc:
-        return "/admin/"
-    # Reject protocol-relative URLs like //evil.com
-    if url.startswith("//"):
-        return "/admin/"
-    # Must start with /
-    if not url.startswith("/"):
-        return "/admin/"
-    return url
+async def _maybe_await(value: Any) -> Any:
+    """Await ``value`` if it is awaitable, supporting sync or async overrides."""
+    if inspect.isawaitable(value):
+        return await value
+    return value
 
 
-def get_admin_user(request: Request, redirect_to_login: bool = True):
-    """
-    Get the authenticated admin user from request state.
-    
-    Args:
-        request: The FastAPI request
-        redirect_to_login: If True, redirect to login page instead of raising 403
-    
-    Returns:
-        User object if authenticated, None otherwise
-        
-    Raises:
-        HTTPException: 403 if user is not staff and redirect_to_login is False
-    """
-    user = getattr(request.state, "user", None)
-    if user and getattr(user, "is_staff", False):
-        return user
-    
-    if redirect_to_login:
-        return None  # Will trigger redirect in view
-    
-    raise HTTPException(
-        status_code=status.HTTP_403_FORBIDDEN,
-        detail="Admin access forbidden. Staff access required.",
+async def _check_permission_callable(
+    checker: Any,
+    request: Request,
+    obj: Optional["Model"] = None,
+) -> bool:
+    """Call a ModelAdmin permission hook with ``obj`` when the hook accepts it."""
+    if obj is None:
+        return bool(await _maybe_await(checker(request)))
+
+    try:
+        signature = inspect.signature(checker)
+    except (TypeError, ValueError):
+        return bool(await _maybe_await(checker(request, obj)))
+
+    positional = [
+        param
+        for param in signature.parameters.values()
+        if param.kind
+        in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD, param.VAR_POSITIONAL)
+    ]
+    accepts_obj = any(param.kind == param.VAR_POSITIONAL for param in positional)
+    accepts_obj = accepts_obj or len(positional) >= 2
+
+    if accepts_obj:
+        return bool(await _maybe_await(checker(request, obj)))
+    return bool(await _maybe_await(checker(request)))
+
+
+def _resolve_site(site: Optional["AdminSite"]) -> "AdminSite":
+    if site is not None:
+        return site
+    from aksara.contrib.admin import site as default_site
+    return default_site
+
+
+def _url_path(url: Any) -> str:
+    """Return a same-origin path/query string from a URL-like object."""
+    parsed = urlparse(str(url))
+    path = parsed.path or "/"
+    return f"{path}?{parsed.query}" if parsed.query else path
+
+
+def _request_path_with_query(request: Request) -> str:
+    path = request.url.path or "/"
+    return f"{path}?{request.url.query}" if request.url.query else path
+
+
+def _append_query_param(url: str, **params: str) -> str:
+    split = urlsplit(url)
+    query = dict(parse_qsl(split.query, keep_blank_values=True))
+    query.update({key: value for key, value in params.items() if value is not None})
+    return urlunsplit(
+        (split.scheme, split.netloc, split.path, urlencode(query), split.fragment)
     )
 
 
-def require_admin_user(request: Request):
+def _validate_next_url(url: str, default: str = "/admin/") -> str:
+    """Validate a redirect URL to prevent open-redirect attacks."""
+    if not url:
+        return default
+    parsed = urlparse(url)
+    if parsed.scheme or parsed.netloc:
+        return default
+    if url.startswith("//"):
+        return default
+    if not url.startswith("/"):
+        return default
+    return url
+
+
+def _with_params(request: Request, **changes: Any) -> str:
     """
-    Get the authenticated admin user, redirecting to login if not authenticated.
-    
-    Returns a tuple of (user, redirect_response).
-    If user is authenticated, returns (user, None).
-    If user is not authenticated, returns (None, RedirectResponse).
+    Build a path + querystring for the current request with some params changed.
+
+    A value of ``None`` removes the param. Used to construct filter, sort and
+    pagination links without losing other active query parameters.
     """
-    user = get_admin_user(request, redirect_to_login=True)
-    if user is None:
-        # Build login URL with next parameter
-        next_url = str(request.url)
-        login_url = str(request.url_for("admin:login")) + "?" + urlencode({"next": next_url})
-        return None, RedirectResponse(url=login_url, status_code=status.HTTP_302_FOUND)
-    return user, None
+    params = dict(request.query_params)
+    for key, value in changes.items():
+        if value is None:
+            params.pop(key, None)
+        else:
+            params[key] = str(value)
+    query = urlencode(params)
+    path = request.url.path
+    return f"{path}?{query}" if query else path
+
+
+# -----------------------------------------------------------------------------
+# Auth
+# -----------------------------------------------------------------------------
+
+def require_admin_user(
+    request: Request, site: "AdminSite"
+) -> Tuple[Any, Optional[RedirectResponse]]:
+    """
+    Resolve the admin user, redirecting to login when access is not allowed.
+
+    Returns (user, None) when access is granted, else (None, RedirectResponse).
+    Access is governed by the site's ``permission_classes`` if set, otherwise by
+    the default staff-only rule.
+    """
+    allowed, _message = site.check_site_permission(request)
+    if allowed:
+        return getattr(request.state, "user", None), None
+
+    next_url = _request_path_with_query(request)
+    login_url = site.login_url or str(request.url_for(f"{site.name}:login"))
+    login_url = _append_query_param(login_url, next=next_url)
+    return None, RedirectResponse(url=login_url, status_code=status.HTTP_302_FOUND)
 
 
 def _get_model_and_admin(
-    app_label: str,
-    model_name: str,
+    app_label: str, model_name: str, site: "AdminSite"
 ) -> Tuple[Type["Model"], "ModelAdmin"]:
-    """
-    Look up model and its ModelAdmin by app_label and model_name.
-    
-    Args:
-        app_label: The app label
-        model_name: The model name (case-insensitive)
-        
-    Returns:
-        Tuple of (Model class, ModelAdmin instance)
-        
-    Raises:
-        HTTPException: 404 if not found
-    """
-    from aksara.contrib.admin import site
-    
+    """Look up model and its ModelAdmin by app_label and model_name."""
     model = site.get_model_by_name(app_label, model_name)
     if model is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Model '{model_name}' not found in app '{app_label}'",
         )
-    
+
     model_admin = site.get_model_admin(model)
     if model_admin is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Model '{model_name}' is not registered with admin",
         )
-    
     return model, model_admin
 
 
+# -----------------------------------------------------------------------------
+# CSRF / settings / rendering
+# -----------------------------------------------------------------------------
+
 def _get_settings():
-    """Get Aksara settings (import here to avoid circular imports)."""
     from aksara.conf import settings
     return settings
 
 
 def _generate_admin_csrf_token() -> str:
-    """Generate a CSRF token for the admin UI."""
     return secrets.token_urlsafe(32)
 
 
 def _get_or_create_admin_csrf_token(request: Request) -> str:
-    """Return the admin CSRF token for this request."""
     token = request.cookies.get(ADMIN_CSRF_COOKIE_NAME)
     if token:
         return token
@@ -156,7 +207,6 @@ def _get_or_create_admin_csrf_token(request: Request) -> str:
 
 
 def _is_same_origin(request: Request, origin_value: str) -> bool:
-    """Validate an Origin or Referer header against the current request."""
     parsed = urlparse(origin_value)
     request_url = urlparse(str(request.base_url))
     return bool(parsed.scheme and parsed.netloc) and (
@@ -165,41 +215,48 @@ def _is_same_origin(request: Request, origin_value: str) -> bool:
 
 
 def _set_admin_csrf_cookie(response: HTMLResponse, request: Request, token: str) -> None:
-    """Set the admin CSRF cookie on a response."""
     settings = _get_settings()
+    cookie_path = getattr(request.state, "admin_csrf_cookie_path", "/admin")
     response.set_cookie(
         key=ADMIN_CSRF_COOKIE_NAME,
         value=token,
         secure=settings.cookie_secure and request.url.scheme == "https",
         httponly=False,
         samesite="strict",
-        path="/admin",
+        path=cookie_path,
     )
 
 
 def _render_admin_template(
     request: Request,
+    site: "AdminSite",
     template_name: str,
     context: Dict[str, Any],
 ) -> HTMLResponse:
-    """Render an admin template with CSRF context and cookie."""
+    """Render an admin template with site branding, CSRF and flash messages."""
     settings = _get_settings()
     csrf_token = _get_or_create_admin_csrf_token(request)
-    response = templates.TemplateResponse(
-        request,
-        template_name,
-        {
-            **context,
-            "csrf_token": csrf_token,
-        },
-    )
+    messages = pop_messages(request)
+
+    merged = {
+        "url_namespace": site.name,
+        "messages": messages,
+        "csrf_token": csrf_token,
+        "studio_enabled": getattr(settings, "enable_studio", False),
+        "debug": settings.debug,
+        **site.base_context(request),
+        **context,
+    }
+    response = templates.TemplateResponse(request, template_name, merged)
     if settings.admin_csrf_enabled:
         _set_admin_csrf_cookie(response, request, csrf_token)
+    if messages:
+        clear_messages_cookie(response)
     return response
 
 
 async def _read_admin_form(request: Request) -> Any:
-    """Read and validate admin POST form data."""
+    """Read and validate admin POST form data (origin + CSRF token)."""
     form_data = await request.form()
     settings = _get_settings()
 
@@ -231,264 +288,457 @@ async def _read_admin_form(request: Request) -> Any:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid admin CSRF token.",
         )
-
     return form_data
 
 
 # -----------------------------------------------------------------------------
-# Admin Index View: /admin/
+# Index / app index
 # -----------------------------------------------------------------------------
 
-async def admin_index(request: Request) -> HTMLResponse:
-    """
-    Admin dashboard showing all registered apps and models.
-    
-    Route: GET /admin/
-    """
-    from aksara.contrib.admin import site
-    
-    user, redirect = require_admin_user(request)
-    if redirect:
-        return redirect
-    
-    settings = _get_settings()
-    
-    # Group models by app_label
+async def _visible_models_by_app(
+    request: Request, site: "AdminSite"
+) -> Dict[str, List[Type["Model"]]]:
+    """Group registered models by app, honouring has_module_permission."""
     apps: Dict[str, List[Type["Model"]]] = {}
     for model, model_admin in site.registry.items():
+        if not await _maybe_await(model_admin.has_module_permission(request)):
+            continue
         app_label = model.meta.app_label or "default"
         apps.setdefault(app_label, []).append(model)
-    
+    return apps
+
+
+async def admin_index(request: Request, site: "AdminSite" = None) -> HTMLResponse:
+    """Admin dashboard showing accessible apps and models. Route: GET /admin/"""
+    site = _resolve_site(site)
+    user, redirect = require_admin_user(request, site)
+    if redirect:
+        return redirect
+
+    apps = await _visible_models_by_app(request, site)
+
+    extra: Dict[str, Any] = {}
+    if site._index_view_func is not None:
+        result = await _maybe_await(site._index_view_func(request))
+        if isinstance(result, dict):
+            extra = result
+
+    template_name = site.index_template or "admin/index.html"
     return _render_admin_template(
         request,
-        "admin/index.html",
-        {
-            "apps": apps,
-            "user": user,
-            "debug": settings.debug,
-            "site_name": "Aksara Admin",
-            "studio_enabled": getattr(settings, "enable_studio", False),
-        },
+        site,
+        template_name,
+        {"apps": apps, "user": user, **extra},
     )
 
 
-# -----------------------------------------------------------------------------
-# App Index View: /admin/{app_label}/
-# -----------------------------------------------------------------------------
-
-async def app_index(request: Request, app_label: str) -> HTMLResponse:
-    """
-    Show all models for a specific app.
-    
-    Route: GET /admin/{app_label}/
-    """
-    from aksara.contrib.admin import site
-    
-    user, redirect = require_admin_user(request)
+async def app_index(
+    request: Request, app_label: str, site: "AdminSite" = None
+) -> HTMLResponse:
+    """Show accessible models for a specific app. Route: GET /admin/{app_label}/"""
+    site = _resolve_site(site)
+    user, redirect = require_admin_user(request, site)
     if redirect:
         return redirect
-    
-    settings = _get_settings()
-    
-    # Find all models for this app
-    app_models: List[Type["Model"]] = []
-    for model, admin in site.registry.items():
-        if (model.meta.app_label or "default") == app_label:
-            app_models.append(model)
-    
+
+    apps = await _visible_models_by_app(request, site)
+    app_models = apps.get(app_label, [])
     if not app_models:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"App '{app_label}' not found or has no registered models",
         )
-    
+
     return _render_admin_template(
         request,
+        site,
         "admin/app_index.html",
-        {
-            "app_label": app_label,
-            "models": app_models,
-            "user": user,
-            "site_name": "Aksara Admin",
-            "studio_enabled": getattr(settings, "enable_studio", False),
-        },
+        {"app_label": app_label, "models": app_models, "user": user},
     )
 
 
 # -----------------------------------------------------------------------------
-# Model List View: /admin/{app_label}/{model_name}/
+# Model list (with search, filters, ordering, pagination, actions)
 # -----------------------------------------------------------------------------
+
+async def _build_filters(
+    request: Request, model_admin: "ModelAdmin"
+) -> List[Any]:
+    """Instantiate each entry in ``list_filter`` into a filter object."""
+    built: List[Any] = []
+    for entry in model_admin.list_filter or []:
+        if isinstance(entry, type) and issubclass(entry, SimpleListFilter):
+            built.append(entry(request, model_admin))
+        elif isinstance(entry, str):
+            built.append(await FieldListFilter.create(entry, request, model_admin))
+    return built
+
+
+def _apply_filter(filt: Any, request: Request, queryset: Any) -> Any:
+    if isinstance(filt, SimpleListFilter):
+        if filt.value() in (None, ""):
+            return queryset
+        try:
+            return filt.queryset(request, queryset)
+        except Exception:
+            return queryset
+    return filt.apply(queryset)
+
+
+def _filter_context(request: Request, filters: List[Any]) -> List[Dict[str, Any]]:
+    specs: List[Dict[str, Any]] = []
+    for filt in filters:
+        if not filt.has_output():
+            continue
+        options = []
+        for choice in filt.choices_for_template():
+            options.append(
+                {
+                    "label": choice["label"],
+                    "selected": choice["selected"],
+                    "url": _with_params(
+                        request,
+                        **{filt.parameter_name: choice["value"], "p": None},
+                    ),
+                }
+            )
+        specs.append({"title": filt.title, "choices": options})
+    return specs
+
+
+def _resolve_ordering(request: Request, model_admin: "ModelAdmin") -> List[str]:
+    """Ordering from the ?o= sort param if valid, else the admin default."""
+    o = request.query_params.get("o")
+    if o:
+        field = o[1:] if o.startswith("-") else o
+        valid = {f.name for f in model_admin.model.meta.fields}
+        if field in valid:
+            return [o]
+    return model_admin.get_ordering(request)
+
+
+async def _run_list_action(
+    request: Request,
+    model: Type["Model"],
+    model_admin: "ModelAdmin",
+    site: "AdminSite",
+    app_label: str,
+    model_name: str,
+) -> Optional[RedirectResponse]:
+    """Handle an action POST from the list view. Returns a redirect or None."""
+    form = await _read_admin_form(request)
+    action_name = form.get("action", "")
+    selected_ids = form.getlist("_selected")
+
+    actions = model_admin.get_actions(request)
+    spec = actions.get(action_name)
+    redirect = RedirectResponse(
+        url=str(
+            request.url_for(
+                f"{site.name}:model_list",
+                app_label=app_label,
+                model_name=model_name.lower(),
+            )
+        ),
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+    if spec is None:
+        model_admin.message_user(request, "Unknown action.", level="error")
+        write_messages_cookie(request, redirect)
+        return redirect
+
+    if not selected_ids:
+        model_admin.message_user(request, "No items selected.", level="warning")
+        write_messages_cookie(request, redirect)
+        return redirect
+
+    base_qs = await _maybe_await(model_admin.get_queryset(request))
+    queryset = base_qs.filter(id__in=selected_ids)
+    selected_objects = await queryset.all()
+
+    if len(selected_objects) != len(set(str(pk) for pk in selected_ids)):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Permission denied for action '{action_name}'.",
+        )
+
+    # Action-level permission gate (allowed_permissions -> has_X_permission).
+    # The list-level check controls whether the action is generally available;
+    # object-level checks prevent bulk actions from bypassing per-row rules.
+    for perm in spec["allowed_permissions"]:
+        checker = getattr(model_admin, f"has_{perm}_permission", None)
+        if checker is None:
+            continue
+        if not await _check_permission_callable(checker, request):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Permission denied for action '{action_name}'.",
+            )
+        for obj in selected_objects:
+            if not await _check_permission_callable(checker, request, obj):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Permission denied for action '{action_name}'.",
+                )
+
+    # A bound ModelAdmin method already carries ``self``; a module-level action
+    # function (e.g. delete_selected) needs the admin passed explicitly.
+    func = spec["func"]
+    if inspect.ismethod(func):
+        result = func(request, queryset)
+    else:
+        result = func(model_admin, request, queryset)
+    await _maybe_await(result)
+
+    write_messages_cookie(request, redirect)
+    return redirect
+
 
 async def model_list(
     request: Request,
     app_label: str,
     model_name: str,
+    site: "AdminSite" = None,
 ) -> HTMLResponse:
-    """
-    List all objects for a model.
-    
-    Route: GET /admin/{app_label}/{model_name}/
-    """
-    user, redirect = require_admin_user(request)
+    """List objects for a model. Route: GET, POST /admin/{app_label}/{model_name}/"""
+    site = _resolve_site(site)
+    user, redirect = require_admin_user(request, site)
     if redirect:
         return redirect
-    
-    settings = _get_settings()
-    model, model_admin = _get_model_and_admin(app_label, model_name)
-    
-    if not model_admin.has_view_permission(request):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permission denied",
+
+    model, model_admin = _get_model_and_admin(app_label, model_name, site)
+
+    if not await _maybe_await(model_admin.has_view_permission(request)):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Permission denied")
+
+    if request.method == "POST":
+        return await _run_list_action(
+            request, model, model_admin, site, app_label, model_name
         )
-    
-    # Get search query
+
+    # Base queryset + search + filters + ordering.
+    queryset = await _maybe_await(model_admin.get_queryset(request))
+
     search_query = request.query_params.get("q", "").strip()
-    
-    # Get objects
-    queryset = await model_admin.get_queryset(request)
-    objects = await queryset.all()
-    
-    # Apply search filter in Python (OR across all search_fields)
-    if search_query and model_admin.search_fields:
-        search_lower = search_query.lower()
-        filtered_objects = []
-        for obj in objects:
-            for field_name in model_admin.search_fields:
-                value = getattr(obj, field_name, None)
-                if value and search_lower in str(value).lower():
-                    filtered_objects.append(obj)
-                    break
-        objects = filtered_objects
-    
-    # Get list display fields
+    if search_query:
+        queryset = model_admin.get_search_results(request, queryset, search_query)
+
+    filters = await _build_filters(request, model_admin)
+    for filt in filters:
+        queryset = _apply_filter(filt, request, queryset)
+
+    # Count the filtered set *before* ordering — an ORDER BY on COUNT(*) is
+    # rejected by PostgreSQL.
+    per_page = max(int(model_admin.list_per_page or 100), 1)
+    total = await queryset.count()
+    show_all = (
+        request.query_params.get("all") == "1"
+        and total <= int(model_admin.list_max_show_all or 200)
+    )
+    try:
+        page = max(int(request.query_params.get("p", "1")), 1)
+    except (TypeError, ValueError):
+        page = 1
+
+    num_pages = max((total + per_page - 1) // per_page, 1) if not show_all else 1
+    page = min(page, num_pages)
+
+    # Apply ordering only for the page fetch.
+    ordering = _resolve_ordering(request, model_admin)
+    ordered_qs = queryset
+    if ordering:
+        try:
+            ordered_qs = queryset.order_by(*ordering)
+        except Exception:
+            ordered_qs = queryset
+
+    page_qs = ordered_qs
+    if not show_all:
+        page_qs = ordered_qs.limit(per_page).offset((page - 1) * per_page)
+    objects = await page_qs.all()
+
+    # Build rows (custom columns + which columns link to the change view).
     list_display = model_admin.get_list_display(request)
-    
-    # Prepare display values for each object
-    objects_data = []
+    link_cols = set(model_admin.get_list_display_links(request, list_display))
+    rows = []
     for obj in objects:
-        row = {"obj": obj, "values": []}
-        for field_name in list_display:
-            value = await _get_display_value(obj, field_name, model_admin)
-            row["values"].append(value)
-        objects_data.append(row)
-    
+        cells = []
+        for col in list_display:
+            is_link = col in link_cols
+            if model_admin.is_callable_column(col):
+                raw = await _maybe_await(getattr(model_admin, col)(obj))
+                cells.append(
+                    {
+                        "value": "" if raw is None else str(raw),
+                        "is_html": model_admin.column_allows_html(col),
+                        "is_link": is_link,
+                    }
+                )
+            else:
+                value = await _get_display_value(obj, col, model_admin)
+                cells.append({"value": value, "is_html": False, "is_link": is_link})
+        rows.append({"obj": obj, "cells": cells})
+
+    pagination = _build_pagination(request, page, num_pages, total, per_page, show_all)
+
     return _render_admin_template(
         request,
+        site,
         "admin/model_list.html",
         {
             "app_label": app_label,
             "model": model,
             "model_name": model.__name__,
-            "objects": objects_data,
+            "rows": rows,
             "list_display": list_display,
+            "list_headers": [
+                {
+                    "name": col,
+                    "label": model_admin.get_column_label(col),
+                    "sort_url": _sort_url(request, model_admin, col),
+                    "sort_dir": _sort_dir(request, col),
+                }
+                for col in list_display
+            ],
             "user": user,
-            "can_add": model_admin.has_add_permission(request),
+            "can_add": await _maybe_await(model_admin.has_add_permission(request)),
             "search_query": search_query,
             "search_fields": model_admin.search_fields,
-            "site_name": "Aksara Admin",
-            "studio_enabled": getattr(settings, "enable_studio", False),
+            "filters": _filter_context(request, filters),
+            "pagination": pagination,
+            "actions": [
+                {"name": name, "description": spec["description"]}
+                for name, spec in model_admin.get_actions(request).items()
+            ],
+            "clear_url": request.url_for(
+                f"{site.name}:model_list",
+                app_label=app_label,
+                model_name=model_name.lower(),
+            ),
         },
     )
 
 
+def _sort_dir(request: Request, col: str) -> Optional[str]:
+    o = request.query_params.get("o")
+    if o == col:
+        return "asc"
+    if o == f"-{col}":
+        return "desc"
+    return None
+
+
+def _sort_url(request: Request, model_admin: "ModelAdmin", col: str) -> Optional[str]:
+    if model_admin.is_callable_column(col):
+        return None  # Custom columns are not DB-sortable.
+    current = _sort_dir(request, col)
+    new_value = f"-{col}" if current == "asc" else col
+    return _with_params(request, o=new_value, p=None)
+
+
+def _build_pagination(
+    request: Request,
+    page: int,
+    num_pages: int,
+    total: int,
+    per_page: int,
+    show_all: bool,
+) -> Dict[str, Any]:
+    return {
+        "page": page,
+        "num_pages": num_pages,
+        "total": total,
+        "per_page": per_page,
+        "show_all": show_all,
+        "has_prev": page > 1 and not show_all,
+        "has_next": page < num_pages and not show_all,
+        "prev_url": _with_params(request, p=page - 1) if page > 1 else None,
+        "next_url": _with_params(request, p=page + 1) if page < num_pages else None,
+        "show_all_url": _with_params(request, all="1", p=None)
+        if (not show_all and total <= per_page * num_pages and num_pages > 1)
+        else None,
+    }
+
+
 # -----------------------------------------------------------------------------
-# Model Add View: /admin/{app_label}/{model_name}/add/
+# Model add / change / delete
 # -----------------------------------------------------------------------------
 
 async def model_add(
     request: Request,
     app_label: str,
     model_name: str,
+    site: "AdminSite" = None,
 ) -> HTMLResponse:
-    """
-    Add a new object.
-    
-    Route: GET, POST /admin/{app_label}/{model_name}/add/
-    """
-    user, redirect = require_admin_user(request)
+    """Add a new object. Route: GET, POST /admin/{app_label}/{model_name}/add/"""
+    site = _resolve_site(site)
+    user, redirect = require_admin_user(request, site)
     if redirect:
         return redirect
-    
-    settings = _get_settings()
-    model, model_admin = _get_model_and_admin(app_label, model_name)
-    
-    if not model_admin.has_add_permission(request):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permission denied",
-        )
-    
+
+    model, model_admin = _get_model_and_admin(app_label, model_name, site)
+
+    if not await _maybe_await(model_admin.has_add_permission(request)):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Permission denied")
+
     form_fields = model_admin.get_form_fields(request)
     errors: Dict[str, str] = {}
     form_data: Dict[str, Any] = {}
-    
+
     if request.method == "POST":
-        # Parse form data
         raw_form = await _read_admin_form(request)
         form_data = _parse_form_data(raw_form, model, form_fields)
-        
+
         try:
-            # Create new instance
             obj = model(**form_data)
-            await model_admin.save_model(request, obj, form_data, is_created=True)
-            
-            # Redirect to list view
+            await model_admin.save_model(request, obj, form_data, True)
             return RedirectResponse(
                 url=request.url_for(
-                    "admin:model_list",
+                    f"{site.name}:model_list",
                     app_label=app_label,
                     model_name=model_name.lower(),
                 ),
                 status_code=status.HTTP_303_SEE_OTHER,
             )
-        except Exception as e:
-            errors["__all__"] = str(e)
-    
-    # Prepare field info for template
-    fields_info = await _get_fields_info(model, model_admin, form_fields, form_data, request)
-    
+        except Exception as exc:
+            errors["__all__"] = _safe_error_message(exc, "create")
+
+    fieldsets = await _get_fieldsets_info(model, model_admin, form_data, request)
+
     return _render_admin_template(
         request,
+        site,
         "admin/model_form.html",
         {
             "app_label": app_label,
             "model": model,
             "model_name": model.__name__,
-            "fields": fields_info,
+            "fieldsets": fieldsets,
+            "prepopulated": _prepopulated_map(model_admin),
             "obj": None,
             "is_add": True,
             "errors": errors,
             "user": user,
-            "site_name": "Aksara Admin",
-            "studio_enabled": getattr(settings, "enable_studio", False),
         },
     )
 
-
-# -----------------------------------------------------------------------------
-# Model Change View: /admin/{app_label}/{model_name}/{pk}/change/
-# -----------------------------------------------------------------------------
 
 async def model_change(
     request: Request,
     app_label: str,
     model_name: str,
     pk: str,
+    site: "AdminSite" = None,
 ) -> HTMLResponse:
-    """
-    Edit an existing object.
-    
-    Route: GET, POST /admin/{app_label}/{model_name}/{pk}/change/
-    """
-    user, redirect = require_admin_user(request)
+    """Edit an object. Route: GET, POST /admin/{app_label}/{model_name}/{pk}/change/"""
+    site = _resolve_site(site)
+    user, redirect = require_admin_user(request, site)
     if redirect:
         return redirect
-    
-    settings = _get_settings()
-    model, model_admin = _get_model_and_admin(app_label, model_name)
-    
-    # Get the object
+
+    model, model_admin = _get_model_and_admin(app_label, model_name, site)
+
     try:
         obj = await model_admin.get_object(request, pk)
     except Exception:
@@ -496,87 +746,72 @@ async def model_change(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Object with pk={pk} not found",
         )
-    
-    if not model_admin.has_change_permission(request, obj):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permission denied",
-        )
-    
+
+    if not await _maybe_await(model_admin.has_change_permission(request, obj)):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Permission denied")
+
     form_fields = model_admin.get_form_fields(request, obj)
     readonly_fields = set(model_admin.get_readonly_fields(request, obj))
     errors: Dict[str, str] = {}
     form_data: Dict[str, Any] = {}
-    
+
     if request.method == "POST":
-        # Parse form data
         raw_form = await _read_admin_form(request)
         form_data = _parse_form_data(raw_form, model, form_fields)
-        
-        # Remove readonly fields from form_data
         for field_name in readonly_fields:
             form_data.pop(field_name, None)
-        
+
         try:
-            await model_admin.save_model(request, obj, form_data, is_created=False)
-            
-            # Redirect to list view
+            await model_admin.save_model(request, obj, form_data, False)
             return RedirectResponse(
                 url=request.url_for(
-                    "admin:model_list",
+                    f"{site.name}:model_list",
                     app_label=app_label,
                     model_name=model_name.lower(),
                 ),
                 status_code=status.HTTP_303_SEE_OTHER,
             )
-        except Exception as e:
-            errors["__all__"] = str(e)
-    
-    # Prepare field info with current values
-    fields_info = await _get_fields_info(
-        model, model_admin, form_fields, form_data, request, obj
-    )
-    
+        except Exception as exc:
+            errors["__all__"] = _safe_error_message(exc, "save")
+
+    fieldsets = await _get_fieldsets_info(model, model_admin, form_data, request, obj)
+
     return _render_admin_template(
         request,
+        site,
         "admin/model_form.html",
         {
             "app_label": app_label,
             "model": model,
             "model_name": model.__name__,
-            "fields": fields_info,
+            "fieldsets": fieldsets,
+            "prepopulated": _prepopulated_map(model_admin),
             "obj": obj,
             "is_add": False,
             "errors": errors,
             "user": user,
-            "can_delete": model_admin.has_delete_permission(request, obj),
-            "site_name": "Aksara Admin",
-            "studio_enabled": getattr(settings, "enable_studio", False),
+            "can_delete": await _maybe_await(
+                model_admin.has_delete_permission(request, obj)
+            ),
         },
     )
 
-
-# -----------------------------------------------------------------------------
-# Model Delete View: /admin/{app_label}/{model_name}/{pk}/delete/
-# -----------------------------------------------------------------------------
 
 async def model_delete(
     request: Request,
     app_label: str,
     model_name: str,
     pk: str,
+    site: "AdminSite" = None,
 ) -> RedirectResponse:
-    """
-    Delete an object.
-    
-    Route: POST /admin/{app_label}/{model_name}/{pk}/delete/
-    """
-    user, redirect = require_admin_user(request)
+    """Delete an object. Route: POST /admin/{app_label}/{model_name}/{pk}/delete/"""
+    site = _resolve_site(site)
+    user, redirect = require_admin_user(request, site)
     if redirect:
         return redirect
-    model, model_admin = _get_model_and_admin(app_label, model_name)
-    
-    # Get the object
+
+    model, model_admin = _get_model_and_admin(app_label, model_name, site)
+
     try:
         obj = await model_admin.get_object(request, pk)
     except Exception:
@@ -584,21 +819,16 @@ async def model_delete(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Object with pk={pk} not found",
         )
-    
-    if not model_admin.has_delete_permission(request, obj):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permission denied",
-        )
+
+    if not await _maybe_await(model_admin.has_delete_permission(request, obj)):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Permission denied")
 
     await _read_admin_form(request)
-    
     await model_admin.delete_model(request, obj)
-    
-    # Redirect to list view
+
     return RedirectResponse(
         url=request.url_for(
-            "admin:model_list",
+            f"{site.name}:model_list",
             app_label=app_label,
             model_name=model_name.lower(),
         ),
@@ -610,100 +840,86 @@ async def model_delete(
 # Helper Functions
 # -----------------------------------------------------------------------------
 
+def _safe_error_message(exc: Exception, action: str) -> str:
+    """
+    Return a user-safe error message and log the full exception.
+
+    Validation errors (ValueError) carry user-actionable text and are shown;
+    anything else is logged and replaced with a generic message to avoid
+    leaking internal details into the UI.
+    """
+    logger.warning("Admin %s failed: %s", action, exc, exc_info=True)
+    if isinstance(exc, (ValueError, TypeError)):
+        return str(exc)
+    return f"Could not {action} this record. Please check the values and try again."
+
+
+def _prepopulated_map(model_admin: "ModelAdmin") -> Dict[str, List[str]]:
+    """JSON-serialisable {target_field: [source_fields]} for client slugify."""
+    return {
+        target: list(sources)
+        for target, sources in (model_admin.prepopulated_fields or {}).items()
+    }
+
+
 async def _get_display_value(
-    obj: "Model",
-    field_name: str,
-    model_admin: "ModelAdmin",
+    obj: "Model", field_name: str, model_admin: "ModelAdmin"
 ) -> str:
-    """
-    Get display value for a field, handling FK relations.
-    
-    Args:
-        obj: The model instance
-        field_name: Name of the field
-        model_admin: The ModelAdmin instance
-        
-    Returns:
-        String representation of the value
-    """
+    """Get display value for a field, handling FK relations and common types."""
     from aksara.fields import ForeignKey
     from datetime import datetime
-    
+
     model = model_admin.model
     field = model.meta.get_field(field_name)
-    
-    # Get raw value
     value = getattr(obj, field_name, None)
-    
+
     if value is None:
         return "-"
-    
-    # Handle ForeignKey - show related object display
+
     if field and isinstance(field, ForeignKey):
-        # value is the FK ID, we need to fetch the related object
         try:
             related_model = field.to_model
             related_obj = await related_model.objects.get(id=value)
             return model_admin._get_object_display(related_obj)
         except Exception:
             return str(value)
-    
-    # Handle datetime
+
     if isinstance(value, datetime):
         return value.strftime("%Y-%m-%d %H:%M")
-    
-    # Handle boolean
+
     if isinstance(value, bool):
         return "✓" if value else "✗"
-    
-    # Handle UUID (shorten for display)
+
     if hasattr(value, "hex") and len(str(value)) == 36:
         return str(value)[:8] + "..."
-    
+
     return str(value)
 
 
 def _parse_form_data(
-    raw_form: Any,
-    model: Type["Model"],
-    form_fields: List[str],
+    raw_form: Any, model: Type["Model"], form_fields: List[str]
 ) -> Dict[str, Any]:
-    """
-    Parse and convert form data to appropriate types.
-    
-    Args:
-        raw_form: The raw form data from request.form()
-        model: The Model class
-        form_fields: List of field names expected
-        
-    Returns:
-        Dict of parsed field values
-    """
+    """Parse and convert form data to appropriate types."""
     data: Dict[str, Any] = {}
     m2m_fields = model.meta.many_to_many
-    
+
     for field_name in form_fields:
-        # Handle ManyToMany fields (come as multiple values)
         if field_name in m2m_fields:
-            # getlist returns all values for a multi-select
             values = raw_form.getlist(field_name)
             data[field_name] = values if values else []
             continue
-        
+
         field = model.meta.get_field(field_name)
         if not field:
             continue
-        
+
         raw_value = raw_form.get(field_name, "")
-        
-        # Skip empty strings for optional fields
+
         if raw_value == "" and getattr(field, "nullable", False):
             data[field_name] = None
             continue
-        
-        # Convert based on field type
+
         field_type = field.__class__.__name__
-        
         try:
             if field_type == "Boolean":
                 data[field_name] = raw_value in ("true", "on", "1", True)
@@ -715,175 +931,175 @@ def _parse_form_data(
                 import json
                 data[field_name] = json.loads(raw_value) if raw_value else None
             elif field_type == "ForeignKey":
-                # FK needs UUID or None
                 if raw_value:
                     import uuid
                     data[field_name] = uuid.UUID(raw_value)
                 else:
-                    # Empty means no selection
                     data[field_name] = None
             else:
                 data[field_name] = raw_value if raw_value else None
         except (ValueError, TypeError):
             data[field_name] = raw_value
-    
+
     return data
 
 
-async def _get_fields_info(
+async def _build_field_info(
+    field_name: str,
     model: Type["Model"],
     model_admin: "ModelAdmin",
-    form_fields: List[str],
+    form_data: Dict[str, Any],
+    request: Request,
+    obj: Optional["Model"],
+    readonly: set,
+) -> Optional[Dict[str, Any]]:
+    """Build a single field's render info (shared by add/change forms)."""
+    from datetime import datetime
+
+    m2m_fields = model.meta.many_to_many
+    is_m2m = field_name in m2m_fields
+
+    if is_m2m:
+        field = m2m_fields[field_name]
+        field_type = "multiselect"
+        nullable = True
+        if form_data.get(field_name) is not None:
+            value = form_data[field_name]
+        elif obj is not None:
+            m2m_manager = getattr(obj, field_name)
+            related_ids = await m2m_manager.ids()
+            value = [str(rid) for rid in related_ids]
+        else:
+            value = []
+    else:
+        field = model.meta.get_field(field_name)
+        if not field:
+            return None
+
+        field_type = model_admin.get_field_type(field_name)
+        nullable = getattr(field, "nullable", False)
+
+        if form_data.get(field_name) is not None:
+            value = form_data[field_name]
+        elif obj is not None:
+            value = getattr(obj, field_name, "")
+        else:
+            value = ""
+
+        if field_type == "datetime-local" and value:
+            if isinstance(value, datetime):
+                value = value.strftime("%Y-%m-%dT%H:%M")
+            elif isinstance(value, str) and value:
+                try:
+                    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+                    value = dt.strftime("%Y-%m-%dT%H:%M")
+                except (ValueError, AttributeError):
+                    pass
+
+        if not isinstance(value, list):
+            value = str(value) if value is not None else ""
+
+    field_info: Dict[str, Any] = {
+        "name": field_name,
+        "label": field_name.replace("_", " ").title(),
+        "type": field_type,
+        "value": value,
+        "readonly": field_name in readonly,
+        "required": not nullable,
+        "choices": None,
+        "widget_html": None,
+    }
+
+    if not is_m2m and field:
+        widget = model_admin.get_widget(field_name, field)
+        if widget:
+            field_info["widget_html"] = widget.render(field_name, value, field)
+
+    if field_type in ("select", "multiselect"):
+        field_info["choices"] = await model_admin.get_field_choices(field_name, request)
+
+    return field_info
+
+
+async def _get_fieldsets_info(
+    model: Type["Model"],
+    model_admin: "ModelAdmin",
     form_data: Dict[str, Any],
     request: Request,
     obj: Optional["Model"] = None,
 ) -> List[Dict[str, Any]]:
     """
-    Build field info list for template rendering.
-    
-    Args:
-        model: The Model class
-        model_admin: The ModelAdmin instance
-        form_fields: List of field names
-        form_data: Current form data (for error re-rendering)
-        request: The request object
-        obj: Optional existing object (for change view)
-        
-    Returns:
-        List of field info dicts
+    Build render info grouped into fieldsets.
+
+    Returns a list of sections: {title, description, classes, fields:[info...]}.
     """
     readonly = set(model_admin.get_readonly_fields(request, obj))
-    fields_info = []
-    m2m_fields = model.meta.many_to_many
-    
-    for field_name in form_fields:
-        # Check if it's a ManyToMany field
-        is_m2m = field_name in m2m_fields
-        
-        if is_m2m:
-            field = m2m_fields[field_name]
-            field_type = "multiselect"
-            nullable = True  # M2M is always optional
-            
-            # Get current selected values for M2M
-            if form_data.get(field_name) is not None:
-                value = form_data[field_name]  # List of IDs from form
-            elif obj is not None:
-                # Fetch current related IDs
-                m2m_manager = getattr(obj, field_name)
-                related_ids = await m2m_manager.ids()
-                value = [str(rid) for rid in related_ids]
-            else:
-                value = []
-        else:
-            field = model.meta.get_field(field_name)
-            if not field:
-                continue
-            
-            field_type = model_admin.get_field_type(field_name)
-            nullable = getattr(field, "nullable", False)
-            
-            # Get current value
-            if form_data.get(field_name) is not None:
-                value = form_data[field_name]
-            elif obj is not None:
-                value = getattr(obj, field_name, "")
-            else:
-                value = ""
-            
-            # Format datetime values for HTML datetime-local input (YYYY-MM-DDTHH:MM)
-            if field_type == "datetime-local" and value:
-                from datetime import datetime
-                if isinstance(value, datetime):
-                    value = value.strftime("%Y-%m-%dT%H:%M")
-                elif isinstance(value, str) and value:
-                    try:
-                        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
-                        value = dt.strftime("%Y-%m-%dT%H:%M")
-                    except (ValueError, AttributeError):
-                        pass
-            
-            # Convert value to string for regular fields
-            if not isinstance(value, list):
-                value = str(value) if value is not None else ""
-        
-        field_info = {
-            "name": field_name,
-            "label": field_name.replace("_", " ").title(),
-            "type": field_type,
-            "value": value,
-            "readonly": field_name in readonly,
-            "required": not nullable,
-            "choices": None,
-            "widget_html": None,  # Will be set if custom widget exists
-        }
-        
-        # Check for custom widget (for non-M2M fields)
-        if not is_m2m and field:
-            widget = model_admin.get_widget(field_name, field)
-            if widget:
-                # Render the widget and store HTML
-                field_info["widget_html"] = widget.render(field_name, value, field)
-        
-        # Fetch choices for FK and M2M fields
-        if field_type in ("select", "multiselect"):
-            field_info["choices"] = await model_admin.get_field_choices(field_name, request)
-        
-        fields_info.append(field_info)
-    
-    return fields_info
+    sections: List[Dict[str, Any]] = []
+
+    for title, opts in model_admin.get_fieldsets(request, obj):
+        field_infos = []
+        for field_name in opts.get("fields", []):
+            info = await _build_field_info(
+                field_name, model, model_admin, form_data, request, obj, readonly
+            )
+            if info is not None:
+                field_infos.append(info)
+        sections.append(
+            {
+                "title": title,
+                "description": opts.get("description"),
+                "classes": opts.get("classes", []),
+                "fields": field_infos,
+            }
+        )
+    return sections
 
 
 # -----------------------------------------------------------------------------
-# Login View: /admin/login/
+# Login / Logout
 # -----------------------------------------------------------------------------
 
-async def admin_login(request: Request) -> HTMLResponse:
-    """
-    Admin login page.
-    
-    Route: GET, POST /admin/login/
-    """
+async def admin_login(request: Request, site: "AdminSite" = None) -> HTMLResponse:
+    """Admin login page. Route: GET, POST /admin/login/"""
+    site = _resolve_site(site)
     settings = _get_settings()
     error = None
     username = ""
-    next_url = _validate_next_url(request.query_params.get("next", "/admin/"))
-    
-    # Check if user is already logged in
+    default_next = _url_path(request.url_for(f"{site.name}:index"))
+    next_url = _validate_next_url(
+        request.query_params.get("next", default_next),
+        default=default_next,
+    )
+
     user = getattr(request.state, "user", None)
     if user and getattr(user, "is_staff", False):
         return RedirectResponse(url=next_url, status_code=status.HTTP_302_FOUND)
-    
+
     if request.method == "POST":
         form_data = await _read_admin_form(request)
         username = form_data.get("username", "")
         password = form_data.get("password", "")
-        next_url = _validate_next_url(form_data.get("next", "/admin/"))
-        
+        next_url = _validate_next_url(form_data.get("next", default_next), default=default_next)
+
         if username and password:
-            # Try to authenticate
             try:
                 from aksara.contrib.auth import authenticate
-                
+
                 user = await authenticate(
-                    request.app.db,
-                    username=username,
-                    password=password,
+                    request.app.db, username=username, password=password
                 )
-                
                 if user:
                     if not getattr(user, "is_staff", False):
-                        error = "You don't have permission to access the admin. Staff access required."
+                        error = (
+                            "You don't have permission to access the admin. "
+                            "Staff access required."
+                        )
                     else:
-                        # Create session token
                         from aksara.contrib.auth import create_session_token
-                        
+
                         token = await create_session_token(request.app.db, user)
-                        
-                        # Set cookie and redirect
                         response = RedirectResponse(
-                            url=next_url,
-                            status_code=status.HTTP_302_FOUND,
+                            url=next_url, status_code=status.HTTP_302_FOUND
                         )
                         response.set_cookie(
                             key="session_token",
@@ -891,44 +1107,32 @@ async def admin_login(request: Request) -> HTMLResponse:
                             httponly=True,
                             secure=settings.cookie_secure,
                             samesite="strict",
-                            max_age=60 * 60 * 24 * 7,  # 7 days
+                            max_age=60 * 60 * 24 * 7,
                         )
                         return response
                 else:
                     error = "Invalid username or password."
             except ImportError:
                 error = "Authentication module not configured. Please set up aksara.contrib.auth."
-            except Exception as e:
-                logger.exception("Admin login error: %s", e)
+            except Exception as exc:
+                logger.exception("Admin login error: %s", exc)
                 error = "Login failed. Please try again."
         else:
             error = "Please enter both username and password."
-    
+
     return _render_admin_template(
         request,
+        site,
         "admin/login.html",
-        {
-            "error": error,
-            "username": username,
-            "next": next_url,
-            "site_name": "Aksara Admin",
-        },
+        {"error": error, "username": username, "next": next_url},
     )
 
 
-# -----------------------------------------------------------------------------
-# Logout View: /admin/logout/
-# -----------------------------------------------------------------------------
-
-async def admin_logout(request: Request) -> RedirectResponse:
-    """
-    Admin logout - clears session and redirects to login.
-    
-    Route: POST /admin/logout/
-    """
+async def admin_logout(request: Request, site: "AdminSite" = None) -> RedirectResponse:
+    """Admin logout - clears session and redirects to login. Route: POST /admin/logout/"""
+    site = _resolve_site(site)
     await _read_admin_form(request)
 
-    # Try to invalidate session in database
     try:
         token = request.cookies.get("session_token")
         if token and request.app.db:
@@ -936,10 +1140,9 @@ async def admin_logout(request: Request) -> RedirectResponse:
             await invalidate_session_token(request.app.db, token)
     except Exception:
         pass  # Session cleanup is best-effort
-    
-    # Clear cookie and redirect to login
+
     response = RedirectResponse(
-        url=str(request.url_for("admin:login")),
+        url=site.logout_url or str(request.url_for(f"{site.name}:login")),
         status_code=status.HTTP_302_FOUND,
     )
     response.delete_cookie(
@@ -949,5 +1152,4 @@ async def admin_logout(request: Request) -> RedirectResponse:
         secure=_get_settings().cookie_secure,
         samesite="strict",
     )
-    
     return response

--- a/aksara/contrib/admin/views.py
+++ b/aksara/contrib/admin/views.py
@@ -532,9 +532,10 @@ async def model_list(
     # rejected by PostgreSQL.
     per_page = max(int(model_admin.list_per_page or 100), 1)
     total = await queryset.count()
+    max_show_all = int(model_admin.list_max_show_all or 200)
     show_all = (
         request.query_params.get("all") == "1"
-        and total <= int(model_admin.list_max_show_all or 200)
+        and total <= max_show_all
     )
     try:
         page = max(int(request.query_params.get("p", "1")), 1)
@@ -580,7 +581,9 @@ async def model_list(
                 cells.append({"value": value, "is_html": False, "is_link": is_link})
         rows.append({"obj": obj, "cells": cells})
 
-    pagination = _build_pagination(request, page, num_pages, total, per_page, show_all)
+    pagination = _build_pagination(
+        request, page, num_pages, total, per_page, show_all, max_show_all
+    )
 
     return _render_admin_template(
         request,
@@ -644,6 +647,7 @@ def _build_pagination(
     total: int,
     per_page: int,
     show_all: bool,
+    max_show_all: int,
 ) -> Dict[str, Any]:
     return {
         "page": page,
@@ -656,7 +660,7 @@ def _build_pagination(
         "prev_url": _with_params(request, p=page - 1) if page > 1 else None,
         "next_url": _with_params(request, p=page + 1) if page < num_pages else None,
         "show_all_url": _with_params(request, all="1", p=None)
-        if (not show_all and total <= per_page * num_pages and num_pages > 1)
+        if (not show_all and num_pages > 1 and total <= max_show_all)
         else None,
     }
 
@@ -683,12 +687,15 @@ async def model_add(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Permission denied")
 
     form_fields = model_admin.get_form_fields(request)
+    readonly_fields = set(model_admin.get_readonly_fields(request))
     errors: Dict[str, str] = {}
     form_data: Dict[str, Any] = {}
 
     if request.method == "POST":
         raw_form = await _read_admin_form(request)
         form_data = _parse_form_data(raw_form, model, form_fields)
+        for field_name in readonly_fields:
+            form_data.pop(field_name, None)
 
         try:
             obj = model(**form_data)

--- a/aksara/studio/fastapi.py
+++ b/aksara/studio/fastapi.py
@@ -295,7 +295,7 @@ async def verify_studio_auth(request: Request) -> None:
             from aksara.contrib.auth import get_user_from_session_token
 
             # Reuse the admin path's DB-backed session lookup for staff cookies.
-            db = getattr(request.scope.get("app"), "db", None)
+            db = getattr(request.app, "db", None)
             if db is not None:
                 user = await get_user_from_session_token(db, session_token)
                 if user and getattr(user, "is_staff", False):

--- a/docs/docs/admin/admin-permissions.md
+++ b/docs/docs/admin/admin-permissions.md
@@ -4,523 +4,248 @@ Control who can see, add, edit, and delete data in the admin interface.
 
 ---
 
-## What are Permissions?
+## Levels of Permission
 
-**Permissions** determine what users can do. Without permissions, anyone could access your admin and modify data—which would be a security disaster.
+| Level | Controls | Where |
+|-------|----------|-------|
+| **Site** | Access to the admin at all | `AdminSite(permission_classes=...)` |
+| **Module** | Whether a model appears in the dashboard/sidebar | `ModelAdmin.has_module_permission` |
+| **Object** | View/add/change/delete records | `ModelAdmin.has_*_permission` |
+| **Field** | Which fields are visible / editable | `get_fields`, `get_readonly_fields` |
+| **Action** | Who can run a bulk action | `@action(permissions=[...])` |
 
-Aksara admin permissions work at four levels:
-
-| Level | What It Controls | Example |
-|-------|------------------|---------|
-| **Site** | Who can access the admin at all | "Only staff members can open `/admin/`" |
-| **Model** | Who can see a model in the admin | "Only superusers can see the Settings model" |
-| **Object** | Who can edit specific records | "Authors can only edit their own posts" |
-| **Action** | Who can perform bulk operations | "Only admins can bulk-delete posts" |
+The admin reads the current user from `request.state.user` (populated by the
+admin session middleware from the `session_token` cookie).
 
 ---
 
 ## Site-Level Permissions
 
-Site-level permissions control who can access the admin interface at all.
-
-### Default: Staff Only
-
-By default, users need `is_staff=True` to access admin:
-
-```python
-# Give a user admin access
-user = await User.objects.get(email="alice@example.com")
-user.is_staff = True
-await user.save()
-# Now Alice can access /admin/
-```
-
-### Superuser Only
-
-Restrict to superusers (users with full system access):
+By default the admin requires an authenticated **staff** user (`is_staff=True`).
+To customize, pass `permission_classes` — standard `aksara.permissions`
+classes — to the site. When set, they replace the default staff gate for site
+access.
 
 ```python
+from aksara.contrib.admin import AdminSite
 from aksara.permissions import BasePermission
 
 class IsSuperuser(BasePermission):
-    """Only superusers can access."""
-    
-    def has_permission(self, request, view):
-        return (
-            request.user.is_authenticated and
-            request.user.is_superuser
-        )
+    def has_permission(self, request, view=None):
+        user = self.get_user(request)
+        return bool(user and getattr(user, "is_superuser", False))
 
-admin = AdminSite(
-    permission_classes=[IsSuperuser],
-)
+admin = AdminSite(permission_classes=[IsSuperuser])
 ```
 
-### Custom Role Check
-
-Check for specific roles or attributes:
-
-```python
-class IsEditorOrHigher(BasePermission):
-    """Editors, admins, and superusers can access."""
-    
-    def has_permission(self, request, view):
-        if not request.user.is_authenticated:
-            return False
-        
-        # Check user's role
-        return request.user.role in ["editor", "admin", "superuser"]
-
-admin = AdminSite(
-    permission_classes=[IsEditorOrHigher],
-)
-```
-
-### Multiple Requirements (AND)
-
-When you pass multiple permission classes, ALL must pass:
-
-```python
-admin = AdminSite(
-    permission_classes=[
-        IsAuthenticated,  # Must be logged in
-        IsStaff,          # AND must be staff
-        HasVerifiedEmail, # AND must have verified email
-    ],
-)
-```
+Combine requirements with the built-in `IsAuthenticated`, `IsAdminUser`, etc., or
+your own `BasePermission` subclasses.
 
 ---
 
-## Model-Level Permissions
+## Module-Level Permissions
 
-Model-level permissions control which models appear in the admin and what users can do with them.
-
-### has_module_permission
-
-**What it does**: Controls whether the model appears in the admin sidebar/index.
-
-**When to use**: To completely hide sensitive models from certain users.
+`has_module_permission(self, request)` controls whether a model shows up in the
+dashboard and app index for the current user. It defaults to the view permission.
 
 ```python
 class SettingsAdmin(ModelAdmin):
     def has_module_permission(self, request):
-        """Only superusers can see Settings in the admin."""
-        return request.user.is_superuser
+        return request.state.user.is_superuser
 ```
 
-**Result**: Non-superusers won't see "Settings" in the admin menu at all.
-
-### CRUD Permissions
-
-These four methods control Create, Read, Update, Delete access:
-
-```python
-class PostAdmin(ModelAdmin):
-    
-    def has_view_permission(self, request, obj=None):
-        """Can user VIEW posts in the admin?"""
-        return True  # Everyone can view
-    
-    def has_add_permission(self, request):
-        """Can user CREATE new posts?"""
-        return request.user.is_staff  # Staff only
-    
-    def has_change_permission(self, request, obj=None):
-        """Can user EDIT posts?"""
-        return request.user.is_staff  # Staff only
-    
-    def has_delete_permission(self, request, obj=None):
-        """Can user DELETE posts?"""
-        return request.user.is_superuser  # Superusers only
-```
-
-**Note**: The `obj` parameter is `None` for list views (checking general permission) and contains the specific object for detail views (checking permission on that specific record).
+Non-superusers won't see the model listed (the underlying detail routes are also
+guarded by the view/change permissions below).
 
 ---
 
-## Object-Level Permissions
+## Object-Level (CRUD) Permissions
 
-Object-level permissions let you control access to specific records, not just the model as a whole.
-
-### "Edit Your Own" Pattern
-
-The most common pattern: users can only edit records they created.
+Override these to control Create, Read, Update, Delete. They may be **sync or
+async**. `obj` is `None` for list-level checks and the specific record for
+detail-level checks.
 
 ```python
 class PostAdmin(ModelAdmin):
-    
+    def has_view_permission(self, request, obj=None):
+        return request.state.user.is_staff
+
+    def has_add_permission(self, request):
+        return request.state.user.is_staff
+
     def has_change_permission(self, request, obj=None):
-        """Users can only edit their own posts."""
-        
-        # List view: check general permission
-        if obj is None:
-            return request.user.is_staff
-        
-        # Detail view: check specific object
-        # Superusers can edit anything
-        if request.user.is_superuser:
-            return True
-        
-        # Others can only edit their own posts
-        return str(obj.author_id) == str(request.user.id)
-    
+        user = request.state.user
+        if obj is None or user.is_superuser:
+            return user.is_staff
+        return str(obj.author_id) == str(user.id)   # edit your own only
+
     def has_delete_permission(self, request, obj=None):
-        """Users can only delete their own posts."""
-        
-        if obj is None:
-            return request.user.is_staff
-        
-        if request.user.is_superuser:
-            return True
-        
-        return str(obj.author_id) == str(request.user.id)
+        return request.state.user.is_superuser
 ```
 
-**How it works**:
-- Alice creates a post → Alice and superusers can edit/delete it
-- Bob creates a post → Bob and superusers can edit/delete it
-- Alice cannot edit Bob's post (unless she's a superuser)
+### Async permissions
 
-### Team-Based Permissions
-
-For collaborative apps where teams share access:
+When a check needs a database lookup, define it as `async def`:
 
 ```python
 class ProjectAdmin(ModelAdmin):
-    
     async def has_change_permission(self, request, obj=None):
-        """Team members can edit their team's projects."""
-        
-        if obj is None:
-            return request.user.is_staff
-        
-        if request.user.is_superuser:
-            return True
-        
-        # Check if user is a member of the project's team
-        is_member = await obj.team.members.filter(
-            id=str(request.user.id)
-        ).exists()
-        
-        return is_member
-```
-
-### Manager/Subordinate Permissions
-
-For hierarchical organizations:
-
-```python
-class EmployeeAdmin(ModelAdmin):
-    
-    async def has_change_permission(self, request, obj=None):
-        """Managers can edit their direct reports."""
-        
-        if obj is None:
-            return request.user.is_staff
-        
-        if request.user.is_superuser:
-            return True
-        
-        # Check if this employee reports to the current user
-        return str(obj.manager_id) == str(request.user.id)
-```
-
----
-
-## Action Permissions
-
-Control who can perform bulk actions (operations on multiple selected records).
-
-### Restrict by CRUD Permission
-
-Link actions to existing permission methods:
-
-```python
-class PostAdmin(ModelAdmin):
-    actions = ["publish", "feature", "archive"]
-    
-    @admin.action(description="Publish selected posts")
-    async def publish(self, request, queryset):
-        await queryset.update(is_published=True)
-    # Requires "change" permission (has_change_permission)
-    publish.allowed_permissions = ["change"]
-    
-    @admin.action(description="Feature selected posts")
-    async def feature(self, request, queryset):
-        await queryset.update(is_featured=True)
-    # Also requires "change" permission
-    feature.allowed_permissions = ["change"]
-    
-    @admin.action(description="Archive selected posts")
-    async def archive(self, request, queryset):
-        await queryset.update(is_archived=True)
-    # Requires "delete" permission (more restrictive)
-    archive.allowed_permissions = ["delete"]
-```
-
-### Custom Action Permissions
-
-Create custom permission methods for specific actions:
-
-```python
-class PostAdmin(ModelAdmin):
-    actions = ["export_csv"]
-    
-    @admin.action(description="Export to CSV")
-    async def export_csv(self, request, queryset):
-        """Export selected posts to a CSV file."""
-        # ... export logic ...
-    
-    def has_export_csv_permission(self, request):
-        """Custom permission: only users with export role."""
-        return (
-            request.user.is_superuser or
-            "exporter" in request.user.roles
-        )
-    
-    # Link action to custom permission
-    export_csv.allowed_permissions = ["export_csv"]
+        user = request.state.user
+        if obj is None or user.is_superuser:
+            return user.is_staff
+        return await obj.team.members.filter(id=str(user.id)).exists()
 ```
 
 ---
 
 ## Field-Level Permissions
 
-Control which fields users can see or edit.
-
-### Read-Only Fields for Some Users
+### Read-only fields per user
 
 ```python
 class PostAdmin(ModelAdmin):
-    
     def get_readonly_fields(self, request, obj=None):
-        """Some fields are read-only for non-superusers."""
-        
-        # Start with base readonly fields
         readonly = list(self.readonly_fields)
-        
-        if not request.user.is_superuser:
-            # Regular staff can't edit these sensitive fields
-            readonly.extend([
-                "is_featured",   # Only admins can feature posts
-                "view_count",    # System-managed
-                "author",        # Can't reassign posts
-            ])
-        
+        if not request.state.user.is_superuser:
+            readonly += ["is_featured", "author"]
         return readonly
 ```
 
-### Hide Fields Entirely
+### Show different fields per user or action
 
 ```python
 class UserAdmin(ModelAdmin):
-    
     def get_fields(self, request, obj=None):
-        """Hide sensitive fields from non-superusers."""
-        
-        # Default fields
-        fields = ["email", "name", "role", "is_active"]
-        
-        if request.user.is_superuser:
-            # Superusers can see everything
-            fields.extend(["password_hash", "api_key", "internal_notes"])
-        
-        return fields
-```
-
-### Different Fields for Add vs. Edit
-
-```python
-class PostAdmin(ModelAdmin):
-    
-    def get_fields(self, request, obj=None):
-        """Different fields when creating vs. editing."""
-        
-        if obj is None:
-            # Creating new post: minimal fields
-            return ["title", "content", "category"]
-        else:
-            # Editing existing post: all fields
-            return [
-                "title", "slug", "content", "category",
-                "is_published", "published_at", "is_featured",
-            ]
+        base = ["email", "name", "role", "is_active"]
+        if request.state.user.is_superuser:
+            base += ["api_key", "internal_notes"]
+        return base
 ```
 
 ---
 
-## Filtering What Users Can See
+## Filtering Visible Records
 
-### QuerySet Filtering
-
-Users only see records they have access to:
+Override `get_queryset` (async) so users only see records they should:
 
 ```python
 class PostAdmin(ModelAdmin):
-    
-    def get_queryset(self, request):
-        """Filter which posts appear in the list."""
-        
-        qs = super().get_queryset(request)
-        
-        if request.user.is_superuser:
-            # Superusers see everything
+    async def get_queryset(self, request):
+        qs = await super().get_queryset(request)
+        user = request.state.user
+        if user.is_superuser:
             return qs
-        
-        # Others only see their own posts
-        return qs.filter(author_id=str(request.user.id))
-```
-
-**Result**: When Alice views the post list, she only sees her posts. Bob only sees his. Superusers see all posts.
-
-### Combining with Permissions
-
-```python
-class PostAdmin(ModelAdmin):
-    
-    def get_queryset(self, request):
-        """Authors see own posts; editors see all."""
-        
-        qs = super().get_queryset(request)
-        
-        if request.user.is_superuser:
-            return qs
-        
-        if request.user.role == "editor":
-            # Editors see all posts but can only edit assigned ones
-            return qs
-        
-        # Regular authors only see their own
-        return qs.filter(author_id=str(request.user.id))
-    
-    def has_change_permission(self, request, obj=None):
-        """Editors can only edit posts assigned to them."""
-        
-        if obj is None:
-            return request.user.is_staff
-        
-        if request.user.is_superuser:
-            return True
-        
-        if request.user.role == "editor":
-            # Editors can edit posts assigned to them
-            return str(obj.assigned_editor_id) == str(request.user.id)
-        
-        # Authors can edit their own posts
-        return str(obj.author_id) == str(request.user.id)
+        return qs.filter(author_id=str(user.id))
 ```
 
 ---
 
-## Permission Quick Reference
+## Action Permissions
 
-| Method | Controls | When `obj` is None |
-|--------|----------|-------------------|
-| `has_module_permission(request)` | Model visibility in admin | N/A |
-| `has_view_permission(request, obj)` | Can view records | List view permission |
-| `has_add_permission(request)` | Can create records | N/A (no object yet) |
-| `has_change_permission(request, obj)` | Can edit records | List view permission |
-| `has_delete_permission(request, obj)` | Can delete records | List view permission |
-
----
-
-## Complete Example
+Tie a bulk action to a permission with the `permissions` argument of `@action`.
+Each name `X` is checked against `has_X_permission(request)` before the action
+runs.
 
 ```python
-from aksara.contrib.admin import ModelAdmin, AdminSite
-from aksara.permissions import BasePermission
+from aksara.contrib.admin import ModelAdmin, action
 
-
-class IsStaffOrReadOnly(BasePermission):
-    """Staff can do anything; others can only view."""
-    
-    def has_permission(self, request, view):
-        if request.user.is_authenticated:
-            return True
-        return False
-
-
-admin = AdminSite(
-    permission_classes=[IsStaffOrReadOnly],
-)
-
-
-@admin.register(Post)
 class PostAdmin(ModelAdmin):
-    list_display = ["title", "author", "is_published"]
-    actions = ["publish", "feature"]
-    
-    # ─── Model Permissions ─────────────────────────────
-    
-    def has_module_permission(self, request):
-        """Everyone can see Posts in the menu."""
-        return True
-    
-    def has_view_permission(self, request, obj=None):
-        """Everyone can view posts."""
-        return True
-    
-    def has_add_permission(self, request):
-        """Only staff can create posts."""
-        return request.user.is_staff
-    
-    def has_change_permission(self, request, obj=None):
-        """Staff can edit; authors can edit their own."""
-        if obj is None:
-            return request.user.is_staff
-        if request.user.is_superuser:
-            return True
-        return str(obj.author_id) == str(request.user.id)
-    
-    def has_delete_permission(self, request, obj=None):
-        """Only superusers and post authors can delete."""
-        if obj is None:
-            return request.user.is_staff
-        if request.user.is_superuser:
-            return True
-        return str(obj.author_id) == str(request.user.id)
-    
-    # ─── QuerySet Filtering ────────────────────────────
-    
-    def get_queryset(self, request):
-        """Superusers see all; others see own posts."""
-        qs = super().get_queryset(request)
-        if request.user.is_superuser:
-            return qs
-        return qs.filter(author_id=str(request.user.id))
-    
-    # ─── Field Permissions ─────────────────────────────
-    
-    def get_readonly_fields(self, request, obj=None):
-        """Regular users can't modify featured status."""
-        readonly = ["created_at", "updated_at"]
-        if not request.user.is_superuser:
-            readonly.append("is_featured")
-        return readonly
-    
-    # ─── Action Permissions ────────────────────────────
-    
-    @admin.action(description="Publish selected")
+    actions = ["publish", "archive"]
+
+    @action(description="Publish selected", permissions=["change"])
     async def publish(self, request, queryset):
         await queryset.update(is_published=True)
-    publish.allowed_permissions = ["change"]
-    
-    @admin.action(description="Feature selected")
-    async def feature(self, request, queryset):
-        await queryset.update(is_featured=True)
-    # Custom permission: only superusers can feature
-    feature.allowed_permissions = ["feature"]
-    
-    def has_feature_permission(self, request):
-        """Only superusers can feature posts."""
-        return request.user.is_superuser
+
+    @action(description="Archive selected", permissions=["delete"])
+    async def archive(self, request, queryset):
+        await queryset.update(is_archived=True)
 ```
+
+If the current user fails the required permission, the action is rejected with a
+403.
+
+For object-aware hooks such as `has_change_permission(request, obj)` and
+`has_delete_permission(request, obj)`, bulk actions also check each selected
+object before the action runs. If any selected object fails, the whole action is
+rejected and no built-in delete is performed.
+
+---
+
+## Complete Pattern
+
+This example combines module visibility, row filtering, object-level edit/delete
+rules, readonly fields, and a guarded bulk action:
+
+```python
+from aksara.contrib.admin import ModelAdmin, action
+
+class PostAdmin(ModelAdmin):
+    list_display = ["title", "author", "is_published"]
+    actions = ["publish_selected", "delete_selected"]
+
+    def has_module_permission(self, request):
+        return request.state.user.is_staff
+
+    async def get_queryset(self, request):
+        qs = await super().get_queryset(request)
+        user = request.state.user
+        if user.is_superuser:
+            return qs
+        return qs.filter(author_id=str(user.id))
+
+    def has_change_permission(self, request, obj=None):
+        user = request.state.user
+        if obj is None:
+            return user.is_staff
+        return user.is_superuser or str(obj.author_id) == str(user.id)
+
+    def has_delete_permission(self, request, obj=None):
+        user = request.state.user
+        if obj is None:
+            return user.is_staff
+        return user.is_superuser
+
+    def get_readonly_fields(self, request, obj=None):
+        if request.state.user.is_superuser:
+            return ["created_at", "updated_at"]
+        return ["created_at", "updated_at", "author"]
+
+    @action(description="Publish selected", permissions=["change"])
+    async def publish_selected(self, request, queryset):
+        count = await queryset.update(is_published=True)
+        self.message_user(request, f"Published {count} posts.", level="success")
+```
+
+---
+
+## Security Notes
+
+- Keep admin CSRF enabled in production. Disabling
+  `AKSARA_ADMIN_CSRF_ENABLED` should be limited to tests or controlled local
+  debugging.
+- A model hidden by `has_module_permission()` is not shown in the dashboard, but
+  direct model routes are still protected by `has_view_permission`,
+  `has_change_permission`, and related hooks.
+- Use `get_queryset()` for data visibility. Permission hooks decide whether an
+  operation is allowed; the queryset decides which rows the user can list and
+  select.
+
+---
+
+## Quick Reference
+
+| Method | Controls | `obj=None` means |
+|--------|----------|------------------|
+| `has_module_permission(request)` | Model visibility in the dashboard | n/a |
+| `has_view_permission(request, obj)` | View records | list-level check |
+| `has_add_permission(request)` | Create records | n/a |
+| `has_change_permission(request, obj)` | Edit records | list-level check |
+| `has_delete_permission(request, obj)` | Delete records | list-level check |
 
 ---
 
 ## Related Documentation
 
-- [AdminSite](admin-site.md) — Configure the admin interface
+- [AdminSite](admin-site.md) — Configure and mount the admin
 - [ModelAdmin](model-admin.md) — Customize model display
 - [Authentication](../api/authentication.md) — User login system

--- a/docs/docs/admin/admin-site.md
+++ b/docs/docs/admin/admin-site.md
@@ -1,416 +1,228 @@
 # AdminSite
 
-The main container for your admin interface—where you configure how the admin looks and which models it manages.
+The container for your admin interface — it holds registered models and controls branding, theme, and access.
 
 ---
 
 ## What is AdminSite?
 
-An **AdminSite** is like the headquarters of your admin interface. It:
+An **AdminSite** holds the models you want to manage and the presentation
+settings for the admin. Aksara ships a ready-to-use global instance called
+`site`; most apps register everything on it and mount it with `include_admin()`.
 
-- Holds all the models you want to manage
-- Controls the appearance (title, header, theme)
-- Manages authentication (who can access)
-- Gets mounted to your app at a URL like `/admin/`
+```python
+from aksara.contrib.admin import site
+
+site.register(Post)
+```
+
+You can also create additional, independently-configured sites:
 
 ```python
 from aksara.contrib.admin import AdminSite
 
-admin = AdminSite(
-    title="My Admin",            # Browser tab text
-    site_header="My Application", # Header shown on every page
-)
+ops = AdminSite(name="ops", site_header="Ops Console", theme="dark")
 ```
 
 ---
 
 ## Configuration Options
 
-### Basic Setup
+`AdminSite` accepts the following (all keyword-only except `name`):
+
+| Option | What It Does | Default |
+|--------|--------------|---------|
+| `name` | Route-name namespace for this site (must be unique per app) | `"admin"` |
+| `title` | Browser tab text | `"Aksara Admin"` |
+| `site_header` | Header/brand shown on every page | `"Aksara Admin"` |
+| `index_title` | Heading on the dashboard | `"Dashboard"` |
+| `login_url` / `logout_url` | Override auth redirect targets | `None` |
+| `theme` | `"default"` or `"dark"` | `"default"` |
+| `index_template` | Custom dashboard template path | `None` |
+| `extra_css` | Extra stylesheet URLs to include | `[]` |
+| `permission_classes` | `BasePermission` list gating site access | `[]` |
 
 ```python
 admin = AdminSite(
-    # What users see
-    title="Admin",              # Browser tab: "Admin"
-    site_header="Site Admin",   # Top of page: "Site Admin"
-    index_title="Dashboard",    # Homepage heading: "Dashboard"
-    
-    # Where admin lives
-    url_prefix="/admin",        # URL: yoursite.com/admin/
-    
-    # Look and feel
-    theme="default",            # "default" or "dark"
+    name="blog",
+    title="Blog Admin",
+    site_header="Blog Administration",
+    index_title="Dashboard",
+    theme="dark",
+    extra_css=["/static/blog-admin.css"],
 )
 ```
 
-### All Configuration Options
-
-| Option | What It Does | Default | Example |
-|--------|--------------|---------|---------|
-| `title` | Browser tab text | `"Admin"` | `"Blog Admin"` |
-| `site_header` | Header at top of every page | `"Site Admin"` | `"My Blog"` |
-| `index_title` | Heading on dashboard page | `"Dashboard"` | `"Welcome"` |
-| `url_prefix` | Base URL path | `"/admin"` | `"/manage"` |
-| `login_url` | Where to go to log in | `"/admin/login/"` | `"/auth/login"` |
-| `logout_url` | Where to go after logout | `"/admin/logout/"` | `"/auth/logout"` |
-| `theme` | Visual theme | `"default"` | `"dark"` |
-| `permission_classes` | Who can access | `[IsAdminUser]` | `[IsSuperuser]` |
+`title` is used in the browser title, `site_header` is the brand shown in the
+admin chrome, and `index_title` is the dashboard heading.
 
 ---
 
 ## Registering Models
 
-**Registering** tells the admin: "I want to manage this model." There are several ways to do it.
-
-### Method 1: Decorator (Recommended)
-
-The `@admin.register()` decorator is clean and keeps the model and its admin config together:
+### Decorator (recommended)
 
 ```python
-from aksara.contrib.admin import ModelAdmin
+from aksara.contrib.admin import site, ModelAdmin
 
-@admin.register(Post)
+@site.register(Post)
 class PostAdmin(ModelAdmin):
     list_display = ["title", "author"]
 ```
 
-### Method 2: Register Method
-
-Call `admin.register()` directly—useful when the admin class is defined elsewhere:
+### Direct call
 
 ```python
-from aksara.contrib.admin import ModelAdmin
-
 class PostAdmin(ModelAdmin):
     list_display = ["title", "author"]
 
-# Register separately
-admin.register(Post, PostAdmin)
+site.register(Post, PostAdmin)   # with a custom admin
+site.register(Author)            # with defaults
 ```
 
-### Method 3: Simple Registration
-
-For basic models that don't need customization, just pass the model:
+### Multiple models, same config
 
 ```python
-admin.register(Post)      # Uses default settings
-admin.register(Author)
-admin.register(Category)
-```
-
-### Method 4: Multiple Models, Same Config
-
-When several models should share the same admin configuration:
-
-```python
-@admin.register(Post, Draft, Archive)
+@site.register(Post, Draft, Archive)
 class ContentAdmin(ModelAdmin):
-    """Same admin for all content-type models."""
     list_display = ["title", "created_at"]
-    search_fields = ["title"]
 ```
+
+Registering the same model twice raises `ValueError`. Use `site.unregister(Model)`
+to remove a registration.
 
 ---
 
 ## Mounting the Admin
 
-**Mounting** connects your admin to your application so it's accessible via a URL.
-
-### Basic Mount
+`include_admin()` attaches the routes, session + CSRF + rate-limit middleware,
+and static files to your app.
 
 ```python
-from aksara import Aksara
-from myapp.admin import admin
+from aksara.contrib.admin import include_admin
 
-app = Aksara()
-app.mount("/admin", admin)  # Admin at: http://localhost:8000/admin/
+include_admin(app)                       # global `site` at /admin/
+include_admin(app, prefix="/manage")     # custom prefix
 ```
 
-### Custom URL Path
+The admin CSRF cookie is scoped to the mounted prefix. If you mount at
+`/manage`, admin forms under `/manage/` work without sharing that cookie with
+unrelated paths.
+
+### Multiple admin sites
+
+Each site has a unique `name`, so several sites can be mounted on one app without
+route collisions:
 
 ```python
-app.mount("/manage", admin)    # Admin at: http://localhost:8000/manage/
-app.mount("/backend", admin)   # Admin at: http://localhost:8000/backend/
-```
+from aksara.contrib.admin import AdminSite, include_admin
 
-### Multiple Admin Sites
-
-You can have separate admin interfaces for different purposes:
-
-```python
-# Public admin: for content editors
-public_admin = AdminSite(
-    title="Content Admin",
-    site_header="Content Management",
-)
+public_admin = AdminSite(name="content", site_header="Content")
 public_admin.register(Post)
 public_admin.register(Category)
 
-# Private admin: for superusers with full access
-private_admin = AdminSite(
-    title="Full Admin",
-    site_header="System Administration",
-)
-private_admin.register(Post)
-private_admin.register(User)
-private_admin.register(Settings)
-private_admin.register(AuditLog)
+ops_admin = AdminSite(name="ops", site_header="Operations")
+ops_admin.register(AuditLog)
 
-# Mount both at different URLs
-app.mount("/admin", public_admin)        # /admin/ for editors
-app.mount("/superadmin", private_admin)  # /superadmin/ for admins
+include_admin(app, prefix="/admin", site=public_admin)
+include_admin(app, prefix="/ops", site=ops_admin)
 ```
 
----
+Each mounted site has independent route names and branding. The session cookie is
+shared, so a user authenticated as staff can move between sites, but each site
+still runs its own `permission_classes` and each `ModelAdmin` still runs its own
+model/object permission hooks.
 
-## Customizing the Dashboard
+### Custom login and logout targets
 
-The **dashboard** (index page) is the first thing users see when they open the admin.
-
-### Custom Dashboard with Statistics
-
-Override the index view to show custom data:
-
-```python
-admin = AdminSite()
-
-@admin.index_view
-async def custom_dashboard(request):
-    """Show statistics on the dashboard."""
-    return {
-        # These become available in the template
-        "recent_posts": await Post.objects.order_by("-created_at")[:5],
-        "total_users": await User.objects.count(),
-        "pending_reviews": await Post.objects.filter(status="pending").count(),
-        "today_signups": await User.objects.filter(created_at__date=today).count(),
-    }
-```
-
-### Custom Dashboard Template
-
-Use your own HTML template for complete control:
+Use `login_url` when authentication is handled by your own route instead of the
+built-in admin login form. Aksara appends a safe relative `next` parameter:
 
 ```python
 admin = AdminSite(
-    index_template="admin/my_dashboard.html",
+    name="staff",
+    login_url="/accounts/login",
+    logout_url="/accounts/signed-out",
 )
 ```
 
-Then create `templates/admin/my_dashboard.html`:
+When an unauthenticated user opens `/staff/`, they are redirected to:
 
-```html
-{% extends "admin/base.html" %}
-
-{% block content %}
-<div class="dashboard">
-    <h1>Welcome, {{ user.name }}!</h1>
-    
-    <div class="stats-grid">
-        <div class="stat-card">
-            <h3>{{ total_users }}</h3>
-            <p>Total Users</p>
-        </div>
-        <div class="stat-card">
-            <h3>{{ pending_reviews }}</h3>
-            <p>Pending Reviews</p>
-        </div>
-    </div>
-    
-    <h2>Recent Posts</h2>
-    <ul>
-    {% for post in recent_posts %}
-        <li>{{ post.title }} by {{ post.author.name }}</li>
-    {% endfor %}
-    </ul>
-</div>
-{% endblock %}
+```text
+/accounts/login?next=/staff/
 ```
+
+`logout_url` controls where the built-in logout route redirects after clearing
+the session cookie.
 
 ---
 
-## Authentication
+## Custom Dashboard
 
-The admin must know who's logged in and whether they're allowed access.
-
-### Default: Staff Users Only
-
-By default, only users with `is_staff=True` can access the admin:
+Use the `@site.index_view` decorator to add context to the dashboard. The function
+receives the request and returns a dict that is merged into the index template
+context:
 
 ```python
-# Give a user admin access
-user.is_staff = True
-await user.save()
-```
-
-### Require Superuser
-
-To restrict to superusers only:
-
-```python
-from aksara.permissions import BasePermission
-
-class IsSuperuser(BasePermission):
-    """Only allow superusers."""
-    def has_permission(self, request, view):
-        return (
-            request.user.is_authenticated and
-            request.user.is_superuser
-        )
-
-admin = AdminSite(
-    permission_classes=[IsSuperuser],
-)
-```
-
-### Use Your App's Login
-
-If your app already has login/logout pages, use those instead of the admin's:
-
-```python
-admin = AdminSite(
-    login_url="/auth/login",    # Redirect here to log in
-    logout_url="/auth/logout",  # Redirect here to log out
-)
-```
-
-### Multiple Permission Requirements
-
-All permissions must pass (AND logic):
-
-```python
-admin = AdminSite(
-    permission_classes=[
-        IsAuthenticated,  # Must be logged in
-        IsStaff,          # AND must be staff
-        IsNotBanned,      # AND must not be banned
-    ],
-)
-```
-
----
-
-## Themes
-
-### Built-in Themes
-
-```python
-# Light theme (default)
-admin = AdminSite(theme="default")
-
-# Dark theme
-admin = AdminSite(theme="dark")
-```
-
-### Custom CSS
-
-Add your own styles:
-
-```python
-admin = AdminSite(
-    extra_css=["/static/admin/custom.css"],
-)
-```
-
----
-
-## Unregistering Models
-
-Remove a model from the admin (useful for overriding third-party admin configs):
-
-```python
-# Remove if previously registered
-admin.unregister(Post)
-
-# Then re-register with your own config
-@admin.register(Post)
-class MyPostAdmin(ModelAdmin):
-    list_display = ["title", "custom_field"]
-```
-
----
-
-## Getting Registered Models
-
-Access the list of registered models:
-
-```python
-# Get all registered models
-for model, model_admin in admin.registry.items():
-    print(f"{model.__name__}: {model_admin.__class__.__name__}")
-
-# Check if a model is registered
-if Post in admin.registry:
-    print("Post is registered")
-
-# Get the ModelAdmin for a model
-post_admin = admin.registry.get(Post)
-```
-
----
-
-## Complete Example
-
-```python
-# admin.py
-from aksara.contrib.admin import AdminSite, ModelAdmin
-from aksara.permissions import BasePermission
-from myapp.models import Post, Author, Category, Settings
-
-
-# Custom permission
-class IsEditorOrAdmin(BasePermission):
-    def has_permission(self, request, view):
-        if not request.user.is_authenticated:
-            return False
-        return request.user.role in ["editor", "admin", "superuser"]
-
-
-# Create admin site
-admin = AdminSite(
-    title="Blog Admin",
-    site_header="Blog Content Management",
-    index_title="Dashboard",
-    permission_classes=[IsEditorOrAdmin],
-)
-
-
-# Custom dashboard
-@admin.index_view
+@site.index_view
 async def dashboard(request):
     return {
-        "post_count": await Post.objects.count(),
+        "total_users": await User.objects.count(),
         "draft_count": await Post.objects.filter(is_published=False).count(),
-        "author_count": await Author.objects.count(),
     }
-
-
-# Register models
-@admin.register(Post)
-class PostAdmin(ModelAdmin):
-    list_display = ["title", "author", "is_published", "created_at"]
-    list_filter = ["is_published", "category"]
-    search_fields = ["title", "content"]
-
-
-@admin.register(Author)
-class AuthorAdmin(ModelAdmin):
-    list_display = ["name", "email", "post_count"]
-    search_fields = ["name", "email"]
-
-
-# Simple registration
-admin.register(Category)
 ```
 
-```python
-# main.py
-from aksara import Aksara
-from aksara.contrib.auth.middleware import AuthenticationMiddleware
-from myapp.admin import admin
+To render an entirely custom dashboard, point `index_template` at your own template:
 
-app = Aksara()
-app.add_middleware(AuthenticationMiddleware)
-app.mount("/admin", admin)
+```python
+admin = AdminSite(index_template="admin/my_dashboard.html")
+```
+
+Your template extends the admin base and can use any keys returned by the
+`index_view` function.
+
+---
+
+## Access Control
+
+By default the admin requires an authenticated **staff** user (`is_staff=True`).
+To customize site-level access, pass `permission_classes` (see
+[Permissions](admin-permissions.md)):
+
+```python
+from aksara.permissions import IsAdminUser
+
+admin = AdminSite(permission_classes=[IsAdminUser])
+```
+
+When `permission_classes` is set, it replaces the default staff-only gate for
+site access. Per-model access is still governed by each `ModelAdmin`'s permission
+methods.
+
+---
+
+## Security Notes
+
+- Keep `AKSARA_ADMIN_CSRF_ENABLED` enabled outside tests. The admin uses a
+  same-site CSRF cookie plus a hidden form token for POST requests.
+- Mount admin only on trusted origins. The admin is designed for staff users, not
+  for public anonymous traffic.
+- If you pass `permission_classes`, those classes replace the default site-level
+  staff gate. Model-level and object-level permissions still run afterward.
+- Session lookup failures are logged and treated as unauthenticated requests.
+
+---
+
+## Inspecting the Registry
+
+```python
+for model, model_admin in site.registry.items():
+    print(model.__name__, model_admin.__class__.__name__)
+
+if site.is_registered(Post):
+    ...
+
+post_admin = site.get_model_admin(Post)
 ```
 
 ---

--- a/docs/docs/admin/index.md
+++ b/docs/docs/admin/index.md
@@ -8,83 +8,66 @@ A web-based dashboard that lets you view, create, edit, and delete your data wit
 
 An **admin interface** (or admin panel) is a private website where you manage your application's data. Instead of writing database queries or building forms manually, Aksara generates a complete management interface automatically from your models.
 
-Think of it like a spreadsheet for your database—but with forms, search, filters, and user permissions built in.
-
 ```python
-from aksara.contrib.admin import AdminSite, ModelAdmin
-from myapp.models import Post, Author
+from aksara.contrib.admin import site, ModelAdmin, include_admin
+from myapp.models import Post
 
-# Create an admin site (the main admin dashboard)
-admin = AdminSite()
-
-# Register a model (tell admin to manage this data)
-@admin.register(Post)
+# Register a model with the admin site
+@site.register(Post)
 class PostAdmin(ModelAdmin):
     list_display = ["title", "author", "is_published", "created_at"]
     search_fields = ["title", "content"]
+    list_filter = ["is_published"]
 
-# Attach admin to your app at the /admin/ URL
-app.mount("/admin", admin)
+# Mount the admin onto your app at /admin/
+include_admin(app)
 ```
 
 ---
 
 ## Quick Start
 
-### 1. Create an Admin Site
+### 1. Register Models
 
-An **AdminSite** is the main container for your admin interface. It holds all the models you want to manage.
+There is a ready-to-use global admin site, `site`. **Registering** a model tells the admin: "I want to manage this type of data." Once registered, the admin creates pages to list, add, edit, and delete records.
 
 ```python
 # admin.py
-from aksara.contrib.admin import AdminSite
-
-admin = AdminSite(
-    title="My Admin",           # Browser tab title
-    site_header="My App Admin", # Header text shown on every page
-)
-```
-
-### 2. Register Models
-
-**Registering** a model tells the admin: "I want to manage this type of data." Once registered, the admin creates pages to list, add, edit, and delete records.
-
-```python
-from aksara.contrib.admin import ModelAdmin
+from aksara.contrib.admin import site, ModelAdmin
 from myapp.models import Post, Author, Category
 
 # Full control: customize how Post appears in admin
-@admin.register(Post)
+@site.register(Post)
 class PostAdmin(ModelAdmin):
     list_display = ["title", "author", "is_published"]
 
-# Another customized model
-@admin.register(Author)
-class AuthorAdmin(ModelAdmin):
-    list_display = ["name", "email"]
-
 # Quick registration: use all defaults
-admin.register(Category)
+site.register(Category)
 ```
 
-### 3. Mount the Admin
+### 2. Mount the Admin
 
-**Mounting** attaches the admin to your application at a URL path. This makes the admin accessible via your web server.
+`include_admin()` attaches the admin routes (and the required session/CSRF middleware and static files) to your application.
 
 ```python
 # main.py
 from aksara import Aksara
-from myapp.admin import admin
+from aksara.contrib.admin import include_admin
+import myapp.admin  # noqa: F401 — registers models with `site`
 
-app = Aksara()
-app.mount("/admin", admin)  # Admin is now at /admin/
+app = Aksara(database_url="postgresql://localhost/myapp")
+include_admin(app)              # Admin at /admin/
+# include_admin(app, prefix="/manage")   # …or a custom prefix
 ```
 
-### 4. Access the Admin
+!!! note "Auto-mount in development"
+    When `debug=True` (and the auth contrib is available), Aksara auto-mounts the
+    admin at `/admin/`, so an explicit `include_admin(app)` is optional in
+    development. Set `enable_admin=True` to mount it in production.
 
-Start your server and navigate to `http://localhost:8000/admin/`
+### 3. Access the Admin
 
-You'll see a dashboard listing all your registered models, with options to manage each one.
+Start your server and navigate to `http://localhost:8000/admin/`. You'll see a dashboard listing the apps and models you can manage. Admin access requires an authenticated **staff** user (`is_staff=True`).
 
 ---
 
@@ -92,11 +75,14 @@ You'll see a dashboard listing all your registered models, with options to manag
 
 | Feature | What It Does |
 |---------|--------------|
-| **Auto-generated UI** | Creates list, add, edit, delete pages automatically from your models |
-| **Search** | Find records by typing keywords |
-| **Filters** | Narrow down records by field values (like "show only published posts") |
-| **Permissions** | Control who can view, add, edit, or delete data |
-| **Responsive** | Works on phones, tablets, and desktops |
+| **Auto-generated UI** | List, add, edit, and delete pages generated from your models |
+| **Search** | `search_fields` adds a search box across model fields |
+| **Filters** | `list_filter` adds a sidebar to narrow records by field value |
+| **Ordering & pagination** | `ordering`, sortable columns, and `list_per_page` |
+| **Bulk actions** | Run an operation on selected rows (incl. built-in delete) |
+| **Permissions** | Per-model and per-object access control |
+| **Custom columns** | Computed/formatted columns from `ModelAdmin` methods |
+| **Structured widgets** | JSON and array editors for complex fields |
 
 ---
 
@@ -104,153 +90,108 @@ You'll see a dashboard listing all your registered models, with options to manag
 
 ### Models vs. ModelAdmin
 
-- A **Model** defines your data structure (what fields exist, what types they are)
-- A **ModelAdmin** controls how that model appears in the admin (which columns show, what's searchable)
+- A **Model** defines your data structure (what fields exist, what types they are).
+- A **ModelAdmin** controls how that model appears in the admin (which columns show, what's searchable, how forms are laid out).
 
 ```python
-# This is a MODEL - defines the data
 class Post(Model):
     title = fields.String(max_length=200)
     content = fields.Text()
     is_published = fields.Boolean(default=False)
 
-# This is a MODELADMIN - controls the admin interface
-@admin.register(Post)
+@site.register(Post)
 class PostAdmin(ModelAdmin):
-    list_display = ["title", "is_published"]  # Columns in the list
-    search_fields = ["title", "content"]       # Fields to search
+    list_display = ["title", "is_published"]   # columns in the list
+    search_fields = ["title", "content"]        # fields to search
 ```
 
 ### List View vs. Detail View
 
-The admin has two main views for each model:
+- **List View**: a paginated table of records, with optional search, filters, sortable columns and bulk actions.
+- **Detail View**: a form for creating or editing a single record, optionally grouped into fieldsets.
 
-- **List View**: A table showing all records (like a spreadsheet)
-- **Detail View**: A form for viewing/editing a single record
+### Admin vs. Studio
 
-```
-List View (all posts)          Detail View (editing one post)
-┌────────────────────────┐     ┌────────────────────────┐
-│ Title     │ Published  │     │ Title: [My Post     ]  │
-├───────────┼────────────┤     │ Content:               │
-│ My Post   │ ✓          │────▶│ [                   ]  │
-│ Draft     │ ✗          │     │ Published: [✓]         │
-│ News      │ ✓          │     │ [Save] [Delete]        │
-└────────────────────────┘     └────────────────────────┘
-```
+Aksara ships two browser UIs with different jobs:
+
+| UI | Path | Use it for |
+|----|------|------------|
+| **Admin** | `/admin/` | Day-to-day data management by authenticated staff users: create records, edit content, run bulk actions, and review model data. |
+| **Studio** | `/studio/ui` | Developer/operator inspection: models, routes, migrations, diagnostics, AI tools, and project health. |
+
+Use Admin when a user is managing application data. Use Studio when a developer
+or operator is inspecting how the application is built and running. They share
+the same app process, but their security settings are separate.
 
 ---
 
-## Section Contents
+## Security Defaults
 
-<div class="grid cards" markdown>
+Admin access requires a staff user by default. Form POSTs use a same-site CSRF
+cookie and hidden form token, and login/action POSTs are rate-limited.
 
--   :material-cog: **[AdminSite](admin-site.md)**
-    
-    Configure the main admin dashboard
-
--   :material-view-list: **[ModelAdmin](model-admin.md)**
-    
-    Customize how each model appears
-
--   :material-shield-lock: **[Permissions](admin-permissions.md)**
-    
-    Control who can access what
-
-</div>
+!!! warning "Do not disable CSRF in production"
+    `AKSARA_ADMIN_CSRF_ENABLED=false` is intended only for controlled tests or
+    local debugging. Leave CSRF enabled for deployed admin sites.
 
 ---
 
 ## Complete Example
 
-Here's a full admin setup for a blog application:
-
 ```python
 # admin.py
-from aksara.contrib.admin import AdminSite, ModelAdmin
+from aksara.contrib.admin import site, ModelAdmin, action
 from myapp.models import Post, Author, Category, Tag
 
 
-# Create the admin site
-admin = AdminSite(
-    title="Blog Admin",
-    site_header="Blog Administration",
-    index_title="Dashboard",
-)
-
-
-@admin.register(Post)
+@site.register(Post)
 class PostAdmin(ModelAdmin):
     """Manage blog posts."""
-    
-    # List view: what columns to show
+
     list_display = ["title", "author", "category", "is_published", "created_at"]
-    
-    # List view: sidebar filters
-    list_filter = ["is_published", "category", "created_at"]
-    
-    # List view: searchable fields
+    list_display_links = ["title"]
+    list_filter = ["is_published", "category"]
     search_fields = ["title", "content"]
-    
-    # List view: default sort order (- means descending)
     ordering = ["-created_at"]
-    
-    # Detail view: which fields to show on the edit form
-    fields = [
-        "title", "slug", "content",
-        "author", "category", "tags",
-        "is_published", "is_featured",
+    list_per_page = 25
+
+    fieldsets = [
+        (None, {"fields": ["title", "slug", "content"]}),
+        ("Publication", {
+            "fields": ["author", "category", "tags", "is_published"],
+            "classes": ["collapse"],
+        }),
     ]
-    
-    # Detail view: fields that can't be edited
     readonly_fields = ["created_at", "updated_at"]
+    prepopulated_fields = {"slug": ("title",)}
+    actions = ["publish_selected"]
+
+    @action(description="Publish selected posts", permissions=["change"])
+    async def publish_selected(self, request, queryset):
+        count = await queryset.update(is_published=True)
+        self.message_user(request, f"Published {count} posts.")
 
 
-@admin.register(Author)
-class AuthorAdmin(ModelAdmin):
-    """Manage authors."""
-    
-    list_display = ["name", "email", "post_count", "created_at"]
-    search_fields = ["name", "email"]
-    
-    def post_count(self, obj):
-        """Custom column: count how many posts this author has."""
-        return len(obj.posts)
-
-
-@admin.register(Category)
-class CategoryAdmin(ModelAdmin):
-    """Manage categories."""
-    
-    list_display = ["name", "slug", "parent"]
-    
-    # Auto-fill slug when typing name
-    prepopulated_fields = {"slug": ("name",)}
-
-
-# Simple registration with all defaults
-admin.register(Tag)
+site.register(Author)
+site.register(Category)
+site.register(Tag)
 ```
 
 ```python
 # main.py
 from aksara import Aksara
-from aksara.contrib.auth.middleware import AuthenticationMiddleware
-from myapp.admin import admin
+from aksara.contrib.admin import include_admin
+import myapp.admin  # noqa: F401
 
-app = Aksara()
-
-# Required: authentication so admin knows who's logged in
-app.add_middleware(AuthenticationMiddleware)
-
-# Mount admin at /admin/
-app.mount("/admin", admin)
+app = Aksara(database_url="postgresql://localhost/myapp")
+include_admin(app)
 ```
 
 ---
 
 ## Related Documentation
 
+- [AdminSite](admin-site.md) — Configure and mount admin sites
+- [ModelAdmin](model-admin.md) — Customize how each model appears
+- [Permissions](admin-permissions.md) — Control who can access what
 - [Models](../orm/models.md) — Define your data structure
-- [Authentication](../api/authentication.md) — User login system
-- [Permissions](admin-permissions.md) — Control access to admin

--- a/docs/docs/admin/model-admin.md
+++ b/docs/docs/admin/model-admin.md
@@ -6,381 +6,218 @@ Control how your data appears and behaves in the admin interface.
 
 ## What is ModelAdmin?
 
-A **ModelAdmin** is a configuration class that tells the admin interface how to display and handle a specific model. Without it, the admin uses sensible defaults. With it, you can customize everything.
+A **ModelAdmin** is a configuration class that tells the admin how to display and
+handle a specific model. Without it, the admin uses sensible defaults; with it,
+you customize the list view, the form, permissions, and bulk actions.
 
 ```python
-from aksara.contrib.admin import ModelAdmin
+from aksara.contrib.admin import site, ModelAdmin
 
-@admin.register(Post)
+@site.register(Post)
 class PostAdmin(ModelAdmin):
-    # What columns appear in the list
     list_display = ["title", "author", "is_published", "created_at"]
-    
-    # What fields users can search
     search_fields = ["title", "content"]
-    
-    # Sidebar filters for narrowing results
     list_filter = ["is_published", "category"]
+    ordering = ["-created_at"]
 ```
 
 ---
 
 ## List View Options
 
-The **list view** shows all records in a table format. These options control that table.
-
 ### list_display
 
-**What it does**: Specifies which columns appear in the list table.
-
-**Default**: Shows all fields (can be cluttered for models with many fields).
+Which columns appear in the list table. Defaults to the first few model fields.
 
 ```python
 class PostAdmin(ModelAdmin):
-    # Show these 4 columns in the table
     list_display = ["title", "author", "is_published", "created_at"]
 ```
 
-**Result**:
-```
-┌──────────────┬─────────┬───────────┬────────────┐
-│ Title        │ Author  │ Published │ Created    │
-├──────────────┼─────────┼───────────┼────────────┤
-│ Hello World  │ Alice   │ ✓         │ 2024-01-15 │
-│ My Draft     │ Bob     │ ✗         │ 2024-01-14 │
-└──────────────┴─────────┴───────────┴────────────┘
-```
+#### Custom columns
 
-#### Custom Columns
-
-You can add columns that don't exist as fields—computed values like word counts or formatted badges:
+A name in `list_display` that is **not** a model field but **is** a method on the
+admin becomes a computed column. Set `short_description` for the header and
+`allow_html` to render markup:
 
 ```python
 class PostAdmin(ModelAdmin):
-    list_display = ["title", "author", "word_count", "status_badge"]
-    
+    list_display = ["title", "word_count", "status_badge"]
+
     def word_count(self, obj):
-        """Count words in the content field."""
-        return len(obj.content.split())
-    word_count.short_description = "Words"  # Column header
-    
+        return len((obj.content or "").split())
+    word_count.short_description = "Words"
+
     def status_badge(self, obj):
-        """Show a colored badge instead of True/False."""
-        if obj.is_published:
-            return '<span class="badge green">Published</span>'
-        return '<span class="badge gray">Draft</span>'
-    status_badge.allow_html = True  # Allow HTML rendering
+        cls = "green" if obj.is_published else "gray"
+        label = "Published" if obj.is_published else "Draft"
+        return f'<span class="badge {cls}">{label}</span>'
+    status_badge.short_description = "Status"
+    status_badge.allow_html = True
 ```
 
----
+Custom columns are not database-sortable, so they render without a sort link.
 
 ### list_display_links
 
-**What it does**: Specifies which columns are clickable links to the edit page.
-
-**Default**: The first column is a link.
+Which columns link to the change form. Defaults to the first column.
 
 ```python
 class PostAdmin(ModelAdmin):
     list_display = ["title", "author", "created_at"]
-    list_display_links = ["title"]  # Only title is clickable
+    list_display_links = ["title"]
 ```
-
-Set to `None` to make no columns clickable (view-only list).
-
----
 
 ### list_filter
 
-**What it does**: Adds a sidebar with filters to narrow down the list.
-
-**Why use it**: When you have hundreds of records, filters help find specific subsets quickly.
+Adds a sidebar of filters. Each entry is either a **field name** (auto-generates
+options from boolean values, `choices`, or distinct values) or a
+**`SimpleListFilter`** subclass for custom logic.
 
 ```python
 class PostAdmin(ModelAdmin):
-    list_filter = [
-        "is_published",      # Checkbox: Published? Yes/No
-        "category",          # Dropdown: all categories
-        "created_at",        # Date picker: Today, Past 7 days, This month, etc.
-        "author__is_staff",  # Filter by a related model's field
-    ]
+    list_filter = ["is_published", "category"]
 ```
 
-**Result**: A sidebar appears with filter options:
-```
-Filters
-─────────────────
-Published
-  ○ All
-  ● Yes
-  ○ No
-
-Category
-  ○ All
-  ○ Tech
-  ○ News
-  ○ Tutorial
-```
-
-#### Custom Filters
-
-For complex filtering logic, create a custom filter class:
+Custom filter:
 
 ```python
 from aksara.contrib.admin import SimpleListFilter
 from datetime import date, timedelta
 
 class RecentlyPublishedFilter(SimpleListFilter):
-    title = "Published"              # Sidebar section title
-    parameter_name = "published"     # URL query parameter
-    
+    title = "Published"
+    parameter_name = "published"
+
     def lookups(self, request, model_admin):
-        """Define the filter options."""
-        return [
-            ("today", "Today"),
-            ("week", "This Week"),
-            ("month", "This Month"),
-        ]
-    
+        return [("week", "This week"), ("month", "This month")]
+
     def queryset(self, request, queryset):
-        """Filter the queryset based on selected option."""
         today = date.today()
-        
-        if self.value() == "today":
-            return queryset.filter(published_at__date=today)
         if self.value() == "week":
             return queryset.filter(published_at__gte=today - timedelta(days=7))
         if self.value() == "month":
             return queryset.filter(published_at__gte=today - timedelta(days=30))
-        
-        return queryset  # No filter applied
+        return queryset
 
 class PostAdmin(ModelAdmin):
     list_filter = ["is_published", RecentlyPublishedFilter]
 ```
 
----
-
 ### search_fields
 
-**What it does**: Enables a search box and specifies which fields to search.
-
-**How it works**: When a user types "hello", the admin finds records where any search field contains "hello".
+Adds a search box. Searching matches any listed field (case-insensitive,
+combined with OR) against the model's own columns.
 
 ```python
 class PostAdmin(ModelAdmin):
-    search_fields = [
-        "title",           # Search in post title
-        "content",         # Search in post content
-        "author__name",    # Search in related author's name
-        "author__email",   # Search in related author's email
-    ]
+    search_fields = ["title", "content"]
 ```
 
-**Syntax for related fields**: Use double underscores (`__`) to search fields on related models. `author__name` means "the name field of the related author".
-
----
+!!! note "Related-field search"
+    Own-table fields are fully supported. Related lookups (e.g. `author__name`)
+    are applied on a best-effort basis and depend on the ORM's relation filtering,
+    which is still maturing — prefer own-table fields for reliable search.
 
 ### ordering
 
-**What it does**: Sets the default sort order for the list.
-
-**Syntax**: Prefix with `-` for descending (newest first), no prefix for ascending (oldest first).
+Default sort order. Prefix with `-` for descending. Clicking a sortable column
+header overrides it for that request.
 
 ```python
 class PostAdmin(ModelAdmin):
-    ordering = ["-created_at"]  # Newest posts first
+    ordering = ["-created_at"]
 ```
 
-```python
-class PostAdmin(ModelAdmin):
-    ordering = ["title"]  # Alphabetical by title (A-Z)
-```
+### Pagination
 
 ```python
 class PostAdmin(ModelAdmin):
-    ordering = ["-is_featured", "-created_at"]  # Featured first, then by date
+    list_per_page = 50        # rows per page (default 100)
+    list_max_show_all = 200   # cap for the optional "Show all" link
 ```
 
 ---
 
-### list_per_page
+## Form (Detail View) Options
 
-**What it does**: How many records to show per page.
+### fields / exclude
 
-**Default**: 20
-
-```python
-class PostAdmin(ModelAdmin):
-    list_per_page = 50  # Show 50 records per page
-```
-
----
-
-### list_max_show_all
-
-**What it does**: Maximum records for the "Show all" link (disables pagination).
-
-**Default**: 200
+`fields` lists exactly which fields appear (and their order); `exclude` removes
+fields from the default set.
 
 ```python
 class PostAdmin(ModelAdmin):
-    list_max_show_all = 500  # Allow showing up to 500 at once
+    fields = ["title", "slug", "content", "author", "is_published"]
+
+class DraftAdmin(ModelAdmin):
+    exclude = ["internal_notes"]
 ```
 
----
-
-## Detail View Options
-
-The **detail view** is the form for creating or editing a single record.
-
-### fields
-
-**What it does**: Specifies which fields appear on the edit form and in what order.
-
-**Default**: All fields appear.
-
-```python
-class PostAdmin(ModelAdmin):
-    fields = ["title", "slug", "content", "author", "category", "tags"]
-```
-
----
-
-### exclude
-
-**What it does**: Hides specific fields from the form (opposite of `fields`).
-
-**When to use**: When you want most fields but need to hide a few.
-
-```python
-class PostAdmin(ModelAdmin):
-    exclude = ["internal_notes", "legacy_id"]  # Hide these fields
-```
-
----
-
-### readonly_fields
-
-**What it does**: Shows fields on the form but prevents editing.
-
-**When to use**: For auto-generated fields like timestamps, or computed values.
-
-```python
-class PostAdmin(ModelAdmin):
-    fields = ["title", "content", "created_at", "updated_at", "view_count"]
-    readonly_fields = ["created_at", "updated_at", "view_count"]
-```
-
----
+By default the form shows all editable fields except the primary key and the
+auto-managed `created_at` / `updated_at` timestamps.
 
 ### fieldsets
 
-**What it does**: Groups fields into collapsible sections with headers.
-
-**When to use**: For models with many fields—organizing them improves usability.
+Group fields into sections. Each section is `(title_or_None, options)` where
+options may include `fields`, `description`, and `classes` (use `"collapse"` to
+start collapsed).
 
 ```python
 class PostAdmin(ModelAdmin):
     fieldsets = [
-        # Section 1: No header (None), always visible
-        (None, {
-            "fields": ["title", "slug", "content"],
-        }),
-        
-        # Section 2: "Metadata" header
+        (None, {"fields": ["title", "slug", "content"]}),
         ("Metadata", {
             "fields": ["author", "category", "tags"],
             "description": "Who wrote this and how it's categorized",
         }),
-        
-        # Section 3: Collapsed by default
-        ("Publication Settings", {
-            "fields": ["is_published", "published_at", "is_featured"],
-            "classes": ["collapse"],  # Start collapsed
-        }),
-        
-        # Section 4: SEO settings, also collapsed
-        ("SEO", {
-            "fields": ["seo_title", "seo_description"],
+        ("Publication", {
+            "fields": ["is_published", "published_at"],
             "classes": ["collapse"],
-            "description": "Search engine optimization settings",
         }),
     ]
 ```
 
-**Result**:
-```
-┌─────────────────────────────────────┐
-│ Title: [___________________________]│
-│ Slug:  [___________________________]│
-│ Content:                            │
-│ [                                  ]│
-├─────────────────────────────────────┤
-│ ▼ Metadata                          │
-│   Who wrote this and how...         │
-│   Author:   [Dropdown ▼]            │
-│   Category: [Dropdown ▼]            │
-│   Tags:     [___________]           │
-├─────────────────────────────────────┤
-│ ▶ Publication Settings (click to expand)
-├─────────────────────────────────────┤
-│ ▶ SEO (click to expand)             │
-└─────────────────────────────────────┘
-```
+`fields`/`exclude` and `fieldsets` are alternatives — when `fieldsets` is set it
+determines the form layout.
 
----
+### readonly_fields
+
+Fields shown on the form but not editable. Listed readonly fields appear when
+included via `fields`/`fieldsets`; otherwise they're omitted from the default form.
+
+```python
+class PostAdmin(ModelAdmin):
+    readonly_fields = ["created_at", "updated_at"]
+```
 
 ### prepopulated_fields
 
-**What it does**: Auto-fills a field based on another field's value.
-
-**Common use**: Generating URL slugs from titles.
+Auto-fill a field from others as you type (commonly slugs). Stops updating once
+the target field is edited manually.
 
 ```python
 class PostAdmin(ModelAdmin):
     prepopulated_fields = {"slug": ("title",)}
 ```
 
-**Result**: When you type "Hello World" in the title, the slug auto-fills with "hello-world".
-
----
-
 ### raw_id_fields
 
-**What it does**: Shows a text input for IDs instead of a dropdown for related fields.
-
-**When to use**: When the related table has thousands of records (dropdowns would be slow).
-
-```python
-class PostAdmin(ModelAdmin):
-    raw_id_fields = ["author"]  # Type author ID instead of picking from dropdown
-```
-
----
-
-### autocomplete_fields
-
-**What it does**: Shows a searchable autocomplete box for related fields.
-
-**When to use**: Best of both worlds—handles large tables but still user-friendly.
+Render a relation field as a plain id text input instead of a dropdown — useful
+when the related table is large.
 
 ```python
 class PostAdmin(ModelAdmin):
-    autocomplete_fields = ["author", "category"]
+    raw_id_fields = ["author"]
 ```
-
-**Requirement**: The related ModelAdmin must have `search_fields` defined.
 
 ---
 
 ## Widgets
 
-**Widgets** control how individual form fields are rendered. Most fields have sensible defaults, but you can customize them.
-
-### formfield_overrides
-
-**What it does**: Assigns custom widgets to specific fields.
+`formfield_overrides` assigns a custom widget to a field. JSON and Array fields
+get their dedicated widgets automatically, but you can configure them explicitly
+when you need different rows, item types, or limits.
 
 ```python
 from aksara.contrib.admin import ModelAdmin
@@ -388,350 +225,147 @@ from aksara.contrib.admin.widgets import JSONAdminWidget, ArrayAdminWidget
 
 class ProductAdmin(ModelAdmin):
     formfield_overrides = {
-        "metadata": JSONAdminWidget(),  # Interactive JSON editor
-        "tags": ArrayAdminWidget(),     # Dynamic list editor
+        "metadata": JSONAdminWidget(rows=16),              # JSON textarea + formatter
+        "tags": ArrayAdminWidget(item_type="text"),        # ordered list editor
+        "scores": ArrayAdminWidget(item_type="number"),    # numeric list editor
     }
 ```
 
-### Built-in Widgets
+### JSONAdminWidget
 
-#### JSONAdminWidget
-
-**What it does**: Provides an interactive JSON editor with syntax highlighting.
-
-**When to use**: For JSON/JSONB fields that store structured data.
+Use this for `JSON` fields. It renders a monospace textarea, pretty-prints the
+initial value when possible, and includes a client-side format button. Submitted
+values are still parsed by the admin form handling before save.
 
 ```python
-from aksara.contrib.admin.widgets import JSONAdminWidget
-
-class SettingsAdmin(ModelAdmin):
-    formfield_overrides = {
-        "config": JSONAdminWidget(),
-    }
+JSONAdminWidget(rows=12, pretty_print=True)
 ```
 
-**Features**:
+### ArrayAdminWidget
 
-- Syntax highlighting (colors for keys, values, brackets)
-- Real-time validation (shows errors as you type)
-- Pretty-print formatting (auto-indents JSON)
-- Collapsible sections for nested objects
-
-#### ArrayAdminWidget
-
-**What it does**: Provides a dynamic list editor for array fields.
-
-**When to use**: For PostgreSQL array fields (like tags, categories).
+Use this for PostgreSQL-style array fields. It renders repeatable rows, supports
+add/remove and drag reorder controls, and stores the resulting list in a hidden
+field submitted with the form.
 
 ```python
-from aksara.contrib.admin.widgets import ArrayAdminWidget
-
-class ArticleAdmin(ModelAdmin):
-    formfield_overrides = {
-        "tags": ArrayAdminWidget(),
-    }
+ArrayAdminWidget(item_type="text", min_rows=1, max_rows=20)
 ```
 
-**Features**:
-
-- Add/remove items with buttons
-- Drag-and-drop reordering
-- Validates each item individually
-- Shows placeholder for empty lists
-
-!!! tip "Auto-Detection"
-    JSON and Array fields automatically use their respective widgets. You only need `formfield_overrides` for custom configuration or to override the default widget for a field.
+Supported `item_type` values are regular HTML input types such as `"text"`,
+`"number"`, `"email"`, and `"url"`.
 
 ---
 
-## Actions
+## Bulk Actions
 
-**Actions** are operations you can perform on multiple selected records at once.
-
-### Built-in Actions
-
-```python
-class PostAdmin(ModelAdmin):
-    actions = ["delete_selected"]  # Bulk delete (enabled by default)
-```
-
-### Custom Actions
+Declare actions by name in `actions` and define them with the `@action`
+decorator. Each action receives the request and a queryset of the selected rows.
+Use `message_user` to report results; `permissions` ties the action to a
+permission check (`["change"]` requires `has_change_permission`).
 
 ```python
+from aksara.contrib.admin import ModelAdmin, action
+
 class PostAdmin(ModelAdmin):
-    actions = ["publish_selected", "unpublish_selected", "export_csv"]
-    
-    @admin.action(description="Publish selected posts")
+    actions = ["publish_selected", "delete_selected"]   # delete_selected is built in
+
+    @action(description="Publish selected posts", permissions=["change"])
     async def publish_selected(self, request, queryset):
-        """Mark all selected posts as published."""
         count = await queryset.update(is_published=True)
-        self.message_user(request, f"Published {count} posts")
-    
-    @admin.action(description="Unpublish selected posts")
-    async def unpublish_selected(self, request, queryset):
-        """Mark all selected posts as unpublished."""
-        count = await queryset.update(is_published=False)
-        self.message_user(request, f"Unpublished {count} posts")
-    
-    @admin.action(description="Export as CSV")
-    async def export_csv(self, request, queryset):
-        """Download selected posts as a CSV file."""
-        posts = await queryset.all()
-        csv_data = generate_csv(posts)
-        return FileResponse(csv_data, filename="posts.csv")
+        self.message_user(request, f"Published {count} posts.", level="success")
 ```
 
-**How users see this**: A dropdown above the list + checkboxes on each row:
+The list view shows an action dropdown and per-row checkboxes; `delete_selected`
+is provided out of the box.
 
-```
-Action: [Publish selected posts ▼] [Go]
-
-☑ Title           Author    Published
-☐ Hello World     Alice     ✓
-☑ My Draft        Bob       ✗
-☑ Breaking News   Carol     ✗
-```
+Action permissions are checked twice: once at the list level and again for each
+selected object when the permission hook accepts `obj`. This prevents bulk
+actions from bypassing object-level `has_change_permission` or
+`has_delete_permission` rules.
 
 ---
 
 ## Permissions
 
-Control who can do what in the admin.
-
-### Object-Level Permissions
-
-Override these methods to control access per-record:
+Override the permission methods to control access. They may be **sync or async**
+and read the user from `request.state.user`.
 
 ```python
 class PostAdmin(ModelAdmin):
-    def has_view_permission(self, request, obj=None):
-        """Can this user view posts?"""
-        return True  # Everyone can view
-    
     def has_add_permission(self, request):
-        """Can this user create new posts?"""
-        return request.user.is_staff
-    
+        return request.state.user.is_staff
+
     def has_change_permission(self, request, obj=None):
-        """Can this user edit this post?"""
-        if obj is None:
-            # General permission (for the list view)
-            return request.user.is_staff
-        # Specific permission: can only edit own posts
-        return (
-            request.user.is_superuser or
-            str(obj.author_id) == str(request.user.id)
-        )
-    
-    def has_delete_permission(self, request, obj=None):
-        """Can this user delete posts?"""
-        return request.user.is_superuser  # Only superusers
+        user = request.state.user
+        if obj is None or user.is_superuser:
+            return user.is_staff
+        return str(obj.author_id) == str(user.id)
 ```
+
+`has_module_permission(self, request)` controls whether the model appears in the
+dashboard/sidebar at all. See [Permissions](admin-permissions.md) for the full
+picture.
 
 ---
 
 ## Hooks
 
-Hooks let you run custom code at specific points.
-
-### save_model
-
-**When it runs**: Before saving a new or updated record.
-
-```python
-class PostAdmin(ModelAdmin):
-    async def save_model(self, request, obj, form, change):
-        """
-        obj: the model instance being saved
-        form: the submitted form data
-        change: True if editing, False if creating
-        """
-        if not change:
-            # Creating new post: set the author automatically
-            obj.author_id = str(request.user.id)
-        
-        # Always track who last modified
-        obj.updated_by_id = str(request.user.id)
-        
-        await obj.save()
-```
-
-### delete_model
-
-**When it runs**: Before deleting a record.
-
-```python
-class PostAdmin(ModelAdmin):
-    async def delete_model(self, request, obj):
-        """Soft delete instead of actually deleting."""
-        obj.is_deleted = True
-        obj.deleted_at = datetime.now()
-        await obj.save()
-        # Note: we don't call obj.delete()
-```
-
----
-
-## QuerySet Customization
-
 ### get_queryset
 
-**What it does**: Customize which records appear in the list.
+Customize the records shown. It is **async** — await `super().get_queryset()` and
+chain queryset methods:
 
 ```python
 class PostAdmin(ModelAdmin):
-    def get_queryset(self, request):
-        qs = super().get_queryset(request)
-        
-        # Optimization: load related data in one query
-        qs = qs.select_related("author", "category")
-        
-        # Security: non-superusers only see their own posts
-        if not request.user.is_superuser:
-            qs = qs.filter(author_id=str(request.user.id))
-        
+    async def get_queryset(self, request):
+        qs = await super().get_queryset(request)
+        if not request.state.user.is_superuser:
+            qs = qs.filter(author_id=str(request.state.user.id))
         return qs
 ```
 
----
-
-## Complete Example
+### save_model / delete_model
 
 ```python
-from aksara.contrib.admin import ModelAdmin, SimpleListFilter
-from aksara.contrib.admin.widgets import JSONAdminWidget
-from datetime import date, timedelta
-
-
-class RecentFilter(SimpleListFilter):
-    """Filter posts by publication date."""
-    title = "Published"
-    parameter_name = "when"
-    
-    def lookups(self, request, model_admin):
-        return [
-            ("today", "Today"),
-            ("week", "This Week"),
-            ("month", "This Month"),
-        ]
-    
-    def queryset(self, request, queryset):
-        today = date.today()
-        if self.value() == "today":
-            return queryset.filter(published_at__date=today)
-        if self.value() == "week":
-            return queryset.filter(published_at__gte=today - timedelta(days=7))
-        if self.value() == "month":
-            return queryset.filter(published_at__gte=today - timedelta(days=30))
-        return queryset
-
-
-@admin.register(Post)
 class PostAdmin(ModelAdmin):
-    """Full-featured Post admin."""
-    
-    # ─── List View ─────────────────────────────────────
-    list_display = [
-        "title", "author", "category", "status_badge",
-        "view_count", "created_at",
-    ]
-    list_display_links = ["title"]
-    list_filter = ["is_published", "is_featured", "category", RecentFilter]
-    search_fields = ["title", "content", "author__name"]
-    ordering = ["-created_at"]
-    list_per_page = 25
-    
-    # ─── Detail View ───────────────────────────────────
-    fieldsets = [
-        (None, {
-            "fields": ["title", "slug", "content"],
-        }),
-        ("Categorization", {
-            "fields": ["author", "category", "tags"],
-        }),
-        ("Publication", {
-            "fields": ["is_published", "is_featured", "published_at"],
-            "classes": ["collapse"],
-        }),
-        ("SEO", {
-            "fields": ["seo_title", "seo_description"],
-            "classes": ["collapse"],
-        }),
-    ]
-    readonly_fields = ["created_at", "updated_at", "view_count"]
-    prepopulated_fields = {"slug": ("title",)}
-    autocomplete_fields = ["author", "category"]
-    
-    # ─── Widgets ───────────────────────────────────────
-    formfield_overrides = {
-        "metadata": JSONAdminWidget(),
-    }
-    
-    # ─── Actions ───────────────────────────────────────
-    actions = ["publish_selected", "feature_selected"]
-    
-    def status_badge(self, obj):
-        """Custom column: colored status badge."""
-        if obj.is_featured:
-            return '<span class="badge gold">Featured</span>'
-        if obj.is_published:
-            return '<span class="badge green">Published</span>'
-        return '<span class="badge gray">Draft</span>'
-    status_badge.allow_html = True
-    status_badge.short_description = "Status"
-    
-    @admin.action(description="Publish selected")
-    async def publish_selected(self, request, queryset):
-        count = await queryset.update(is_published=True)
-        self.message_user(request, f"Published {count} posts")
-    
-    @admin.action(description="Feature selected")
-    async def feature_selected(self, request, queryset):
-        count = await queryset.update(is_featured=True)
-        self.message_user(request, f"Featured {count} posts")
-    
-    def get_queryset(self, request):
-        """Optimize queries and filter by user."""
-        qs = super().get_queryset(request)
-        qs = qs.select_related("author", "category")
-        if not request.user.is_superuser:
-            qs = qs.filter(author_id=str(request.user.id))
-        return qs
-    
-    def has_change_permission(self, request, obj=None):
-        """Users can only edit their own posts."""
-        if request.user.is_superuser:
-            return True
-        if obj and str(obj.author_id) == str(request.user.id):
-            return True
-        return False
-    
-    async def save_model(self, request, obj, form, change):
-        """Auto-set author on create."""
-        if not change:
-            obj.author_id = str(request.user.id)
-        await obj.save()
+    async def save_model(self, request, obj, form_data, is_created):
+        if is_created:
+            obj.author_id = str(request.state.user.id)
+        await super().save_model(request, obj, form_data, is_created)
+
+    async def delete_model(self, request, obj):
+        await obj.delete()
 ```
+
+`save_model` validates submitted many-to-many ids before mutating relations. If a
+related id can't be resolved it raises `ValueError`, which the form surfaces
+rather than silently dropping the selection. When many-to-many data is present,
+the save and relation update run inside one transaction so relation updates roll
+back if a later step fails.
 
 ---
 
 ## Quick Reference
 
-| Option | Purpose | Example |
-|--------|---------|---------|
-| `list_display` | Columns in list | `["title", "author"]` |
-| `list_filter` | Sidebar filters | `["status", "category"]` |
-| `search_fields` | Searchable fields | `["title", "content"]` |
-| `ordering` | Default sort | `["-created_at"]` |
-| `fields` | Form fields | `["title", "content"]` |
-| `readonly_fields` | Non-editable fields | `["created_at"]` |
-| `fieldsets` | Grouped sections | See example above |
-| `actions` | Bulk operations | `["publish", "delete"]` |
+| Option | Purpose |
+|--------|---------|
+| `list_display` | Columns in the list (fields or custom methods) |
+| `list_display_links` | Which columns link to the change form |
+| `list_filter` | Sidebar filters (field names or `SimpleListFilter`) |
+| `search_fields` | Searchable fields |
+| `ordering` | Default sort |
+| `list_per_page` / `list_max_show_all` | Pagination |
+| `fields` / `exclude` / `fieldsets` | Form layout |
+| `readonly_fields` | Non-editable fields |
+| `prepopulated_fields` | Auto-filled fields (e.g. slug) |
+| `raw_id_fields` | Relation as id text input |
+| `formfield_overrides` | Custom widgets |
+| `actions` | Bulk operations |
 
 ---
 
 ## Related Documentation
 
-- [AdminSite](admin-site.md) — Configure the admin dashboard
+- [AdminSite](admin-site.md) — Configure and mount the admin
 - [Permissions](admin-permissions.md) — Control access
 - [Models](../orm/models.md) — Define your data

--- a/docs/docs/api/filtering.md
+++ b/docs/docs/api/filtering.md
@@ -8,6 +8,8 @@ Aksara provides powerful, out-of-the-box filtering and search capabilities for y
 
 Manually parsing query parameters is tedious and error-prone. Aksara provides `AksaraFilterBackend` to automatically parse Django-style query parameters.
 
+`DjangoFilterBackend` remains available as a backward-compatible alias, but `AksaraFilterBackend` is the preferred name for new code.
+
 ### Setup
 
 Add the backend to your `ModelViewSet` and specify which fields are filterable:

--- a/docs/docs/api/filtering.md
+++ b/docs/docs/api/filtering.md
@@ -6,7 +6,7 @@ Aksara provides powerful, out-of-the-box filtering and search capabilities for y
 
 ## Automatic URL Filtering
 
-Manually parsing query parameters is tedious and error-prone. Aksara provides `DjangoFilterBackend` to automatically parse Django-style query parameters.
+Manually parsing query parameters is tedious and error-prone. Aksara provides `AksaraFilterBackend` to automatically parse Django-style query parameters.
 
 ### Setup
 
@@ -14,7 +14,7 @@ Add the backend to your `ModelViewSet` and specify which fields are filterable:
 
 ```python
 from aksara import Model, fields
-from aksara.api import ModelViewSet, DjangoFilterBackend
+from aksara.api import ModelViewSet, AksaraFilterBackend
 
 class Product(Model):
     name = fields.String()
@@ -24,7 +24,7 @@ class Product(Model):
 
 class ProductViewSet(ModelViewSet):
     model = Product
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [AksaraFilterBackend]
     filterable_fields = ['price', 'category', 'in_stock']
 
 # ✅ Now all these queries work automatically:
@@ -120,7 +120,7 @@ You can combine multiple backends to provide comprehensive list endpoints:
 ```python
 class PostViewSet(ModelViewSet):
     model = Post
-    filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
+    filter_backends = [AksaraFilterBackend, SearchFilter, OrderingFilter]
     filterable_fields = ['status', 'author_id']
     search_fields = ['title', 'content']
     ordering_fields = ['created_at', 'views']

--- a/tests/admin/test_admin_features_v051.py
+++ b/tests/admin/test_admin_features_v051.py
@@ -647,6 +647,142 @@ class TestAdminRoutingSecurity:
         assert "<title>Operations Home - Ops Browser</title>" in response.text
         assert "<h1>Operations Home</h1>" in response.text
 
+    def test_default_staff_user_can_login(self):
+        from starlette.testclient import TestClient
+        from aksara import Aksara
+        from aksara.conf import configure, settings
+        from aksara.contrib.admin import include_admin
+
+        site = AdminSite(name="stafflogin")
+        app = Aksara(database_url=None, debug=True, auto_discover_views=False, enable_admin=False)
+        include_admin(app, prefix="/stafflogin", site=site)
+        user = MagicMock()
+        user.is_staff = True
+
+        original_csrf = settings.admin_csrf_enabled
+        configure(admin_csrf_enabled=False)
+        try:
+            with TestClient(app, raise_server_exceptions=False, follow_redirects=False) as client:
+                with patch("aksara.contrib.auth.authenticate", new=AsyncMock(return_value=user)):
+                    with patch(
+                        "aksara.contrib.auth.create_session_token",
+                        new=AsyncMock(return_value="token"),
+                    ):
+                        response = client.post(
+                            "/stafflogin/login/",
+                            data={"username": "admin@test.com", "password": "secret"},
+                        )
+
+            assert response.status_code == 302
+            assert response.headers["location"] == "/stafflogin/"
+        finally:
+            configure(admin_csrf_enabled=original_csrf)
+
+    def test_default_non_staff_user_is_denied_login(self):
+        from starlette.testclient import TestClient
+        from aksara import Aksara
+        from aksara.conf import configure, settings
+        from aksara.contrib.admin import include_admin
+
+        site = AdminSite(name="staffonly")
+        app = Aksara(database_url=None, debug=True, auto_discover_views=False, enable_admin=False)
+        include_admin(app, prefix="/staffonly", site=site)
+        user = MagicMock()
+        user.is_staff = False
+
+        original_csrf = settings.admin_csrf_enabled
+        configure(admin_csrf_enabled=False)
+        try:
+            with TestClient(app, raise_server_exceptions=False, follow_redirects=False) as client:
+                create_session = AsyncMock(return_value="token")
+                with patch("aksara.contrib.auth.authenticate", new=AsyncMock(return_value=user)):
+                    with patch("aksara.contrib.auth.create_session_token", new=create_session):
+                        response = client.post(
+                            "/staffonly/login/",
+                            data={"username": "member@test.com", "password": "secret"},
+                        )
+
+            assert response.status_code == 200
+            assert "Staff access required" in response.text
+            create_session.assert_not_awaited()
+        finally:
+            configure(admin_csrf_enabled=original_csrf)
+
+    def test_custom_async_permission_can_allow_non_staff_login(self):
+        from starlette.testclient import TestClient
+        from aksara import Aksara
+        from aksara.conf import configure, settings
+        from aksara.contrib.admin import include_admin
+
+        class AllowMember:
+            message = "Member access required."
+
+            async def has_permission(self, request, view=None):
+                user = getattr(request.state, "user", None)
+                return getattr(user, "email", None) == "member@test.com"
+
+        site = AdminSite(name="memberadmin", permission_classes=[AllowMember])
+        app = Aksara(database_url=None, debug=True, auto_discover_views=False, enable_admin=False)
+        include_admin(app, prefix="/memberadmin", site=site)
+        user = MagicMock()
+        user.is_staff = False
+        user.email = "member@test.com"
+
+        original_csrf = settings.admin_csrf_enabled
+        configure(admin_csrf_enabled=False)
+        try:
+            with TestClient(app, raise_server_exceptions=False, follow_redirects=False) as client:
+                with patch("aksara.contrib.auth.authenticate", new=AsyncMock(return_value=user)):
+                    with patch(
+                        "aksara.contrib.auth.create_session_token",
+                        new=AsyncMock(return_value="token"),
+                    ):
+                        response = client.post(
+                            "/memberadmin/login/",
+                            data={"username": "member@test.com", "password": "secret"},
+                        )
+
+            assert response.status_code == 302
+            assert response.headers["location"] == "/memberadmin/"
+        finally:
+            configure(admin_csrf_enabled=original_csrf)
+
+    def test_custom_async_permission_can_deny_staff_login(self):
+        from starlette.testclient import TestClient
+        from aksara import Aksara
+        from aksara.conf import configure, settings
+        from aksara.contrib.admin import include_admin
+
+        class DenyAll:
+            message = "Denied by policy."
+
+            async def has_permission(self, request, view=None):
+                return False
+
+        site = AdminSite(name="lockedadmin", permission_classes=[DenyAll])
+        app = Aksara(database_url=None, debug=True, auto_discover_views=False, enable_admin=False)
+        include_admin(app, prefix="/lockedadmin", site=site)
+        user = MagicMock()
+        user.is_staff = True
+
+        original_csrf = settings.admin_csrf_enabled
+        configure(admin_csrf_enabled=False)
+        try:
+            with TestClient(app, raise_server_exceptions=False, follow_redirects=False) as client:
+                create_session = AsyncMock(return_value="token")
+                with patch("aksara.contrib.auth.authenticate", new=AsyncMock(return_value=user)):
+                    with patch("aksara.contrib.auth.create_session_token", new=create_session):
+                        response = client.post(
+                            "/lockedadmin/login/",
+                            data={"username": "admin@test.com", "password": "secret"},
+                        )
+
+            assert response.status_code == 200
+            assert "Staff access required" in response.text
+            create_session.assert_not_awaited()
+        finally:
+            configure(admin_csrf_enabled=original_csrf)
+
 
 class TestModelAdminSaveSafety:
     async def test_invalid_m2m_ids_do_not_save_or_clear_relations(self):
@@ -761,13 +897,14 @@ class TestDBBackedFeatures:
 class LockedNote(Model):
     name = fields.String()
     locked = fields.String(nullable=True)
+    enabled = fields.Boolean(default=False)
 
     class Meta:
         app_label = "locked_notes"
 
 
 class LockedNoteAdmin(ModelAdmin):
-    fields = ["name", "locked"]
+    fields = ["name", "locked", "enabled"]
     readonly_fields = ["locked"]
 
 
@@ -805,14 +942,16 @@ class TestAdminReadonlyHTTPIntegration:
 
         asyncio.run(run())
 
-    def _create_note(self, name, locked):
+    def _create_note(self, name, locked, enabled=False):
         import asyncio
         from aksara.db import Database
 
         async def run():
             db = Database(os.getenv("DATABASE_URL"))
             await db.connect()
-            note = await LockedNote.objects.create(name=name, locked=locked)
+            note = await LockedNote.objects.create(
+                name=name, locked=locked, enabled=enabled
+            )
             await db.disconnect()
             return str(note.id)
 
@@ -913,6 +1052,158 @@ class TestAdminReadonlyHTTPIntegration:
         finally:
             configure(admin_csrf_enabled=original_csrf)
             self._drop_schema()
+
+    def _enabled_checkbox(self, html):
+        import re
+
+        match = re.search(r'<input[^>]+name="enabled"[^>]*>', html)
+        assert match is not None
+        return match.group(0)
+
+    def test_boolean_add_form_default_false_renders_unchecked(self):
+        if not os.getenv("DATABASE_URL"):
+            pytest.skip("DATABASE_URL is unavailable for live database tests")
+
+        from starlette.testclient import TestClient
+        from aksara import Aksara
+        from aksara.conf import configure, settings
+        from aksara.contrib.admin import site
+
+        site.register(LockedNote, LockedNoteAdmin)
+        self._reset_schema()
+        original_csrf = settings.admin_csrf_enabled
+        configure(admin_csrf_enabled=False)
+        try:
+            app = Aksara(
+                database_url=os.getenv("DATABASE_URL"),
+                debug=True,
+                auto_discover_views=False,
+            )
+            app.add_middleware(_staff_middleware())
+
+            with TestClient(app, raise_server_exceptions=False, follow_redirects=False) as client:
+                form = client.get("/admin/locked_notes/lockednote/add/")
+
+            assert form.status_code == 200
+            assert "checked" not in self._enabled_checkbox(form.text)
+        finally:
+            configure(admin_csrf_enabled=original_csrf)
+            self._drop_schema()
+
+    def test_boolean_false_edit_form_renders_unchecked(self):
+        if not os.getenv("DATABASE_URL"):
+            pytest.skip("DATABASE_URL is unavailable for live database tests")
+
+        from starlette.testclient import TestClient
+        from aksara import Aksara
+        from aksara.conf import configure, settings
+        from aksara.contrib.admin import site
+
+        site.register(LockedNote, LockedNoteAdmin)
+        self._reset_schema()
+        pk = self._create_note("disabled", "server", enabled=False)
+        original_csrf = settings.admin_csrf_enabled
+        configure(admin_csrf_enabled=False)
+        try:
+            app = Aksara(
+                database_url=os.getenv("DATABASE_URL"),
+                debug=True,
+                auto_discover_views=False,
+            )
+            app.add_middleware(_staff_middleware())
+
+            with TestClient(app, raise_server_exceptions=False, follow_redirects=False) as client:
+                form = client.get(f"/admin/locked_notes/lockednote/{pk}/change/")
+
+            assert form.status_code == 200
+            assert "checked" not in self._enabled_checkbox(form.text)
+        finally:
+            configure(admin_csrf_enabled=original_csrf)
+            self._drop_schema()
+
+    def test_boolean_true_edit_form_renders_checked(self):
+        if not os.getenv("DATABASE_URL"):
+            pytest.skip("DATABASE_URL is unavailable for live database tests")
+
+        from starlette.testclient import TestClient
+        from aksara import Aksara
+        from aksara.conf import configure, settings
+        from aksara.contrib.admin import site
+
+        site.register(LockedNote, LockedNoteAdmin)
+        self._reset_schema()
+        pk = self._create_note("enabled", "server", enabled=True)
+        original_csrf = settings.admin_csrf_enabled
+        configure(admin_csrf_enabled=False)
+        try:
+            app = Aksara(
+                database_url=os.getenv("DATABASE_URL"),
+                debug=True,
+                auto_discover_views=False,
+            )
+            app.add_middleware(_staff_middleware())
+
+            with TestClient(app, raise_server_exceptions=False, follow_redirects=False) as client:
+                form = client.get(f"/admin/locked_notes/lockednote/{pk}/change/")
+
+            assert form.status_code == 200
+            assert "checked" in self._enabled_checkbox(form.text)
+        finally:
+            configure(admin_csrf_enabled=original_csrf)
+            self._drop_schema()
+
+    def test_boolean_checkbox_post_parses_checked_value(self):
+        if not os.getenv("DATABASE_URL"):
+            pytest.skip("DATABASE_URL is unavailable for live database tests")
+
+        from starlette.testclient import TestClient
+        from aksara import Aksara
+        from aksara.conf import configure, settings
+        from aksara.contrib.admin import site
+
+        site.register(LockedNote, LockedNoteAdmin)
+        self._reset_schema()
+        pk = self._create_note("flag", "server", enabled=False)
+        original_csrf = settings.admin_csrf_enabled
+        configure(admin_csrf_enabled=False)
+        try:
+            app = Aksara(
+                database_url=os.getenv("DATABASE_URL"),
+                debug=True,
+                auto_discover_views=False,
+            )
+            app.add_middleware(_staff_middleware())
+
+            with TestClient(app, raise_server_exceptions=False, follow_redirects=False) as client:
+                checked = client.post(
+                    f"/admin/locked_notes/lockednote/{pk}/change/",
+                    data={"name": "checked", "locked": "crafted", "enabled": "on"},
+                )
+                assert checked.status_code == 303
+
+            rows = self._notes()
+            assert len(rows) == 1
+            assert rows[0].name == "checked"
+            assert rows[0].enabled is True
+        finally:
+            configure(admin_csrf_enabled=original_csrf)
+            self._drop_schema()
+
+    def test_boolean_checkbox_missing_post_value_parses_false(self):
+        from aksara.contrib.admin.views import _parse_form_data
+
+        class FakeForm(dict):
+            def getlist(self, key):
+                return self.get(key, [])
+
+        parsed = _parse_form_data(
+            FakeForm({"name": "missing"}),
+            LockedNote,
+            ["name", "enabled"],
+        )
+
+        assert parsed["name"] == "missing"
+        assert parsed["enabled"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/admin/test_admin_features_v051.py
+++ b/tests/admin/test_admin_features_v051.py
@@ -26,7 +26,7 @@ from aksara.contrib.admin.actions import (
     queue_message,
     write_messages_cookie,
 )
-from aksara.contrib.admin.filters import FieldListFilter
+from aksara.contrib.admin.filters import FieldListFilter, MAX_AUTO_FILTER_CHOICES
 from aksara.contrib.admin.urls import build_admin_router
 from aksara.permissions import IsAdminUser
 from aksara.registry import ModelRegistry
@@ -365,6 +365,182 @@ class TestSimpleListFilter:
         assert any(c["label"] == "A" and c["selected"] for c in choices)
 
 
+class TestFieldListFilter:
+    class _Meta:
+        def __init__(self, field):
+            self.field = field
+
+        def get_field(self, name):
+            return self.field
+
+    class _BoundedQuery:
+        def __init__(self, values):
+            self.values = values
+            self.limit_arg = None
+            self.materialized_count = 0
+
+        def limit(self, n):
+            self.limit_arg = n
+            return TestFieldListFilter._LimitedQuery(self, self.values[:n])
+
+        async def all(self):
+            raise AssertionError("unbounded filter choice query was materialized")
+
+    class _LimitedQuery:
+        def __init__(self, parent, values):
+            self.parent = parent
+            self.values = values
+
+        async def all(self):
+            self.parent.materialized_count = len(self.values)
+            return [SimpleNamespace(category=value) for value in self.values]
+
+    class _Manager:
+        def __init__(self, query):
+            self.query = query
+
+        def filter(self):
+            return self.query
+
+        async def all(self):
+            raise AssertionError("unbounded manager all() should not be called")
+
+    def _admin_for_field(self, field, manager=None):
+        class FakeModel:
+            pass
+
+        FakeModel.meta = self._Meta(field)
+        if manager is not None:
+            FakeModel.objects = manager
+        return SimpleNamespace(model=FakeModel)
+
+    async def test_django_style_choice_pairs_keep_value_and_label(self):
+        field = SimpleNamespace(choices=[("draft", "Draft")])
+        ma = self._admin_for_field(field)
+
+        filt = await FieldListFilter.create(
+            "status",
+            make_request(query={"status": "draft"}),
+            ma,
+        )
+
+        assert filt.lookup_choices == [("draft", "Draft")]
+        rendered = filt.choices_for_template()
+        assert any(
+            choice["value"] == "draft"
+            and choice["label"] == "Draft"
+            and choice["selected"]
+            for choice in rendered
+        )
+
+        class RecordingQuerySet:
+            def __init__(self):
+                self.kwargs = None
+
+            def filter(self, **kwargs):
+                self.kwargs = kwargs
+                return self
+
+        queryset = RecordingQuerySet()
+        assert filt.apply(queryset) is queryset
+        assert queryset.kwargs == {"status": "draft"}
+
+    async def test_scalar_choices_render_as_before(self):
+        field = SimpleNamespace(choices=["in_review"])
+        ma = self._admin_for_field(field)
+
+        filt = await FieldListFilter.create("status", make_request(), ma)
+
+        assert filt.lookup_choices == [("in_review", "In Review")]
+
+    async def test_boolean_filter_choices_are_static(self):
+        class Boolean:
+            pass
+
+        ma = self._admin_for_field(Boolean())
+
+        filt = await FieldListFilter.create("pinned", make_request(), ma)
+
+        assert filt.lookup_choices == [("true", "Yes"), ("false", "No")]
+
+    async def test_fallback_choices_are_loaded_through_bounded_limit(self):
+        query = self._BoundedQuery(["tools", "food", "tools"])
+        ma = self._admin_for_field(
+            SimpleNamespace(choices=None),
+            manager=self._Manager(query),
+        )
+
+        filt = await FieldListFilter.create("category", make_request(), ma)
+
+        assert query.limit_arg == MAX_AUTO_FILTER_CHOICES + 1
+        assert query.materialized_count == 3
+        assert filt.lookup_choices == [("tools", "tools"), ("food", "food")]
+
+    async def test_high_cardinality_fallback_does_not_materialize_all_rows(self):
+        values = [f"value_{i}" for i in range(MAX_AUTO_FILTER_CHOICES + 10)]
+        query = self._BoundedQuery(values)
+        ma = self._admin_for_field(
+            SimpleNamespace(choices=None),
+            manager=self._Manager(query),
+        )
+
+        filt = await FieldListFilter.create("category", make_request(), ma)
+
+        assert query.limit_arg == MAX_AUTO_FILTER_CHOICES + 1
+        assert query.materialized_count == MAX_AUTO_FILTER_CHOICES + 1
+        assert filt.lookup_choices == []
+
+
+class TestPaginationHelpers:
+    def _request(self, query=None):
+        return SimpleNamespace(
+            query_params=query or {},
+            url=SimpleNamespace(path="/admin/docs/doc/"),
+        )
+
+    def test_show_all_url_exists_for_capped_multi_page_results(self):
+        from aksara.contrib.admin.views import _build_pagination
+
+        pagination = _build_pagination(
+            self._request(), 1, 2, total=50, per_page=25, show_all=False, max_show_all=50
+        )
+
+        assert pagination["show_all_url"] == "/admin/docs/doc/?all=1"
+
+    def test_show_all_url_is_hidden_above_cap(self):
+        from aksara.contrib.admin.views import _build_pagination
+
+        pagination = _build_pagination(
+            self._request(), 1, 5, total=101, per_page=25, show_all=False, max_show_all=100
+        )
+
+        assert pagination["show_all_url"] is None
+
+    def test_show_all_url_is_hidden_when_already_showing_all(self):
+        from aksara.contrib.admin.views import _build_pagination
+
+        pagination = _build_pagination(
+            self._request(query={"all": "1"}),
+            1,
+            1,
+            total=50,
+            per_page=25,
+            show_all=True,
+            max_show_all=50,
+        )
+
+        assert pagination["show_all_url"] is None
+
+    def test_show_all_url_is_hidden_for_single_page_results(self):
+        from aksara.contrib.admin.views import _build_pagination
+
+        pagination = _build_pagination(
+            self._request(), 1, 1, total=20, per_page=25, show_all=False, max_show_all=50
+        )
+
+        assert pagination["show_all_url"] is None
+
+
 class TestMultiSiteRouter:
     def test_route_names_namespaced(self):
         site = AdminSite(name="ops")
@@ -580,6 +756,163 @@ class TestDBBackedFeatures:
         target = (await _base_qs(ma)).filter(id__in=ids)
         await delete_selected(ma, req, target)
         assert await (await _base_qs(ma)).count() == 3
+
+
+class LockedNote(Model):
+    name = fields.String()
+    locked = fields.String(nullable=True)
+
+    class Meta:
+        app_label = "locked_notes"
+
+
+class LockedNoteAdmin(ModelAdmin):
+    fields = ["name", "locked"]
+    readonly_fields = ["locked"]
+
+
+class TestAdminReadonlyHTTPIntegration:
+    """Readonly fields remain display-only across crafted create/change posts."""
+
+    def setup_method(self):
+        ModelRegistry.clear()
+        from aksara.contrib.admin import site
+
+        site.clear()
+
+    def _reset_schema(self):
+        import asyncio
+        from aksara.db import Database
+
+        async def run():
+            db = Database(os.getenv("DATABASE_URL"))
+            await db.connect()
+            await db.execute(f"DROP TABLE IF EXISTS {LockedNote.__tablename__} CASCADE")
+            await db.execute(LockedNote.get_create_table_sql())
+            await db.disconnect()
+
+        asyncio.run(run())
+
+    def _drop_schema(self):
+        import asyncio
+        from aksara.db import Database
+
+        async def run():
+            db = Database(os.getenv("DATABASE_URL"))
+            await db.connect()
+            await db.execute(f"DROP TABLE IF EXISTS {LockedNote.__tablename__} CASCADE")
+            await db.disconnect()
+
+        asyncio.run(run())
+
+    def _create_note(self, name, locked):
+        import asyncio
+        from aksara.db import Database
+
+        async def run():
+            db = Database(os.getenv("DATABASE_URL"))
+            await db.connect()
+            note = await LockedNote.objects.create(name=name, locked=locked)
+            await db.disconnect()
+            return str(note.id)
+
+        return asyncio.run(run())
+
+    def _notes(self):
+        import asyncio
+        from aksara.db import Database
+
+        async def run():
+            db = Database(os.getenv("DATABASE_URL"))
+            await db.connect()
+            rows = await LockedNote.objects.all()
+            await db.disconnect()
+            return rows
+
+        return asyncio.run(run())
+
+    def test_readonly_field_is_displayed_but_ignored_on_create(self):
+        if not os.getenv("DATABASE_URL"):
+            pytest.skip("DATABASE_URL is unavailable for live database tests")
+
+        from starlette.testclient import TestClient
+        from aksara import Aksara
+        from aksara.conf import configure, settings
+        from aksara.contrib.admin import site
+
+        site.register(LockedNote, LockedNoteAdmin)
+        self._reset_schema()
+        original_csrf = settings.admin_csrf_enabled
+        configure(admin_csrf_enabled=False)
+        try:
+            app = Aksara(
+                database_url=os.getenv("DATABASE_URL"),
+                debug=True,
+                auto_discover_views=False,
+            )
+            app.add_middleware(_staff_middleware())
+
+            with TestClient(app, raise_server_exceptions=False, follow_redirects=False) as client:
+                form = client.get("/admin/locked_notes/lockednote/add/")
+                assert form.status_code == 200
+                assert 'name="locked"' in form.text
+                assert "readonly" in form.text
+
+                response = client.post(
+                    "/admin/locked_notes/lockednote/add/",
+                    data={"name": "created", "locked": "crafted"},
+                )
+                assert response.status_code == 303
+
+            rows = self._notes()
+            assert len(rows) == 1
+            assert rows[0].name == "created"
+            assert rows[0].locked is None
+        finally:
+            configure(admin_csrf_enabled=original_csrf)
+            self._drop_schema()
+
+    def test_readonly_field_is_displayed_but_ignored_on_update(self):
+        if not os.getenv("DATABASE_URL"):
+            pytest.skip("DATABASE_URL is unavailable for live database tests")
+
+        from starlette.testclient import TestClient
+        from aksara import Aksara
+        from aksara.conf import configure, settings
+        from aksara.contrib.admin import site
+
+        site.register(LockedNote, LockedNoteAdmin)
+        self._reset_schema()
+        pk = self._create_note("original", "server")
+        original_csrf = settings.admin_csrf_enabled
+        configure(admin_csrf_enabled=False)
+        try:
+            app = Aksara(
+                database_url=os.getenv("DATABASE_URL"),
+                debug=True,
+                auto_discover_views=False,
+            )
+            app.add_middleware(_staff_middleware())
+
+            with TestClient(app, raise_server_exceptions=False, follow_redirects=False) as client:
+                form = client.get(f"/admin/locked_notes/lockednote/{pk}/change/")
+                assert form.status_code == 200
+                assert 'name="locked"' in form.text
+                assert "readonly" in form.text
+
+                response = client.post(
+                    f"/admin/locked_notes/lockednote/{pk}/change/",
+                    data={"name": "updated", "locked": "crafted"},
+                )
+                assert response.status_code == 303
+
+            rows = self._notes()
+            assert len(rows) == 1
+            assert rows[0].name == "updated"
+            assert rows[0].locked == "server"
+        finally:
+            configure(admin_csrf_enabled=original_csrf)
+            self._drop_schema()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/admin/test_admin_features_v051.py
+++ b/tests/admin/test_admin_features_v051.py
@@ -1,0 +1,745 @@
+"""
+Tests for the v0.5.51 admin feature build:
+
+- AdminSite configuration, multi-model register, index_view, permission_classes
+- ModelAdmin list_display_links, custom columns, fields/exclude/fieldsets,
+  ordering, has_module_permission, actions resolution
+- SimpleListFilter / FieldListFilter
+- Flash messages
+- Multi-site router namespacing
+- DB-backed: search, ordering + pagination, field filtering, bulk actions
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aksara import Model, fields
+from aksara.contrib.admin import AdminSite, ModelAdmin, SimpleListFilter, action
+from aksara.contrib.admin.actions import (
+    delete_selected,
+    pop_messages,
+    queue_message,
+    write_messages_cookie,
+)
+from aksara.contrib.admin.filters import FieldListFilter
+from aksara.contrib.admin.urls import build_admin_router
+from aksara.permissions import IsAdminUser
+from aksara.registry import ModelRegistry
+
+
+def make_request(query=None, user=None, cookies=None):
+    """Minimal request stand-in for unit tests."""
+    return SimpleNamespace(
+        query_params=query or {},
+        state=SimpleNamespace(user=user),
+        cookies=cookies or {},
+    )
+
+
+def staff_user():
+    return SimpleNamespace(is_staff=True, is_superuser=False, is_authenticated=True, id="u1")
+
+
+# ---------------------------------------------------------------------------
+# AdminSite configuration
+# ---------------------------------------------------------------------------
+
+class TestAdminSiteConfig:
+    def test_config_defaults(self):
+        site = AdminSite()
+        assert site.title == "Aksara Admin"
+        assert site.theme == "default"
+        assert site.permission_classes == []
+
+    def test_config_custom(self):
+        site = AdminSite(
+            name="ops",
+            title="Ops",
+            site_header="Ops Console",
+            index_title="Home",
+            theme="dark",
+            extra_css=["/x.css"],
+        )
+        ctx = site.base_context(make_request())
+        assert ctx["site_header"] == "Ops Console"
+        assert ctx["admin_theme"] == "dark"
+        assert ctx["extra_css"] == ["/x.css"]
+
+    def test_index_view_decorator(self):
+        site = AdminSite(name="cfg1")
+
+        @site.index_view
+        async def dashboard(request):
+            return {"x": 1}
+
+        assert site._index_view_func is dashboard
+
+    def test_check_site_permission_default_staff(self):
+        site = AdminSite(name="cfg2")
+        allowed, _ = site.check_site_permission(make_request(user=staff_user()))
+        assert allowed is True
+        denied, _ = site.check_site_permission(make_request(user=None))
+        assert denied is False
+
+    def test_check_site_permission_with_permission_classes(self):
+        site = AdminSite(name="cfg3", permission_classes=[IsAdminUser])
+        allowed, _ = site.check_site_permission(make_request(user=staff_user()))
+        assert allowed is True
+        anon = SimpleNamespace(is_staff=False, is_superuser=False, is_authenticated=False)
+        denied, msg = site.check_site_permission(make_request(user=anon))
+        assert denied is False
+
+
+class TestMultiModelRegister:
+    def setup_method(self):
+        ModelRegistry.clear()
+
+    def test_register_multiple_models_with_one_admin(self):
+        site = AdminSite(name="multi")
+
+        class Alpha(Model):
+            name = fields.String()
+            class Meta:
+                app_label = "m"
+
+        class Beta(Model):
+            name = fields.String()
+            class Meta:
+                app_label = "m"
+
+        @site.register(Alpha, Beta)
+        class SharedAdmin(ModelAdmin):
+            list_display = ["name"]
+
+        assert site.is_registered(Alpha)
+        assert site.is_registered(Beta)
+        assert isinstance(site.get_model_admin(Alpha), SharedAdmin)
+        assert isinstance(site.get_model_admin(Beta), SharedAdmin)
+
+    def test_register_requires_a_model(self):
+        site = AdminSite(name="empty")
+        with pytest.raises(ValueError):
+            site.register()
+
+
+# ---------------------------------------------------------------------------
+# ModelAdmin options
+# ---------------------------------------------------------------------------
+
+class _Doc(Model):
+    title = fields.String()
+    slug = fields.String()
+    body = fields.Text()
+    status = fields.String(choices=["draft", "published"])
+    pinned = fields.Boolean(default=False)
+
+    class Meta:
+        app_label = "docs"
+
+
+def doc_admin(**attrs):
+    site = AdminSite(name="t")
+    cls = type("DocAdmin", (ModelAdmin,), attrs)
+    return cls(_Doc, site)
+
+
+class TestModelAdminOptions:
+    def test_list_display_links_default_first(self):
+        ma = doc_admin(list_display=["title", "status"])
+        assert ma.get_list_display_links(make_request(), ["title", "status"]) == ["title"]
+
+    def test_list_display_links_explicit(self):
+        ma = doc_admin(list_display=["title", "status"], list_display_links=["status"])
+        assert ma.get_list_display_links(make_request(), ["title", "status"]) == ["status"]
+
+    def test_custom_column_detection_and_label(self):
+        def word_count(self, obj):
+            return len((obj.body or "").split())
+        word_count.short_description = "Words"
+        word_count.allow_html = False
+
+        ma = doc_admin(list_display=["title", "word_count"], word_count=word_count)
+        assert ma.is_callable_column("word_count") is True
+        assert ma.is_callable_column("title") is False
+        assert ma.get_column_label("word_count") == "Words"
+        assert ma.get_column_label("title") == "Title"
+        assert ma.column_allows_html("word_count") is False
+
+    def test_custom_column_allow_html(self):
+        def badge(self, obj):
+            return "<b>x</b>"
+        badge.allow_html = True
+        ma = doc_admin(list_display=["badge"], badge=badge)
+        assert ma.column_allows_html("badge") is True
+
+    def test_fields_explicit(self):
+        ma = doc_admin(fields=["title", "slug"])
+        assert ma.get_fields(make_request()) == ["title", "slug"]
+
+    def test_exclude(self):
+        ma = doc_admin(exclude=["body"])
+        result = ma.get_fields(make_request())
+        assert "body" not in result
+        assert "title" in result
+
+    def test_default_form_excludes_pk_timestamps_readonly(self):
+        ma = doc_admin(readonly_fields=["status"])
+        result = ma.get_fields(make_request())
+        assert "id" not in result
+        assert "created_at" not in result
+        assert "status" not in result
+        assert "title" in result
+
+    def test_fieldsets_explicit_and_form_fields_flatten(self):
+        ma = doc_admin(
+            fieldsets=[
+                (None, {"fields": ["title", "slug"]}),
+                ("Meta", {"fields": ["status"], "classes": ["collapse"]}),
+            ]
+        )
+        sets = ma.get_fieldsets(make_request())
+        assert sets[0][0] is None
+        assert sets[1][0] == "Meta"
+        assert ma.get_form_fields(make_request()) == ["title", "slug", "status"]
+
+    def test_fieldsets_default_single_section(self):
+        ma = doc_admin(fields=["title"])
+        sets = ma.get_fieldsets(make_request())
+        assert len(sets) == 1
+        assert sets[0][0] is None
+        assert sets[0][1]["fields"] == ["title"]
+
+    def test_get_ordering(self):
+        ma = doc_admin(ordering=["-title"])
+        assert ma.get_ordering(make_request()) == ["-title"]
+
+    def test_has_module_permission_default(self):
+        ma = doc_admin()
+        assert ma.has_module_permission(make_request(user=staff_user())) is True
+        assert ma.has_module_permission(make_request(user=None)) is False
+
+
+class TestActionsResolution:
+    def test_action_decorator_sets_attrs(self):
+        @action(description="Publish", permissions=["change"])
+        async def publish(self, request, queryset):
+            pass
+        assert publish._is_admin_action is True
+        assert publish.action_description == "Publish"
+        assert publish.allowed_permissions == ["change"]
+
+    def test_get_actions_resolves_names_and_builtin(self):
+        @action(description="Archive")
+        async def archive(self, request, queryset):
+            pass
+        ma = doc_admin(actions=["delete_selected", "archive"], archive=archive)
+        actions = ma.get_actions(make_request())
+        assert "delete_selected" in actions
+        assert "archive" in actions
+        assert actions["delete_selected"]["allowed_permissions"] == ["delete"]
+        assert actions["archive"]["description"] == "Archive"
+
+    def test_get_actions_skips_unknown(self):
+        ma = doc_admin(actions=["nonexistent"])
+        assert ma.get_actions(make_request()) == {}
+
+
+class TestBulkActionPermissions:
+    async def test_actions_reject_objects_failing_object_permission(self):
+        from fastapi import HTTPException
+        from aksara.conf import configure, settings
+        from aksara.contrib.admin.views import _run_list_action
+
+        class FakeForm(dict):
+            def getlist(self, key):
+                return self.get(key, [])
+
+        denied = SimpleNamespace(id="denied", qty=9)
+        allowed = SimpleNamespace(id="allowed", qty=1)
+
+        class FakeQuerySet:
+            def __init__(self, objects):
+                self.objects = objects
+
+            def filter(self, **kwargs):
+                return self
+
+            async def all(self):
+                return self.objects
+
+        class GuardedAdmin(ModelAdmin):
+            actions = ["delete_selected"]
+
+            async def get_queryset(self, request):
+                return FakeQuerySet([denied, allowed])
+
+            def has_delete_permission(self, request, obj=None):
+                if obj is None:
+                    return True
+                return obj.qty < 5
+
+            async def delete_model(self, request, obj):
+                raise AssertionError("delete_model should not be called")
+
+        class FakeModel:
+            __name__ = "FakeModel"
+
+        form = FakeForm({"action": "delete_selected", "_selected": ["denied", "allowed"]})
+
+        def url_for(name, **kwargs):
+            return "/admin/app/fakemodel/"
+
+        request = SimpleNamespace(
+            form=AsyncMock(return_value=form),
+            headers={},
+            cookies={},
+            state=SimpleNamespace(user=staff_user()),
+            url=SimpleNamespace(path="/admin/app/fakemodel/", query=""),
+            url_for=url_for,
+        )
+
+        original_csrf = settings.admin_csrf_enabled
+        configure(admin_csrf_enabled=False)
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                await _run_list_action(
+                    request,
+                    FakeModel,
+                    GuardedAdmin(FakeModel, AdminSite(name="admin")),
+                    AdminSite(name="admin"),
+                    "app",
+                    "fakemodel",
+                )
+        finally:
+            configure(admin_csrf_enabled=original_csrf)
+
+        assert exc_info.value.status_code == 403
+
+
+class TestFlashMessages:
+    def test_queue_and_pop_roundtrip(self):
+        req = make_request()
+        queue_message(req, "Saved!", level="success")
+        queue_message(req, "Heads up", level="warning")
+
+        captured = {}
+
+        class FakeResp:
+            def set_cookie(self, key, value, **kw):
+                captured["key"] = key
+                captured["value"] = value
+
+        write_messages_cookie(req, FakeResp())
+        read = make_request(cookies={"aksara_admin_messages": captured["value"]})
+        msgs = pop_messages(read)
+        assert [m["text"] for m in msgs] == ["Saved!", "Heads up"]
+        assert msgs[0]["alert_class"] == "alert-success"
+        assert msgs[1]["alert_class"] == "alert-warning"
+
+    def test_pop_messages_empty(self):
+        assert pop_messages(make_request()) == []
+
+
+class TestSimpleListFilter:
+    def test_lookups_and_value(self):
+        class StatusFilter(SimpleListFilter):
+            title = "Status"
+            parameter_name = "st"
+
+            def lookups(self, request, model_admin):
+                return [("a", "A"), ("b", "B")]
+
+            def queryset(self, request, queryset):
+                return queryset
+
+        f = StatusFilter(make_request(query={"st": "a"}), doc_admin())
+        assert f.value() == "a"
+        assert f.has_output() is True
+        choices = f.choices_for_template()
+        assert choices[0]["label"] == "All"
+        assert any(c["label"] == "A" and c["selected"] for c in choices)
+
+
+class TestMultiSiteRouter:
+    def test_route_names_namespaced(self):
+        site = AdminSite(name="ops")
+        router = build_admin_router(site)
+        names = {r.name for r in router.routes}
+        assert "ops:index" in names
+        assert "ops:model_list" in names
+        assert "admin:index" not in names
+
+    def test_safe_error_message(self):
+        from aksara.contrib.admin.views import _safe_error_message
+        assert _safe_error_message(ValueError("bad slug"), "save") == "bad slug"
+        generic = _safe_error_message(RuntimeError("secret internals"), "save")
+        assert "secret internals" not in generic
+
+
+class TestAdminRoutingSecurity:
+    def test_custom_prefix_sets_matching_csrf_path_and_login_default(self):
+        from starlette.testclient import TestClient
+        from aksara import Aksara
+        from aksara.contrib.admin import include_admin
+
+        site = AdminSite(name="manage")
+        app = Aksara(database_url=None, debug=True, auto_discover_views=False, enable_admin=False)
+        include_admin(app, prefix="/manage", site=site)
+
+        with TestClient(app, raise_server_exceptions=False, follow_redirects=False) as client:
+            login = client.get("/manage/login/")
+            assert login.status_code == 200
+            assert "Path=/manage" in login.headers["set-cookie"]
+            csrf_token = client.cookies.get("aksara_admin_csrf")
+
+            user = MagicMock()
+            user.is_staff = True
+            with patch("aksara.contrib.auth.authenticate", new=AsyncMock(return_value=user)):
+                with patch(
+                    "aksara.contrib.auth.create_session_token",
+                    new=AsyncMock(return_value="token"),
+                ):
+                    response = client.post(
+                        "/manage/login/",
+                        data={
+                            "username": "admin@test.com",
+                            "password": "secret",
+                            "csrf_token": csrf_token,
+                        },
+                    )
+
+            assert response.status_code == 302
+            assert response.headers["location"] == "/manage/"
+
+    def test_custom_login_and_logout_urls_are_used(self):
+        from starlette.testclient import TestClient
+        from aksara import Aksara
+        from aksara.contrib.admin import include_admin
+
+        site = AdminSite(
+            name="secure",
+            login_url="/staff/login",
+            logout_url="/signed-out",
+        )
+        app = Aksara(database_url=None, debug=True, auto_discover_views=False, enable_admin=False)
+        include_admin(app, prefix="/secure", site=site)
+
+        with TestClient(app, raise_server_exceptions=False, follow_redirects=False) as client:
+            denied = client.get("/secure/")
+            assert denied.status_code == 302
+            assert denied.headers["location"] == "/staff/login?next=%2Fsecure%2F"
+
+            csrf = client.get("/secure/login/")
+            assert csrf.status_code == 200
+            response = client.post(
+                "/secure/logout/",
+                data={"csrf_token": client.cookies.get("aksara_admin_csrf")},
+            )
+            assert response.status_code == 302
+            assert response.headers["location"] == "/signed-out"
+
+    def test_configured_title_and_index_title_render(self):
+        from starlette.middleware.base import BaseHTTPMiddleware
+        from starlette.testclient import TestClient
+        from aksara import Aksara
+        from aksara.contrib.admin import include_admin
+
+        class StaffMW(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):
+                request.state.user = staff_user()
+                return await call_next(request)
+
+        site = AdminSite(
+            name="ops",
+            title="Ops Browser",
+            site_header="Ops Console",
+            index_title="Operations Home",
+        )
+        app = Aksara(database_url=None, debug=True, auto_discover_views=False, enable_admin=False)
+        app.add_middleware(StaffMW)
+        include_admin(app, prefix="/ops", site=site)
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get("/ops/")
+
+        assert response.status_code == 200
+        assert "<title>Operations Home - Ops Browser</title>" in response.text
+        assert "<h1>Operations Home</h1>" in response.text
+
+
+class TestModelAdminSaveSafety:
+    async def test_invalid_m2m_ids_do_not_save_or_clear_relations(self):
+        class Related:
+            objects = SimpleNamespace(get=AsyncMock(side_effect=LookupError("missing")))
+
+        class FakeModel:
+            meta = SimpleNamespace(
+                many_to_many={"tags": SimpleNamespace(to_model=Related)}
+            )
+
+        obj = SimpleNamespace(save=AsyncMock())
+        ma = ModelAdmin(FakeModel, AdminSite(name="m2m"))
+
+        with pytest.raises(ValueError):
+            await ma.save_model(make_request(), obj, {"title": "x", "tags": ["bad"]}, False)
+
+        obj.save.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# DB-backed integration of ORM-dependent features
+# ---------------------------------------------------------------------------
+
+class _Thing(Model):
+    name = fields.String()
+    category = fields.String()
+    qty = fields.Integer(default=0)
+
+    class Meta:
+        app_label = "things"
+
+
+class _ThingAdmin(ModelAdmin):
+    list_display = ["name", "category", "qty"]
+    search_fields = ["name"]
+    list_filter = ["category"]
+    ordering = ["-qty"]
+    actions = ["delete_selected"]
+
+
+@pytest.fixture
+async def thing_admin():
+    """Create the things table, seed rows, yield a configured ModelAdmin."""
+    from aksara.db import Database
+
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        pytest.skip("DATABASE_URL is unavailable for live database tests")
+
+    database = Database(database_url)
+    await database.connect()
+    await database.execute(f"DROP TABLE IF EXISTS {_Thing.__tablename__} CASCADE")
+    await database.execute(_Thing.get_create_table_sql())
+    for n, c, q in [
+        ("alpha", "tools", 5),
+        ("beta", "tools", 1),
+        ("gamma", "food", 9),
+        ("delta", "food", 3),
+        ("epsilon", "tools", 7),
+    ]:
+        await _Thing.objects.create(name=n, category=c, qty=q)
+
+    site = AdminSite(name="admin")
+    ma = _ThingAdmin(_Thing, site)
+    try:
+        yield ma
+    finally:
+        await database.execute(f"DROP TABLE IF EXISTS {_Thing.__tablename__} CASCADE")
+        await database.disconnect()
+
+
+async def _base_qs(ma):
+    import inspect
+    qs = ma.get_queryset(make_request(user=staff_user()))
+    return await qs if inspect.isawaitable(qs) else qs
+
+
+class TestDBBackedFeatures:
+    async def test_search_filters_to_matching_rows(self, thing_admin):
+        ma = thing_admin
+        req = make_request(user=staff_user())
+        qs = ma.get_search_results(req, await _base_qs(ma), "a")
+        assert await qs.count() == 4  # alpha, beta, gamma, delta
+
+    async def test_ordering_and_pagination(self, thing_admin):
+        ma = thing_admin
+        page1 = await (await _base_qs(ma)).order_by(*ma.get_ordering(make_request())).limit(2).offset(0).all()
+        page2 = await (await _base_qs(ma)).order_by(*ma.get_ordering(make_request())).limit(2).offset(2).all()
+        assert [r.name for r in page1] == ["gamma", "epsilon"]
+        assert [r.name for r in page2] == ["alpha", "delta"]
+
+    async def test_field_filter_choices_and_apply(self, thing_admin):
+        ma = thing_admin
+        req = make_request(user=staff_user(), query={"category": "food"})
+        filt = await FieldListFilter.create("category", req, ma)
+        labels = {label for _v, label in filt.lookup_choices}
+        assert {"tools", "food"} <= labels
+        filtered = filt.apply(await _base_qs(ma))
+        assert await filtered.count() == 2
+
+    async def test_delete_selected_action(self, thing_admin):
+        ma = thing_admin
+        req = make_request(user=staff_user())
+        rows = await (await _base_qs(ma)).all()
+        ids = [str(rows[0].id), str(rows[1].id)]
+        target = (await _base_qs(ma)).filter(id__in=ids)
+        await delete_selected(ma, req, target)
+        assert await (await _base_qs(ma)).count() == 3
+
+
+# ---------------------------------------------------------------------------
+# End-to-end HTTP integration (list render, filters, pagination, bulk action)
+# ---------------------------------------------------------------------------
+
+class Gadget(Model):
+    name = fields.String()
+    category = fields.String()
+    qty = fields.Integer(default=0)
+
+    class Meta:
+        app_label = "lab"
+
+
+@action(description="Zero out qty", permissions=["change"])
+async def _zero_qty(self, request, queryset):
+    n = await queryset.update(qty=0)
+    self.message_user(request, f"Zeroed {n}", level="success")
+
+
+class GadgetAdmin(ModelAdmin):
+    list_display = ["name", "category", "qty", "badge"]
+    list_display_links = ["name"]
+    search_fields = ["name"]
+    list_filter = ["category"]
+    ordering = ["-qty"]
+    list_per_page = 2
+    actions = ["delete_selected", "zero_qty"]
+    zero_qty = _zero_qty
+
+    def badge(self, obj):
+        return f'<span class="bdg">{obj.category}</span>'
+
+    badge.short_description = "Cat"
+    badge.allow_html = True
+
+
+def _staff_middleware():
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from unittest.mock import MagicMock
+
+    class StaffMW(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            user = MagicMock()
+            user.is_staff = True
+            user.email = "admin@test.com"
+            user.id = "u1"
+            request.state.user = user
+            return await call_next(request)
+
+    return StaffMW
+
+
+class TestAdminHTTPIntegration:
+    """Full request/response cycle against a live database."""
+
+    def setup_method(self):
+        ModelRegistry.clear()
+        from aksara.contrib.admin import site
+        site.clear()
+
+    def _seed(self):
+        import asyncio
+        from aksara.db import Database
+
+        async def run():
+            db = Database(os.getenv("DATABASE_URL"))
+            await db.connect()
+            await db.execute(f"DROP TABLE IF EXISTS {Gadget.__tablename__} CASCADE")
+            await db.execute(Gadget.get_create_table_sql())
+            for n, c, q in [
+                ("aa", "tools", 5),
+                ("ab", "tools", 1),
+                ("ac", "food", 9),
+                ("ad", "food", 3),
+                ("ae", "tools", 7),
+            ]:
+                await Gadget.objects.create(name=n, category=c, qty=q)
+            await db.disconnect()
+
+        asyncio.run(run())
+
+    def _drop(self):
+        import asyncio
+        from aksara.db import Database
+
+        async def run():
+            db = Database(os.getenv("DATABASE_URL"))
+            await db.connect()
+            await db.execute(f"DROP TABLE IF EXISTS {Gadget.__tablename__} CASCADE")
+            await db.disconnect()
+
+        asyncio.run(run())
+
+    def _qtys(self):
+        import asyncio
+        from aksara.db import Database
+
+        async def run():
+            db = Database(os.getenv("DATABASE_URL"))
+            await db.connect()
+            rows = await Gadget.objects.all()
+            await db.disconnect()
+            return sorted(r.qty for r in rows)
+
+        return asyncio.run(run())
+
+    def test_list_render_and_bulk_action(self):
+        if not os.getenv("DATABASE_URL"):
+            pytest.skip("DATABASE_URL is unavailable for live database tests")
+
+        import re
+        from starlette.testclient import TestClient
+        from aksara import Aksara
+        from aksara.conf import configure, settings
+        from aksara.contrib.admin import site
+
+        site.register(Gadget, GadgetAdmin)
+        self._seed()
+        # CSRF round-tripping is covered by the existing login/add/delete POST
+        # tests; here we isolate the new action-execution path.
+        original_csrf = settings.admin_csrf_enabled
+        configure(admin_csrf_enabled=False)
+        try:
+            app = Aksara(database_url=os.getenv("DATABASE_URL"), debug=True, auto_discover_views=False)
+            app.add_middleware(_staff_middleware())
+
+            with TestClient(app, raise_server_exceptions=False, follow_redirects=False) as client:
+                # List renders with the full feature surface.
+                resp = client.get("/admin/lab/gadget/?o=-qty&category=tools")
+                assert resp.status_code == 200
+                body = resp.text
+                assert "Filters" in body                 # filter sidebar
+                assert "data-select-all" in body          # action checkboxes
+                assert "sortable-header" in body           # sortable columns
+                assert 'class="bdg"' in body               # custom HTML column
+                assert "Zero out qty" in body              # custom action
+
+                # Add form renders fieldsets.
+                add = client.get("/admin/lab/gadget/add/")
+                assert add.status_code == 200
+
+                # Search narrows the list.
+                searched = client.get("/admin/lab/gadget/?q=aa")
+                assert searched.status_code == 200
+
+                # Run a bulk action on two selected rows.
+                page = client.get("/admin/lab/gadget/?all=1")
+                ids = re.findall(r'name="_selected" value="([^"]+)"', page.text)[:2]
+                assert len(ids) == 2
+
+                action_resp = client.post(
+                    "/admin/lab/gadget/",
+                    data={"action": "zero_qty", "_selected": ids},
+                )
+                assert action_resp.status_code == 303
+
+            # Two rows zeroed by the action.
+            assert self._qtys().count(0) == 2
+        finally:
+            configure(admin_csrf_enabled=original_csrf)
+            self._drop()

--- a/tests/admin/test_admin_views_basic.py
+++ b/tests/admin/test_admin_views_basic.py
@@ -183,6 +183,9 @@ class TestAdminModelListView:
         with patch.object(ItemAdmin, 'get_queryset', new_callable=AsyncMock) as mock_qs:
             mock_queryset = MagicMock()
             mock_queryset.all = AsyncMock(return_value=[])
+            mock_queryset.count = AsyncMock(return_value=0)
+            for _chain in ("order_by", "search", "filter", "limit", "offset"):
+                getattr(mock_queryset, _chain).return_value = mock_queryset
             mock_qs.return_value = mock_queryset
             
             client = TestClient(app)
@@ -440,6 +443,9 @@ class TestAdmin20Features:
         with patch.object(ArticleAdmin, 'get_queryset', new_callable=AsyncMock) as mock_qs:
             mock_queryset = MagicMock()
             mock_queryset.all = AsyncMock(return_value=[])
+            mock_queryset.count = AsyncMock(return_value=0)
+            for _chain in ("order_by", "search", "filter", "limit", "offset"):
+                getattr(mock_queryset, _chain).return_value = mock_queryset
             mock_qs.return_value = mock_queryset
             
             client = TestClient(app)

--- a/tests/security/fuzz/test_filter_fuzz.py
+++ b/tests/security/fuzz/test_filter_fuzz.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 from hypothesis import given, strategies as st
 
-from aksara.api.filters import DjangoFilterBackend
+from aksara.api.filters import AksaraFilterBackend
 from aksara.api.viewsets import ModelViewSet
 from aksara.manager import QuerySet
 
@@ -16,7 +16,7 @@ pytestmark = [pytest.mark.security, pytest.mark.fuzz]
 class FuzzAccountViewSet(ModelViewSet):
     model = FuzzAccount
     prefix = "/security-fuzz-accounts"
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [AksaraFilterBackend]
     filterable_fields = ["name", "tenant_id", "metadata"]
 
 

--- a/tests/test_v044_features.py
+++ b/tests/test_v044_features.py
@@ -5,7 +5,7 @@ Unit tests for all new v0.5.44 enterprise DX features.
 These tests verify that all new features are properly implemented and accessible.
 
 v0.5.44 Features Tested:
-1. DjangoFilterBackend (see test_v044_filter_backends.py)
+1. AksaraFilterBackend (see test_v044_filter_backends.py)
 2. Pagination backends (see test_v044_pagination.py)
 3. Bulk operations (bulk_create, bulk_update)
 4. Upsert operations
@@ -162,8 +162,8 @@ class TestPublicAPIExports:
     
     def test_filter_backends_in_api_export(self):
         """Test filter backends are exported from aksara.api."""
-        from aksara.api import DjangoFilterBackend
-        assert DjangoFilterBackend is not None
+        from aksara.api import AksaraFilterBackend
+        assert AksaraFilterBackend is not None
     
     def test_pagination_in_api_export(self):
         """Test pagination classes are exported from aksara.api."""
@@ -179,8 +179,8 @@ class TestDocumentationExamples:
     """Test that code examples in documentation are valid."""
     
     def test_django_filter_backend_example(self):
-        """Test DjangoFilterBackend example code is valid."""
-        from aksara.api import ModelViewSet, DjangoFilterBackend
+        """Test AksaraFilterBackend example code is valid."""
+        from aksara.api import ModelViewSet, AksaraFilterBackend
         
         class TestModel(Model):
             status = fields.String()
@@ -188,7 +188,7 @@ class TestDocumentationExamples:
         
         class TestViewSet(ModelViewSet):
             model = TestModel
-            filter_backends = [DjangoFilterBackend]
+            filter_backends = [AksaraFilterBackend]
             filterable_fields = ['status', 'category']
         
         # Should construct without errors
@@ -229,11 +229,11 @@ class Testv044Features:
     
     def test_category_1_features(self):
         """Test Category 1 (API & ViewSet DX) features are available."""
-        from aksara.api import DjangoFilterBackend, SearchFilter, OrderingFilter
+        from aksara.api import AksaraFilterBackend, SearchFilter, OrderingFilter
         from aksara.api import PageNumberPagination, LimitOffsetPagination, CursorPagination
         
         # All Category 1 features should be importable
-        assert DjangoFilterBackend is not None
+        assert AksaraFilterBackend is not None
         assert SearchFilter is not None
         assert OrderingFilter is not None
         assert PageNumberPagination is not None

--- a/tests/test_v044_filter_backends.py
+++ b/tests/test_v044_filter_backends.py
@@ -8,7 +8,7 @@ v0.5.44: Comprehensive test coverage for filter backends.
 
 import pytest
 from unittest.mock import Mock, AsyncMock, patch
-from aksara.api import AksaraFilterBackend
+from aksara.api import AksaraFilterBackend, DjangoFilterBackend
 from aksara.registry import ModelRegistry
 
 
@@ -134,6 +134,28 @@ class TestFilterBackendParameterParsing:
         assert filters['category__in'] == ['tech', 'news']
 
 
+class TestFilterBackendCompatibilityAliases:
+    """Test preferred and legacy public import names."""
+
+    def test_module_imports_expose_preferred_and_legacy_names(self):
+        from aksara.api.filters import (
+            AksaraFilterBackend as ModuleAksaraFilterBackend,
+            DjangoFilterBackend as ModuleDjangoFilterBackend,
+        )
+
+        assert ModuleAksaraFilterBackend is AksaraFilterBackend
+        assert ModuleDjangoFilterBackend is ModuleAksaraFilterBackend
+
+    def test_api_package_exports_preferred_and_legacy_names(self):
+        from aksara.api import (
+            AksaraFilterBackend as PackageAksaraFilterBackend,
+            DjangoFilterBackend as PackageDjangoFilterBackend,
+        )
+
+        assert PackageAksaraFilterBackend is AksaraFilterBackend
+        assert PackageDjangoFilterBackend is PackageAksaraFilterBackend
+
+
 class TestFilterBackendMockIntegration:
     """Test filter backend with mocked QuerySet."""
     
@@ -218,4 +240,3 @@ class TestFilterBackendEdgeCases:
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])
-

--- a/tests/test_v044_filter_backends.py
+++ b/tests/test_v044_filter_backends.py
@@ -1,14 +1,14 @@
 """
 Test Filter Backends
 
-Tests for DjangoFilterBackend and query parameter parsing.
+Tests for AksaraFilterBackend and query parameter parsing.
 
 v0.5.44: Comprehensive test coverage for filter backends.
 """
 
 import pytest
 from unittest.mock import Mock, AsyncMock, patch
-from aksara.api import DjangoFilterBackend
+from aksara.api import AksaraFilterBackend
 from aksara.registry import ModelRegistry
 
 
@@ -21,11 +21,11 @@ def clear_registry():
 
 
 class TestFilterBackendParameterParsing:
-    """Test DjangoFilterBackend query parameter parsing."""
+    """Test AksaraFilterBackend query parameter parsing."""
     
     def test_exact_match_filter(self):
         """Test exact match filtering (field=value)."""
-        backend = DjangoFilterBackend()
+        backend = AksaraFilterBackend()
         
         # Mock request with query params
         request = Mock()
@@ -38,7 +38,7 @@ class TestFilterBackendParameterParsing:
     
     def test_boolean_coercion(self):
         """Test boolean value coercion."""
-        backend = DjangoFilterBackend()
+        backend = AksaraFilterBackend()
         request = Mock()
         
         # Test various boolean representations
@@ -58,7 +58,7 @@ class TestFilterBackendParameterParsing:
     
     def test_null_coercion(self):
         """Test null/None coercion."""
-        backend = DjangoFilterBackend()
+        backend = AksaraFilterBackend()
         request = Mock()
         request.query_params = {'value': 'null'}
         
@@ -67,7 +67,7 @@ class TestFilterBackendParameterParsing:
     
     def test_gt_gte_lookups(self):
         """Test greater than lookups."""
-        backend = DjangoFilterBackend()
+        backend = AksaraFilterBackend()
         request = Mock()
         request.query_params = {'age__gt': '18', 'age__gte': '18'}
         
@@ -77,7 +77,7 @@ class TestFilterBackendParameterParsing:
     
     def test_in_lookup(self):
         """Test IN lookup with comma-separated values."""
-        backend = DjangoFilterBackend()
+        backend = AksaraFilterBackend()
         request = Mock()
         request.query_params = {'category__in': 'tech,news,science'}
         
@@ -86,7 +86,7 @@ class TestFilterBackendParameterParsing:
     
     def test_icontains_lookup(self):
         """Test case-insensitive contains."""
-        backend = DjangoFilterBackend()
+        backend = AksaraFilterBackend()
         request = Mock()
         request.query_params = {'name__icontains': 'john'}
         
@@ -95,7 +95,7 @@ class TestFilterBackendParameterParsing:
     
     def test_float_coercion(self):
         """Test float value coercion."""
-        backend = DjangoFilterBackend()
+        backend = AksaraFilterBackend()
         request = Mock()
         request.query_params = {'price__gte': '19.99'}
         
@@ -104,7 +104,7 @@ class TestFilterBackendParameterParsing:
     
     def test_unknown_field_filtered(self):
         """Test that unknown fields are ignored."""
-        backend = DjangoFilterBackend()
+        backend = AksaraFilterBackend()
         request = Mock()
         request.query_params = {'status': 'active', 'unknown': 'value'}
         
@@ -116,7 +116,7 @@ class TestFilterBackendParameterParsing:
     
     def test_multiple_filters(self):
         """Test parsing multiple filter parameters."""
-        backend = DjangoFilterBackend()
+        backend = AksaraFilterBackend()
         request = Mock()
         request.query_params = {
             'status': 'active',
@@ -140,7 +140,7 @@ class TestFilterBackendMockIntegration:
     def test_filter_backend_integrates_with_view(self):
         """Test that filter backend integrates with view configuration."""
         # This test verifies the filter backend is available and can be used
-        backend = DjangoFilterBackend()
+        backend = AksaraFilterBackend()
         
         # Verify backend has required methods
         assert hasattr(backend, 'filter_queryset')
@@ -152,19 +152,19 @@ class TestFilterBackendViewSetConfiguration:
     """Test ViewSet configuration with filter backends."""
     
     def test_filter_backends_list(self):
-        """Test that DjangoFilterBackend is available for ViewSets."""
+        """Test that AksaraFilterBackend is available for ViewSets."""
         # Verify the backend can be imported and used in ViewSets
         from aksara.api import ModelViewSet
         
-        # DjangoFilterBackend should be available for use in filter_backends list
-        assert DjangoFilterBackend is not None
-        assert callable(DjangoFilterBackend)
+        # AksaraFilterBackend should be available for use in filter_backends list
+        assert AksaraFilterBackend is not None
+        assert callable(AksaraFilterBackend)
     
     def test_viewset_filter_backends_attribute(self):
         """Test ViewSet accepts filter_backends attribute."""
         # ViewSets have a filter_backends attribute that can be set
         # This is tested indirectly through the documentation examples
-        backend = DjangoFilterBackend()
+        backend = AksaraFilterBackend()
         assert hasattr(backend, 'filterable_fields') or True  # Optional attribute
 
 
@@ -173,7 +173,7 @@ class TestFilterBackendEdgeCases:
     
     def test_empty_query_params(self):
         """Test with no query parameters."""
-        backend = DjangoFilterBackend()
+        backend = AksaraFilterBackend()
         request = Mock()
         request.query_params = {}
         
@@ -182,7 +182,7 @@ class TestFilterBackendEdgeCases:
     
     def test_invalid_number_value(self):
         """Test invalid numeric value."""
-        backend = DjangoFilterBackend()
+        backend = AksaraFilterBackend()
         request = Mock()
         request.query_params = {'age': 'not-a-number'}
         
@@ -192,7 +192,7 @@ class TestFilterBackendEdgeCases:
     
     def test_empty_in_value(self):
         """Test empty IN value."""
-        backend = DjangoFilterBackend()
+        backend = AksaraFilterBackend()
         request = Mock()
         request.query_params = {'category__in': ''}
         
@@ -202,7 +202,7 @@ class TestFilterBackendEdgeCases:
     
     def test_isnull_boolean_values(self):
         """Test various isnull parameter values."""
-        backend = DjangoFilterBackend()
+        backend = AksaraFilterBackend()
         request = Mock()
         
         for value in ['true', 'yes', '1']:


### PR DESCRIPTION
## Summary

This PR prepares the admin correctness work for `v0.5.52`.

It fixes confirmed admin implementation gaps around mounting, permissions, CSRF behavior, object-safe actions, M2M save consistency, session lookup logging, configurable titles, and admin documentation accuracy.

## Changes

- Ensured custom admin prefixes use the correct CSRF cookie path.
- Wired documented `login_url` / `logout_url` behavior.
- Logged admin session lookup failures instead of silently swallowing them.
- Enforced object-level permissions for bulk actions.
- Made M2M save behavior safer by validating related IDs before mutating relations.
- Wrapped relation updates in a transaction.
- Updated admin templates to use configured title / index title.
- Expanded admin docs for:
  - CSRF guidance
  - Admin vs Studio usage
  - Widgets
  - custom auth redirects
  - object-safe actions
  - permission patterns

## Validation

- `tests/admin`: `110 passed`
- Focused new regression tests: `5 passed`
- Full suite: one unrelated task-worker concurrency test failed during broad run and passed when rerun in isolation
- Docs build: passed
- Package build: passed
- Twine check: passed
- `git diff --check`: passed

## Notes

Package version remains unchanged in this PR. This is intended for `v0.5.52`.