### PR TITLE
fix(orm): improve write paths and relation safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## v0.5.54 — ORM Write & Relation Correctness
+
+Unreleased.
+
+This release focuses on targeted write-path consistency and relation safety
+fixes from the ORM audit. It does not claim that all ORM correctness issues are
+fixed.
+
+### Fixed
+
+- `bulk_create()` now aligns more closely with `create()` and `save()` for
+  auto-managed fields, runs field preparation hooks, and preserves explicit
+  per-row `auto_now_add` values such as `created_at`.
+- `bulk_update()` now casts `Vector` field CASE branch parameters with
+  `CAST($n AS vector)`.
+- `ForeignKey` and `OneToOne` now validate `on_delete` values and reject
+  unknown actions before DDL generation.
+- Migration relation DDL now validates `ON DELETE` and `ON UPDATE` actions
+  before emitting SQL.
+- `ManyToMany(..., through=...)` now fails clearly because custom through
+  models are not supported yet.
+- The forward FK access contract is documented: forward FK/O2O attributes
+  expose the stored FK value/id; load related objects explicitly or via
+  `select_related()` plus `get_related()`.
+
+### Changed
+
+- `QuerySet.update()` now refreshes `auto_now` fields such as `updated_at` when
+  regular fields are updated. Explicit `updated_at` values are respected, and
+  `update(updated_at=...)` does not override itself.
+
+### Compatibility / Behavior Changes
+
+- `ForeignKey(..., on_delete="SET_NULL")` and
+  `ForeignKey(..., on_delete="SET NULL")` now require `nullable=True` because
+  `SET NULL` on a non-nullable relation creates contradictory runtime and DDL
+  behavior.
+
+  Before:
+
+  ```python
+  author = fields.ForeignKey(User, on_delete="SET_NULL")
+  ```
+
+  Now:
+
+  ```python
+  author = fields.ForeignKey(User, on_delete="SET_NULL", nullable=True)
+  ```
+
+### Tests
+
+- Added regression coverage for write-path timestamp hydration, vector
+  subclass casting, relation `on_delete` validation, nullable `SET NULL`
+  enforcement, migration DDL action validation, custom through rejection, and
+  forward FK id access.
+
+---
+
 ## v0.5.53 — ORM Query Semantics & Migration Generation Correctness
 
 Released 2026-05-29.

--- a/aksara/fields.py
+++ b/aksara/fields.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from aksara.relations import OnDelete as OnDeleteType
 
 from aksara.i18n import normalize_datetime_for_storage, normalize_datetime_from_storage
+from aksara.relations import normalize_on_delete
 from aksara.storage import FieldFile, build_upload_name, get_default_storage, read_uploaded_content
 
 
@@ -2890,8 +2891,7 @@ class ForeignKey(Field):
         )
         self._to = to
         self._column_name = column_name
-        # Normalize on_delete to string (handles both string and OnDelete enum)
-        self.on_delete = on_delete.upper() if isinstance(on_delete, str) else str(on_delete)
+        self.on_delete = normalize_on_delete(on_delete, nullable=nullable)
         self.related_name = related_name
         
         # These will be set after model class creation
@@ -3149,6 +3149,9 @@ class ManyToMany(Field):
         ai_agent_writable: bool = True,
     ):
         # ManyToMany doesn't have a direct column, so nullable doesn't apply
+        if through is not None:
+            raise ValueError("Custom through models are not supported yet")
+
         super().__init__(
             nullable=True,  # No actual column
             ai_description=ai_description,

--- a/aksara/manager.py
+++ b/aksara/manager.py
@@ -6,6 +6,7 @@ Django-like query interface for Aksara models.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Type, TypeVar, Generic, Tuple, Set, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -1247,10 +1248,23 @@ class QuerySet(Generic[T]):
         if not kwargs:
             raise ValueError("update() requires at least one field assignment")
 
+        assignments = dict(kwargs)
+        auto_now_fields = [
+            name
+            for name, field in self._model._fields.items()
+            if getattr(field, "auto_now", False)
+        ]
+        auto_now_field_set = set(auto_now_fields)
+        updates_non_auto_field = any(name not in auto_now_field_set for name in assignments)
+        if auto_now_fields and updates_non_auto_field:
+            now = datetime.now(timezone.utc)
+            for field_name in auto_now_fields:
+                assignments.setdefault(field_name, now)
+
         values: List[Any] = []
         set_clauses = []
 
-        for field_name, value in kwargs.items():
+        for field_name, value in assignments.items():
             if field_name not in self._model._fields:
                 raise ValueError(f"Unknown field: {field_name}")
 
@@ -1524,6 +1538,66 @@ class Manager(Generic[T]):
             create_kwargs = {**kwargs, **(defaults or {})}
             instance = await self.create(**create_kwargs)
             return instance, True
+
+    async def _prepare_bulk_create_objects(self, objs: List[T]) -> None:
+        """Apply save-path preparation and auto_now timestamps before bulk insert."""
+        from aksara.db.expressions import is_expression
+
+        for obj in objs:
+            for field_name in self._model._fields:
+                if is_expression(obj._data.get(field_name)):
+                    raise ValueError("Expressions are not supported in bulk_create()")
+
+            for field_name, field in self._model._async_prepare_fields.items():
+                obj._data[field_name] = await field.async_prepare(
+                    obj._data.get(field_name),
+                    instance=obj,
+                )
+
+            for field in self._model._generic_fk_fields.values():
+                await field.async_prepare(obj)
+
+            await obj._validate_fields()
+
+        now = datetime.now(timezone.utc)
+        for obj in objs:
+            for field_name, field in self._model._fields.items():
+                if getattr(field, "auto_now", False):
+                    obj._data[field_name] = now
+
+    def _bulk_create_field_names(self, batch: List[T]) -> List[str]:
+        """Return the DB insert field set after all batch rows are prepared."""
+        field_names = []
+        for field_name, field in self._model._fields.items():
+            values = [obj._data.get(field_name) for obj in batch]
+
+            if field_name == "id" and all(value is None for value in values):
+                continue
+            if getattr(field, "auto_now_add", False) and all(value is None for value in values):
+                continue
+
+            if any(value is not None for value in values) or getattr(field, "nullable", False):
+                field_names.append(field_name)
+
+        return field_names
+
+    def _bulk_create_value_sql(
+        self,
+        field_name: str,
+        field: Any,
+        value: Any,
+        param_idx: int,
+    ) -> tuple[str, bool]:
+        """Return the SQL token for a bulk-create value and whether it binds a param."""
+        if value is None and (
+            field_name == "id"
+            or getattr(field, "auto_now_add", False)
+        ):
+            return "DEFAULT", False
+
+        if field.__class__.__name__ == "Vector":
+            return f"CAST(${param_idx} AS vector)", True
+        return f"${param_idx}", True
     
     async def bulk_create(
         self,
@@ -1556,7 +1630,6 @@ class Manager(Generic[T]):
             created_users = await User.objects.bulk_create(users_to_create, batch_size=1000)
         """
         from aksara.db import Database
-        from aksara.db.expressions import is_expression
         
         if not objs:
             return []
@@ -1565,6 +1638,8 @@ class Manager(Generic[T]):
         for obj in objs:
             if not obj._is_new:
                 raise ValueError("bulk_create() requires unsaved model instances")
+
+        await self._prepare_bulk_create_objects(objs)
         
         db = Database.get_instance()
         created_instances = []
@@ -1574,36 +1649,29 @@ class Manager(Generic[T]):
             batch = objs[batch_start : batch_start + batch_size]
             
             # Build multi-row INSERT statement
-            field_names = []
+            field_names = self._bulk_create_field_names(batch)
             all_values = []
             placeholders = []
             param_idx = 1
-            row_num = 0
             
             for obj in batch:
                 row_placeholders = []
                 
-                for field_name, field in self._model._fields.items():
-                    if row_num == 0:  # First row - collect field names
-                        # Skip auto-generated primary keys without values
-                        if field_name == 'id' and obj._data.get('id') is None:
-                            continue
-                        # Skip auto_now_add fields unless explicitly set
-                        if hasattr(field, 'auto_now_add') and field.auto_now_add and obj._data.get(field_name) is None:
-                            continue
-                        field_names.append(field_name)
-                    
-                    # Only include fields we're inserting for this row
-                    if field_name in field_names:
-                        value = obj._data.get(field_name)
-                        if is_expression(value):
-                            raise ValueError("Expressions are not supported in bulk_create()")
+                for field_name in field_names:
+                    field = self._model._fields[field_name]
+                    value = obj._data.get(field_name)
+                    value_sql, binds_param = self._bulk_create_value_sql(
+                        field_name,
+                        field,
+                        value,
+                        param_idx,
+                    )
+                    row_placeholders.append(value_sql)
+                    if binds_param:
                         all_values.append(field.to_db(value))
-                        row_placeholders.append(f"${param_idx}")
                         param_idx += 1
                 
                 placeholders.append(f"({', '.join(row_placeholders)})")
-                row_num += 1
             
             # Build the INSERT statement using each field's DB column name
             # (e.g. ForeignKey "owner" → column "owner_id"), not the Python
@@ -1701,8 +1769,11 @@ class Manager(Generic[T]):
                     # Searched CASE requires a boolean WHEN expression — must
                     # compare the primary key column to the parameter, not just
                     # bind the PK value as the condition.
+                    value_sql = f"${param_idx + 1}"
+                    if field.__class__.__name__ == "Vector":
+                        value_sql = f"CAST(${param_idx + 1} AS vector)"
                     when_clauses.append(
-                        f"WHEN id = ${param_idx} THEN ${param_idx + 1}"
+                        f"WHEN {quote_identifier('id')} = ${param_idx} THEN {value_sql}"
                     )
                     ids.append(obj.id)
                     value = obj._data.get(field_name)

--- a/aksara/manager.py
+++ b/aksara/manager.py
@@ -20,6 +20,13 @@ T = TypeVar("T", bound="Model")
 _UNSET = object()
 
 
+def _is_vector_field(field: Any) -> bool:
+    """Return True for Vector fields, including subclasses."""
+    from aksara.fields import Vector
+
+    return isinstance(field, Vector)
+
+
 # Supported lookup types
 LOOKUP_OPERATORS = {
     "exact": "=",          # field__exact=value (same as field=value)
@@ -1274,7 +1281,7 @@ class QuerySet(Generic[T]):
                 set_clauses.append(f"{col_name} = {compile_expression(self._model, value, values)}")
             else:
                 values.append(field.to_db(value))
-                if field.__class__.__name__ == "Vector":
+                if _is_vector_field(field):
                     set_clauses.append(f"{col_name} = CAST(${len(values)} AS vector)")
                 else:
                     set_clauses.append(f"{col_name} = ${len(values)}")
@@ -1595,9 +1602,23 @@ class Manager(Generic[T]):
         ):
             return "DEFAULT", False
 
-        if field.__class__.__name__ == "Vector":
+        if _is_vector_field(field):
             return f"CAST(${param_idx} AS vector)", True
         return f"${param_idx}", True
+
+    def _hydrate_bulk_created_object(self, obj: T, record: Any) -> None:
+        """Update the caller's object with all columns returned by INSERT."""
+        from aksara.fields import ForeignKey
+
+        record_keys = set(record.keys())
+        for field_name, field in self._model._fields.items():
+            if isinstance(field, ForeignKey):
+                col_name = field.db_column_name
+                if col_name in record_keys:
+                    obj._data[field_name] = field.to_python(record[col_name])
+            elif field_name in record_keys:
+                obj._data[field_name] = field.to_python(record[field_name])
+        obj._is_new = False
     
     async def bulk_create(
         self,
@@ -1696,10 +1717,17 @@ class Manager(Generic[T]):
             
             records = await db.fetch(query, *all_values)
             
-            # Reconstruct model instances from returned records
-            for record in records:
-                instance = self._model._from_record(record)
-                created_instances.append(instance)
+            # Hydrate original objects when PostgreSQL returned one row per
+            # input object. With ignore_conflicts=True PostgreSQL may return
+            # fewer rows, and the skipped input rows cannot be matched safely.
+            if len(records) == len(batch):
+                for obj, record in zip(batch, records):
+                    self._hydrate_bulk_created_object(obj, record)
+                    created_instances.append(obj)
+            else:
+                for record in records:
+                    instance = self._model._from_record(record)
+                    created_instances.append(instance)
         
         return created_instances
     
@@ -1770,7 +1798,7 @@ class Manager(Generic[T]):
                     # compare the primary key column to the parameter, not just
                     # bind the PK value as the condition.
                     value_sql = f"${param_idx + 1}"
-                    if field.__class__.__name__ == "Vector":
+                    if _is_vector_field(field):
                         value_sql = f"CAST(${param_idx + 1} AS vector)"
                     when_clauses.append(
                         f"WHEN {quote_identifier('id')} = ${param_idx} THEN {value_sql}"

--- a/aksara/migrations/operations.py
+++ b/aksara/migrations/operations.py
@@ -24,18 +24,14 @@ import re
 from abc import ABC, abstractmethod
 from typing import Any, List, Optional, Tuple, Union
 
+from aksara.relations import normalize_fk_action
+
 logger = logging.getLogger(__name__)
 
 
 # =============================================================================
 # Security: SQL Identifier Quoting
 # =============================================================================
-
-# Valid FK referential actions
-_VALID_FK_ACTIONS = frozenset({
-    "CASCADE", "SET NULL", "SET DEFAULT", "RESTRICT", "NO ACTION",
-})
-
 
 def _quote_ident(name: str) -> str:
     """
@@ -55,12 +51,14 @@ def _validate_fk_action(action: str) -> str:
     Raises ValueError if the action is not a recognised PostgreSQL
     referential action keyword.
     """
-    normalised = action.strip().upper()
-    if normalised not in _VALID_FK_ACTIONS:
-        raise ValueError(
-            f"Invalid FK action: {action!r}. "
-            f"Allowed: {', '.join(sorted(_VALID_FK_ACTIONS))}"
-        )
+    return normalize_fk_action(action)
+
+
+def _validate_fk_delete_action(action: str, *, nullable: bool) -> str:
+    """Validate an ON DELETE action against the relation column nullability."""
+    normalised = _validate_fk_action(action)
+    if normalised == "SET NULL" and not nullable:
+        raise ValueError("on_delete=SET NULL requires nullable=True")
     return normalised
 
 
@@ -962,6 +960,9 @@ class OneToOneField(FieldOp):
         self.column_type = column_type
     
     def to_sql(self) -> str:
+        _validate_fk_delete_action(self.on_delete, nullable=self.nullable)
+        _validate_fk_action(self.on_update)
+
         parts = [self.column_type]
         
         if not self.nullable:
@@ -973,7 +974,7 @@ class OneToOneField(FieldOp):
     def get_constraint_sql(self, column_name: str, table_name: str = "") -> str:
         """Generate the FOREIGN KEY constraint SQL."""
         prefix = f"{table_name}_" if table_name else ""
-        on_del = _validate_fk_action(self.on_delete)
+        on_del = _validate_fk_delete_action(self.on_delete, nullable=self.nullable)
         on_upd = _validate_fk_action(self.on_update)
         return (
             f"CONSTRAINT fk_{prefix}{column_name} "
@@ -1068,6 +1069,9 @@ class ForeignKeyField(FieldOp):
         self.column_type = column_type
     
     def to_sql(self) -> str:
+        _validate_fk_delete_action(self.on_delete, nullable=self.nullable)
+        _validate_fk_action(self.on_update)
+
         parts = [self.column_type]
         
         if not self.nullable:
@@ -1079,7 +1083,7 @@ class ForeignKeyField(FieldOp):
     def get_constraint_sql(self, column_name: str, table_name: str = "") -> str:
         """Generate the FOREIGN KEY constraint SQL."""
         prefix = f"{table_name}_" if table_name else ""
-        on_del = _validate_fk_action(self.on_delete)
+        on_del = _validate_fk_delete_action(self.on_delete, nullable=self.nullable)
         on_upd = _validate_fk_action(self.on_update)
         return (
             f"CONSTRAINT fk_{prefix}{column_name} "

--- a/aksara/relations.py
+++ b/aksara/relations.py
@@ -70,7 +70,7 @@ _DDL_FK_ACTIONS = {
 }
 
 
-def _normalise_action_token(action: Any) -> str:
+def _normalize_action_token(action: Any) -> str:
     raw = getattr(action, "value", action)
     return str(raw).strip().upper().replace("_", " ")
 
@@ -82,11 +82,13 @@ def normalize_on_delete(action: Any, *, nullable: Optional[bool] = None) -> str:
     Runtime relation fields intentionally support the behaviours Aksara can
     enforce today: CASCADE, SET NULL, and RESTRICT/PROTECT.
     """
-    token = _normalise_action_token(action)
+    token = _normalize_action_token(action)
     if token not in _RUNTIME_ON_DELETE_ACTIONS:
         raise ValueError(
             f"Invalid on_delete action: {action!r}. "
-            "Allowed: CASCADE, SET NULL, RESTRICT, PROTECT"
+            "Allowed canonical values: CASCADE, SET NULL, RESTRICT, PROTECT. "
+            "Values are case-insensitive; underscore and space variants such as "
+            "SET_NULL and SET NULL are accepted; OnDelete enum instances are accepted."
         )
 
     normalized = _RUNTIME_ON_DELETE_ACTIONS[token]
@@ -99,7 +101,7 @@ def normalize_fk_action(action: Any) -> str:
     """
     Normalize and validate SQL FK referential actions for migration DDL.
     """
-    token = _normalise_action_token(action)
+    token = _normalize_action_token(action)
     if token not in _DDL_FK_ACTIONS:
         raise ValueError(
             f"Invalid FK action: {action!r}. "

--- a/aksara/relations.py
+++ b/aksara/relations.py
@@ -55,6 +55,59 @@ class OnDelete(str, Enum):
         return self.value
 
 
+_RUNTIME_ON_DELETE_ACTIONS = {
+    "CASCADE": "CASCADE",
+    "SET NULL": "SET NULL",
+    "RESTRICT": "RESTRICT",
+    "PROTECT": "RESTRICT",
+}
+
+_DDL_FK_ACTIONS = {
+    **_RUNTIME_ON_DELETE_ACTIONS,
+    "SET DEFAULT": "SET DEFAULT",
+    "NO ACTION": "NO ACTION",
+    "DO NOTHING": "NO ACTION",
+}
+
+
+def _normalise_action_token(action: Any) -> str:
+    raw = getattr(action, "value", action)
+    return str(raw).strip().upper().replace("_", " ")
+
+
+def normalize_on_delete(action: Any, *, nullable: Optional[bool] = None) -> str:
+    """
+    Normalize and validate runtime FK/O2O ``on_delete`` values.
+
+    Runtime relation fields intentionally support the behaviours Aksara can
+    enforce today: CASCADE, SET NULL, and RESTRICT/PROTECT.
+    """
+    token = _normalise_action_token(action)
+    if token not in _RUNTIME_ON_DELETE_ACTIONS:
+        raise ValueError(
+            f"Invalid on_delete action: {action!r}. "
+            "Allowed: CASCADE, SET NULL, RESTRICT, PROTECT"
+        )
+
+    normalized = _RUNTIME_ON_DELETE_ACTIONS[token]
+    if normalized == OnDelete.SET_NULL.value and nullable is False:
+        raise ValueError("on_delete=SET NULL requires nullable=True")
+    return normalized
+
+
+def normalize_fk_action(action: Any) -> str:
+    """
+    Normalize and validate SQL FK referential actions for migration DDL.
+    """
+    token = _normalise_action_token(action)
+    if token not in _DDL_FK_ACTIONS:
+        raise ValueError(
+            f"Invalid FK action: {action!r}. "
+            f"Allowed: {', '.join(sorted(set(_DDL_FK_ACTIONS.values())))}"
+        )
+    return _DDL_FK_ACTIONS[token]
+
+
 class RelationMeta:
     """
     Metadata about a relation between two models.

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -6,6 +6,67 @@ All notable changes to Aksara.
 
 ---
 
+## v0.5.54 — ORM Write & Relation Correctness
+
+Unreleased.
+
+This release focuses on targeted write-path consistency and relation safety
+fixes from the ORM audit. It does not claim that all ORM correctness issues are
+fixed.
+
+### ORM Write & Relation Correctness
+
+#### Fixed
+
+- `bulk_create()` now aligns more closely with `create()` and `save()` for
+  auto-managed fields, including non-null `updated_at` values for default
+  timestamp fields.
+- `bulk_create()` now runs field preparation hooks before insertion, so fields
+  such as `Slug(auto_from=...)` behave consistently with `save()`.
+- `bulk_create()` now determines insert columns after row preparation and
+  preserves explicit per-row `auto_now_add` values such as `created_at` instead
+  of silently ignoring later-row values.
+- `QuerySet.update()` now has an explicit `updated_at` policy: auto-managed
+  `auto_now` fields are refreshed when regular fields are updated, while
+  caller-provided `updated_at` values are respected.
+- `bulk_update()` now casts `Vector` field CASE branch parameters with
+  `CAST($n AS vector)`, matching normal vector update behavior.
+- `ForeignKey` and `OneToOne` now validate `on_delete` values, normalize
+  supported casing/aliases, and reject unknown actions before DDL generation.
+- `on_delete=SET NULL` now requires `nullable=True` for `ForeignKey`,
+  `OneToOne`, and migration relation field operations.
+- Migration relation DDL now validates `ON DELETE` and `ON UPDATE` actions
+  before emitting SQL, so arbitrary text cannot be interpolated into relation
+  constraints.
+- `ManyToMany(..., through=...)` now fails clearly because custom through
+  models are not supported yet.
+- The forward FK access contract is documented: forward FK/O2O attributes
+  expose the stored FK value/id, while related objects should be loaded
+  explicitly or through `select_related()` plus `get_related()`.
+
+#### Tests
+
+- Added SQL-level and DB-backed regression coverage for `bulk_create()`
+  timestamp handling, async field preparation, mixed explicit/implicit
+  `created_at`, `QuerySet.update()` `updated_at` policy, F-expression updates,
+  vector `bulk_update()` casting, relation `on_delete` validation, nullable
+  `SET NULL` enforcement, migration DDL action validation, custom through
+  rejection, and forward FK id access.
+
+#### Remaining Known ORM Correctness Work
+
+- Lazy forward FK object loading is not implemented; use explicit queries or
+  `select_related()` with `get_related()`.
+- Custom ManyToMany through models remain intentionally unsupported.
+- Array item typing and nested array policy.
+- Vector precision policy.
+- FileField/ImageField `to_python()` contract.
+- JSON scalar behavior.
+- Other relation features intentionally not implemented by the current
+  relation manager APIs.
+
+---
+
 ## v0.5.53 — ORM Query Semantics & Migration Generation Correctness
 
 Released 2026-05-29.

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -26,9 +26,6 @@ fixed.
 - `bulk_create()` now determines insert columns after row preparation and
   preserves explicit per-row `auto_now_add` values such as `created_at` instead
   of silently ignoring later-row values.
-- `QuerySet.update()` now has an explicit `updated_at` policy: auto-managed
-  `auto_now` fields are refreshed when regular fields are updated, while
-  caller-provided `updated_at` values are respected.
 - `bulk_update()` now casts `Vector` field CASE branch parameters with
   `CAST($n AS vector)`, matching normal vector update behavior.
 - `ForeignKey` and `OneToOne` now validate `on_delete` values, normalize
@@ -43,6 +40,33 @@ fixed.
 - The forward FK access contract is documented: forward FK/O2O attributes
   expose the stored FK value/id, while related objects should be loaded
   explicitly or through `select_related()` plus `get_related()`.
+
+#### Changed
+
+- `QuerySet.update()` now refreshes `auto_now` fields such as `updated_at` when
+  regular fields are updated, matching `save()` more closely. Explicit
+  `updated_at` values are respected, and `update(updated_at=...)` does not
+  override itself.
+
+#### Compatibility / Behavior Changes
+
+- `ForeignKey(..., on_delete="SET_NULL")` and
+  `ForeignKey(..., on_delete="SET NULL")` now require `nullable=True`.
+  `SET NULL` on a non-nullable relation creates contradictory runtime and DDL
+  semantics: the delete policy needs to write `NULL`, while the column rejects
+  `NULL`.
+
+  Before:
+
+  ```python
+  author = fields.ForeignKey(User, on_delete="SET_NULL")
+  ```
+
+  Now:
+
+  ```python
+  author = fields.ForeignKey(User, on_delete="SET_NULL", nullable=True)
+  ```
 
 #### Tests
 

--- a/docs/docs/orm/relations.md
+++ b/docs/docs/orm/relations.md
@@ -63,15 +63,17 @@ Access the stored foreign-key value from the child:
 post = await Post.objects.get(id=post_id)
 
 # Forward FK fields currently expose the stored FK value/id.
-author_value = post.author
 author_id = post.author_id
+# post.author currently exposes the same stored FK value/id.
+same_author_id = post.author
 
 # Load the related object explicitly.
 author = await Author.objects.get(id=author_id)
 ```
 
-For eager loading, use `select_related()` and then read the loaded object with
-`get_related("author")`.
+Today, `post.author` and `post.author_id` expose the same stored FK value/id;
+`post.author` is not a lazy-loaded related object. For eager loading, use
+`select_related()` and then read the loaded object with `get_related("author")`.
 
 ### Reverse Access
 
@@ -193,7 +195,8 @@ class UserProfile(Model):
 
 ```python
 profile = await UserProfile.objects.get(id=profile_id)
-user_id = profile.user
+user_id = profile.user_id
+# profile.user currently exposes the same stored FK value/id.
 user = await User.objects.get(id=user_id)
 print(user.email)
 ```
@@ -343,7 +346,7 @@ child = await Category.objects.create(name="Phones", parent=parent)
 phones = await parent.children.all()
 
 # Access parent
-electronics_id = child.parent
+electronics_id = child.parent_id
 electronics = await Category.objects.get(id=electronics_id)
 ```
 

--- a/docs/docs/orm/relations.md
+++ b/docs/docs/orm/relations.md
@@ -16,7 +16,7 @@ Aksara supports three types of relationships:
 
 All relationships support:
 
-- **Forward access** — Access related objects from the defining model
+- **Forward access** — Access stored FK values or relation managers from the defining model
 - **Reverse access** — Access back from the related model
 - **AI metadata** — Relationship descriptions for LLMs
 
@@ -56,19 +56,22 @@ class Post(Model):
 
 ### Forward Access
 
-Access the related object from the child:
+Access the stored foreign-key value from the child:
 
 ```python
 # Get a post
 post = await Post.objects.get(id=post_id)
 
-# Access the author (async call for lazy loading)
-author = await post.author
-print(author.name)
-
-# Or access the raw FK value (synchronous)
+# Forward FK fields currently expose the stored FK value/id.
+author_value = post.author
 author_id = post.author_id
+
+# Load the related object explicitly.
+author = await Author.objects.get(id=author_id)
 ```
+
+For eager loading, use `select_related()` and then read the loaded object with
+`get_related("author")`.
 
 ### Reverse Access
 
@@ -190,7 +193,8 @@ class UserProfile(Model):
 
 ```python
 profile = await UserProfile.objects.get(id=profile_id)
-user = await profile.user
+user_id = profile.user
+user = await User.objects.get(id=user_id)
 print(user.email)
 ```
 
@@ -237,7 +241,7 @@ class Post(Model):
 |--------|------|---------|-------------|
 | `to` | `str` or `type` | Required | Target model |
 | `related_name` | `str` | `{model}_set` | Name for reverse relation |
-| `through` | `str` | Auto-generated | Custom junction table |
+| `through` | `str` | Unsupported | Custom through models are not supported yet |
 
 ### Forward Access
 
@@ -291,27 +295,9 @@ CREATE TABLE post_tags (
 
 ### Custom Through Model
 
-For additional data on the relationship:
-
-```python
-class PostTag(Model):
-    """Junction table with extra fields."""
-    post = fields.ForeignKey(Post, on_delete=CASCADE)
-    tag = fields.ForeignKey(Tag, on_delete=CASCADE)
-    added_at = fields.DateTime(auto_now_add=True)
-    added_by = fields.ForeignKey(User, on_delete=SET_NULL, nullable=True)
-    
-    class Meta:
-        unique_together = [("post", "tag")]
-
-class Post(Model):
-    title = fields.String(max_length=200)
-    tags = fields.ManyToMany(
-        Tag,
-        through="PostTag",  # Use custom junction
-        related_name="posts",
-    )
-```
+Custom through models are not supported yet. Passing `through=` raises a clear
+configuration error instead of silently creating a join table that cannot store
+the custom model's extra fields.
 
 ---
 
@@ -357,7 +343,8 @@ child = await Category.objects.create(name="Phones", parent=parent)
 phones = await parent.children.all()
 
 # Access parent
-electronics = await child.parent
+electronics_id = child.parent
+electronics = await Category.objects.get(id=electronics_id)
 ```
 
 ---
@@ -385,12 +372,13 @@ Avoid N+1 queries by loading related objects in one query:
 # Without select_related: N+1 queries
 posts = await Post.objects.all()
 for post in posts:
-    author = await post.author  # Query per post!
+    author = await Author.objects.get(id=post.author_id)  # Query per post
 
 # With select_related: Single query
 posts = await Post.objects.select_related("author").all()
 for post in posts:
-    print(post.author.name)  # Already loaded
+    author = post.get_related("author")
+    print(author.name)
 ```
 
 ### Prefetch Related (For M2M)
@@ -399,7 +387,7 @@ for post in posts:
 # Efficient M2M loading
 posts = await Post.objects.prefetch_related("tags").all()
 for post in posts:
-    for tag in post.tags:
+    for tag in post.get_prefetched_m2m("tags"):
         print(tag.name)
 ```
 

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -199,6 +199,43 @@ class TestForeignKeyField:
         assert 'REFERENCES "users"(id)' in constraint
         assert "ON DELETE CASCADE" in constraint
 
+    def test_constraint_sql_normalizes_lowercase_on_delete(self):
+        field = op.ForeignKeyField("users", on_delete="cascade")
+        constraint = field.get_constraint_sql("author_id")
+        assert "ON DELETE CASCADE" in constraint
+
+    def test_to_sql_rejects_invalid_on_delete(self):
+        field = op.ForeignKeyField("users", on_delete="DROP TABLE x")
+        with pytest.raises(ValueError, match="Invalid FK action"):
+            field.to_sql()
+
+    def test_constraint_sql_rejects_invalid_on_delete(self):
+        field = op.ForeignKeyField("users", on_delete="DROP TABLE x")
+        with pytest.raises(ValueError, match="Invalid FK action"):
+            field.get_constraint_sql("author_id")
+
+    def test_set_null_requires_nullable_true(self):
+        field = op.ForeignKeyField("users", on_delete="SET NULL", nullable=False)
+        with pytest.raises(ValueError, match="SET NULL requires nullable=True"):
+            field.to_sql()
+
+    def test_set_null_nullable_true_passes(self):
+        field = op.ForeignKeyField("users", on_delete="SET NULL", nullable=True)
+        sql = field.to_sql()
+        constraint = field.get_constraint_sql("author_id")
+        assert "NOT NULL" not in sql
+        assert "ON DELETE SET NULL" in constraint
+
+    def test_one_to_one_to_sql_rejects_invalid_on_delete(self):
+        field = op.OneToOneField("users", on_delete="DROP TABLE x")
+        with pytest.raises(ValueError, match="Invalid FK action"):
+            field.to_sql()
+
+    def test_one_to_one_set_null_requires_nullable_true(self):
+        field = op.OneToOneField("users", on_delete="SET NULL", nullable=False)
+        with pytest.raises(ValueError, match="SET NULL requires nullable=True"):
+            field.to_sql()
+
 
 # =============================================================================
 # Index Operation Tests

--- a/tests/test_jsonb_vector_features.py
+++ b/tests/test_jsonb_vector_features.py
@@ -101,3 +101,34 @@ class TestVectorFieldIntegration:
         fetched = await EmbeddingRecord.objects.get(id=created.id)
 
         assert fetched.embedding == [1.0, 2.0, 3.0]
+
+    @pytest.mark.asyncio
+    async def test_bulk_update_vectors_when_extension_available(self, db):
+        extension_available = await db.fetchval(
+            "SELECT EXISTS(SELECT 1 FROM pg_available_extensions WHERE name = 'vector')"
+        )
+        if not extension_available:
+            pytest.skip("pgvector extension is not available")
+
+        await db.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+        class EmbeddingRecord(Model):
+            title = fields.String(max_length=200)
+            embedding = fields.Vector(dimensions=3)
+
+            class Meta:
+                table_name = "json_vector_records"
+
+        await db.execute(EmbeddingRecord.get_create_table_sql())
+
+        created = await EmbeddingRecord.objects.create(
+            title="Vector",
+            embedding=[1, 2, 3],
+        )
+        created.embedding = [4, 5, 6]
+
+        updated = await EmbeddingRecord.objects.bulk_update([created], ["embedding"])
+        fetched = await EmbeddingRecord.objects.get(id=created.id)
+
+        assert updated == 1
+        assert fetched.embedding == [4.0, 5.0, 6.0]

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -319,9 +319,27 @@ class TestWritePathSQL:
         assert params == (explicit_updated,)
 
     @pytest.mark.asyncio
-    async def test_bulk_update_vector_casts_case_values(self):
+    async def test_queryset_update_vector_subclass_uses_vector_cast(self):
+        class CustomVector(fields.Vector):
+            pass
+
         class Embedding(Model):
-            embedding = fields.Vector(dimensions=3)
+            embedding = CustomVector(dimensions=3)
+
+        db = _CapturingDB(execute_return="UPDATE 1")
+        with patch("aksara.db.Database.get_instance", return_value=db):
+            await QuerySet(Embedding).update(embedding=[1, 2, 3])
+
+        query = db.execute.await_args.args[0]
+        assert '"embedding" = CAST($1 AS vector)' in query
+
+    @pytest.mark.asyncio
+    async def test_bulk_update_vector_casts_case_values(self):
+        class CustomVector(fields.Vector):
+            pass
+
+        class Embedding(Model):
+            embedding = CustomVector(dimensions=3)
 
         instance = Embedding(embedding=[1, 2, 3])
         instance._is_new = False
@@ -336,6 +354,23 @@ class TestWritePathSQL:
         normalized = " ".join(query.split())
         assert 'WHEN "id" = $1 THEN CAST($2 AS vector)' in normalized
         assert '"embedding" = CASE' in normalized
+
+    @pytest.mark.asyncio
+    async def test_bulk_create_vector_subclass_uses_vector_cast(self):
+        class CustomVector(fields.Vector):
+            pass
+
+        class Embedding(Model):
+            embedding = CustomVector(dimensions=3)
+
+        instance = Embedding(embedding=[1, 2, 3])
+
+        db = _CapturingDB()
+        with patch("aksara.db.Database.get_instance", return_value=db):
+            await Embedding.objects.bulk_create([instance])
+
+        query = db.fetch.await_args.args[0]
+        assert "CAST($1 AS vector)" in query
 
 
 class TestExceptions:
@@ -453,17 +488,23 @@ class TestWritePathDatabase:
         await db.execute(BulkCreatedAtUser.get_create_table_sql())
 
         try:
-            await BulkCreatedAtUser.objects.bulk_create([
-                BulkCreatedAtUser(email="first@example.com"),
-                BulkCreatedAtUser(
-                    email="second@example.com",
-                    created_at=explicit_created,
-                ),
-            ])
+            first_obj = BulkCreatedAtUser(email="first@example.com")
+            second_obj = BulkCreatedAtUser(
+                email="second@example.com",
+                created_at=explicit_created,
+            )
+            returned = await BulkCreatedAtUser.objects.bulk_create([first_obj, second_obj])
 
             first = await BulkCreatedAtUser.objects.get(email="first@example.com")
             second = await BulkCreatedAtUser.objects.get(email="second@example.com")
 
+            assert returned == [first_obj, second_obj]
+            assert first_obj.created_at is not None
+            assert first_obj.created_at == first.created_at
+            assert second_obj.created_at == explicit_created
+            assert second_obj.created_at == second.created_at
+            assert first_obj._is_new is False
+            assert second_obj._is_new is False
             assert first.created_at is not None
             assert second.created_at == explicit_created
         finally:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -4,13 +4,25 @@ Tests for QuerySet and Manager
 Unit tests for the query API.
 """
 
+import asyncio
 import os
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
 from aksara import Model, fields
+from aksara.db.expressions import F
 from aksara.manager import QuerySet, Manager, DoesNotExist, MultipleObjectsReturned
 from aksara.registry import ModelRegistry
+
+
+class _CapturingDB:
+    """Stand-in for the Database singleton that records write calls."""
+
+    def __init__(self, fetch_return=None, execute_return="UPDATE 0"):
+        self.fetch = AsyncMock(return_value=fetch_return or [])
+        self.execute = AsyncMock(return_value=execute_return)
 
 
 @pytest.fixture(autouse=True)
@@ -225,6 +237,107 @@ class TestManager:
         assert qs._filters == {"email": "test@example.com"}
 
 
+class TestWritePathSQL:
+    """SQL-level regressions for write-path consistency fixes."""
+
+    @pytest.mark.asyncio
+    async def test_bulk_create_prepares_slug_and_keeps_later_explicit_created_at(self):
+        class Article(Model):
+            title = fields.String(max_length=200)
+            slug = fields.Slug(max_length=200, auto_from="title")
+
+        explicit_created = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        first = Article(title="Hello World")
+        second = Article(title="Second Post", created_at=explicit_created)
+
+        db = _CapturingDB()
+        with patch("aksara.db.Database.get_instance", return_value=db):
+            await Article.objects.bulk_create([first, second])
+
+        query = db.fetch.await_args.args[0]
+        params = db.fetch.await_args.args[1:]
+
+        assert first.slug == "hello-world"
+        assert second.slug == "second-post"
+        assert first.updated_at is not None
+        assert second.updated_at is not None
+        assert '"created_at"' in query
+        assert "DEFAULT" in query
+        assert explicit_created in params
+
+    @pytest.mark.asyncio
+    async def test_bulk_create_auto_now_overwrites_explicit_updated_at_like_save(self):
+        class Article(Model):
+            title = fields.String(max_length=200)
+
+        explicit_updated = datetime(1999, 1, 1, tzinfo=timezone.utc)
+        article = Article(title="Old timestamp", updated_at=explicit_updated)
+
+        db = _CapturingDB()
+        with patch("aksara.db.Database.get_instance", return_value=db):
+            await Article.objects.bulk_create([article])
+
+        params = db.fetch.await_args.args[1:]
+        assert article.updated_at is not None
+        assert article.updated_at != explicit_updated
+        assert explicit_updated not in params
+
+    @pytest.mark.asyncio
+    async def test_queryset_update_adds_auto_now_for_regular_updates(self):
+        class User(Model):
+            age = fields.Integer(default=0)
+
+        db = _CapturingDB(execute_return="UPDATE 1")
+        with patch("aksara.db.Database.get_instance", return_value=db):
+            updated = await QuerySet(User).filter(age__gte=0).update(age=F("age") + 1)
+
+        query = db.execute.await_args.args[0]
+        params = db.execute.await_args.args[1:]
+
+        assert updated == 1
+        assert '"age" = ("age" + $1)' in query
+        assert '"updated_at" = $2' in query
+        assert 'WHERE "age" >= $3' in query
+        assert params[0] == 1
+        assert isinstance(params[1], datetime)
+        assert params[2] == 0
+
+    @pytest.mark.asyncio
+    async def test_queryset_update_respects_explicit_updated_at_only_update(self):
+        class User(Model):
+            age = fields.Integer(default=0)
+
+        explicit_updated = datetime(2001, 1, 1, tzinfo=timezone.utc)
+        db = _CapturingDB(execute_return="UPDATE 1")
+        with patch("aksara.db.Database.get_instance", return_value=db):
+            await QuerySet(User).update(updated_at=explicit_updated)
+
+        query = db.execute.await_args.args[0]
+        params = db.execute.await_args.args[1:]
+
+        assert query.count('"updated_at"') == 1
+        assert params == (explicit_updated,)
+
+    @pytest.mark.asyncio
+    async def test_bulk_update_vector_casts_case_values(self):
+        class Embedding(Model):
+            embedding = fields.Vector(dimensions=3)
+
+        instance = Embedding(embedding=[1, 2, 3])
+        instance._is_new = False
+        instance._data["id"] = uuid4()
+        instance.embedding = [4, 5, 6]
+
+        db = _CapturingDB(execute_return="UPDATE 1")
+        with patch("aksara.db.Database.get_instance", return_value=db):
+            await Embedding.objects.bulk_update([instance], ["embedding"])
+
+        query = db.execute.await_args.args[0]
+        normalized = " ".join(query.split())
+        assert 'WHEN "id" = $1 THEN CAST($2 AS vector)' in normalized
+        assert '"embedding" = CASE' in normalized
+
+
 class TestExceptions:
     """Tests for ORM exceptions."""
     
@@ -297,3 +410,125 @@ class TestQuerySetNullDatabase:
         users = await null_user_model.objects.filter(email__isnull="False").all()
 
         assert [user.id for user in users] == [present_user.id]
+
+
+@pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="DATABASE_URL not set")
+class TestWritePathDatabase:
+    """DB-backed regressions for ORM write-path consistency."""
+
+    @pytest.mark.asyncio
+    async def test_bulk_create_sets_updated_at_for_single_and_multiple_rows(self, db):
+        class BulkTimestampUser(Model):
+            __tablename__ = "bulk_timestamp_users_v054"
+            email = fields.String(max_length=255)
+
+        await db.execute('DROP TABLE IF EXISTS "bulk_timestamp_users_v054" CASCADE')
+        await db.execute(BulkTimestampUser.get_create_table_sql())
+
+        try:
+            created = await BulkTimestampUser.objects.create(email="create@example.com")
+            single = await BulkTimestampUser.objects.bulk_create([
+                BulkTimestampUser(email="bulk-one@example.com")
+            ])
+            many = await BulkTimestampUser.objects.bulk_create([
+                BulkTimestampUser(email="bulk-two@example.com"),
+                BulkTimestampUser(email="bulk-three@example.com"),
+            ])
+
+            assert created.updated_at is not None
+            assert single[0].updated_at is not None
+            assert all(user.updated_at is not None for user in many)
+        finally:
+            await db.execute('DROP TABLE IF EXISTS "bulk_timestamp_users_v054" CASCADE')
+
+    @pytest.mark.asyncio
+    async def test_bulk_create_preserves_later_explicit_created_at(self, db):
+        class BulkCreatedAtUser(Model):
+            __tablename__ = "bulk_created_at_users_v054"
+            email = fields.String(max_length=255)
+
+        explicit_created = datetime(2000, 1, 1, tzinfo=timezone.utc)
+
+        await db.execute('DROP TABLE IF EXISTS "bulk_created_at_users_v054" CASCADE')
+        await db.execute(BulkCreatedAtUser.get_create_table_sql())
+
+        try:
+            await BulkCreatedAtUser.objects.bulk_create([
+                BulkCreatedAtUser(email="first@example.com"),
+                BulkCreatedAtUser(
+                    email="second@example.com",
+                    created_at=explicit_created,
+                ),
+            ])
+
+            first = await BulkCreatedAtUser.objects.get(email="first@example.com")
+            second = await BulkCreatedAtUser.objects.get(email="second@example.com")
+
+            assert first.created_at is not None
+            assert second.created_at == explicit_created
+        finally:
+            await db.execute('DROP TABLE IF EXISTS "bulk_created_at_users_v054" CASCADE')
+
+    @pytest.mark.asyncio
+    async def test_bulk_create_runs_async_prepare_for_slug(self, db):
+        class BulkSlugArticle(Model):
+            __tablename__ = "bulk_slug_articles_v054"
+            title = fields.String(max_length=200)
+            slug = fields.Slug(max_length=200, auto_from="title")
+
+        await db.execute('DROP TABLE IF EXISTS "bulk_slug_articles_v054" CASCADE')
+        await db.execute(BulkSlugArticle.get_create_table_sql())
+
+        try:
+            bulk = await BulkSlugArticle.objects.bulk_create([
+                BulkSlugArticle(title="Hello World")
+            ])
+            created = await BulkSlugArticle.objects.create(title="Hello World")
+
+            assert bulk[0].slug == "hello-world"
+            assert created.slug == "hello-world"
+        finally:
+            await db.execute('DROP TABLE IF EXISTS "bulk_slug_articles_v054" CASCADE')
+
+    @pytest.mark.asyncio
+    async def test_queryset_update_updated_at_policy(self, db):
+        class UpdatePolicyUser(Model):
+            __tablename__ = "update_policy_users_v054"
+            email = fields.String(max_length=255)
+            age = fields.Integer(default=0)
+
+        await db.execute('DROP TABLE IF EXISTS "update_policy_users_v054" CASCADE')
+        await db.execute(UpdatePolicyUser.get_create_table_sql())
+
+        try:
+            user = await UpdatePolicyUser.objects.create(
+                email="update-policy@example.com",
+                age=0,
+            )
+            initial_updated_at = user.updated_at
+
+            await asyncio.sleep(0.01)
+            await UpdatePolicyUser.objects.filter(id=user.id).update(age=1)
+            after_age_update = await UpdatePolicyUser.objects.get(id=user.id)
+
+            assert after_age_update.age == 1
+            assert after_age_update.updated_at > initial_updated_at
+
+            explicit_updated = datetime(2001, 1, 1, tzinfo=timezone.utc)
+            await UpdatePolicyUser.objects.filter(id=user.id).update(
+                updated_at=explicit_updated
+            )
+            after_explicit_update = await UpdatePolicyUser.objects.get(id=user.id)
+
+            assert after_explicit_update.updated_at == explicit_updated
+
+            await asyncio.sleep(0.01)
+            await UpdatePolicyUser.objects.filter(id=user.id).update(
+                age=F("age") + 1
+            )
+            after_f_update = await UpdatePolicyUser.objects.get(id=user.id)
+
+            assert after_f_update.age == 2
+            assert after_f_update.updated_at > explicit_updated
+        finally:
+            await db.execute('DROP TABLE IF EXISTS "update_policy_users_v054" CASCADE')

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -33,6 +33,61 @@ class MockArticle(Model):
         table = "articles"
 
 
+class TestForeignKeySafety:
+    """Tests for FK/O2O relation configuration safety."""
+
+    def test_foreign_key_on_delete_accepts_valid_values(self):
+        field = ForeignKey(MockCategory, on_delete="CASCADE")
+        assert field.on_delete == "CASCADE"
+
+    def test_foreign_key_on_delete_normalizes_case(self):
+        field = ForeignKey(MockCategory, on_delete="cascade")
+        assert field.on_delete == "CASCADE"
+
+    def test_foreign_key_on_delete_normalizes_set_null_constant_style(self):
+        field = ForeignKey(MockCategory, on_delete="SET_NULL", nullable=True)
+        assert field.on_delete == "SET NULL"
+
+    def test_foreign_key_protect_aliases_to_restrict(self):
+        field = ForeignKey(MockCategory, on_delete="PROTECT")
+        assert field.on_delete == "RESTRICT"
+
+    def test_foreign_key_rejects_invalid_on_delete(self):
+        with pytest.raises(ValueError, match="Invalid on_delete action.*Allowed"):
+            ForeignKey(MockCategory, on_delete="DROP TABLE users")
+
+    def test_one_to_one_rejects_invalid_on_delete(self):
+        with pytest.raises(ValueError, match="Invalid on_delete action.*Allowed"):
+            OneToOne(MockCategory, on_delete="DROP TABLE users")
+
+    def test_foreign_key_set_null_requires_nullable_true(self):
+        with pytest.raises(ValueError, match="SET NULL requires nullable=True"):
+            ForeignKey(MockCategory, on_delete="SET NULL", nullable=False)
+
+    def test_foreign_key_set_null_nullable_true_passes(self):
+        field = ForeignKey(MockCategory, on_delete="SET NULL", nullable=True)
+        assert field.on_delete == "SET NULL"
+        assert field.nullable is True
+
+    def test_one_to_one_set_null_requires_nullable_true(self):
+        with pytest.raises(ValueError, match="SET NULL requires nullable=True"):
+            OneToOne(MockCategory, on_delete="SET NULL", nullable=False)
+
+    def test_forward_fk_access_returns_stored_id_and_alias(self):
+        class Author(Model):
+            name = String(max_length=100)
+
+        class Post(Model):
+            title = String(max_length=100)
+            author = ForeignKey(Author)
+
+        author_id = uuid4()
+        post = Post(title="Contract", author_id=author_id)
+
+        assert post.author == author_id
+        assert post.author_id == author_id
+
+
 class TestOneToOneField:
     """Tests for OneToOne field."""
     
@@ -76,7 +131,7 @@ class TestOneToOneField:
         assert field.on_delete == "CASCADE"
     
     def test_on_delete_custom(self):
-        field = OneToOne(MockCategory, on_delete="SET NULL")
+        field = OneToOne(MockCategory, on_delete="SET NULL", nullable=True)
         assert field.on_delete == "SET NULL"
     
     def test_to_model(self):
@@ -103,6 +158,10 @@ class TestManyToManyField:
     def test_related_name(self):
         field = ManyToMany(MockTag, related_name="articles")
         assert field.related_name == "articles"
+
+    def test_custom_through_model_is_rejected_until_supported(self):
+        with pytest.raises(ValueError, match="Custom through models are not supported yet"):
+            ManyToMany(MockTag, through=MockArticle)
     
     def test_join_table_name_generation(self):
         field = ManyToMany(MockTag)

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -12,6 +12,7 @@ from aksara.fields import (
     ManyToManyManager,
 )
 from aksara.model.base import Model
+from aksara.relations import OnDelete
 
 
 # Mock models for testing
@@ -53,8 +54,21 @@ class TestForeignKeySafety:
         assert field.on_delete == "RESTRICT"
 
     def test_foreign_key_rejects_invalid_on_delete(self):
-        with pytest.raises(ValueError, match="Invalid on_delete action.*Allowed"):
+        with pytest.raises(ValueError, match="Invalid on_delete action.*Allowed") as exc_info:
             ForeignKey(MockCategory, on_delete="DROP TABLE users")
+
+        message = str(exc_info.value)
+        assert "CASCADE" in message
+        assert "SET NULL" in message
+        assert "RESTRICT" in message
+        assert "PROTECT" in message
+        assert "case-insensitive" in message
+        assert "SET_NULL" in message
+        assert "OnDelete enum" in message
+
+    def test_foreign_key_accepts_on_delete_enum_instances(self):
+        field = ForeignKey(MockCategory, on_delete=OnDelete.CASCADE)
+        assert field.on_delete == "CASCADE"
 
     def test_one_to_one_rejects_invalid_on_delete(self):
         with pytest.raises(ValueError, match="Invalid on_delete action.*Allowed"):

--- a/tests/test_v02_features.py
+++ b/tests/test_v02_features.py
@@ -345,7 +345,7 @@ class TestForeignKey:
     
     def test_foreign_key_on_delete_set_null(self):
         """Test ForeignKey with SET NULL on delete."""
-        fk = fields.ForeignKey("User", on_delete="SET NULL")
+        fk = fields.ForeignKey("User", on_delete="SET NULL", nullable=True)
         assert fk.on_delete == "SET NULL"
     
     def test_foreign_key_default_sql_type(self):

--- a/tests/test_v045_orm_expressions.py
+++ b/tests/test_v045_orm_expressions.py
@@ -270,9 +270,15 @@ class TestUpdateExpressions:
         assert updated == 3
         query = fake_db.execute.await_args.args[0]
         params = fake_db.execute.await_args.args[1:]
-        assert 'UPDATE "metric_records" SET "views" = ("views" + $1), "title" = $2' in query
-        assert 'WHERE "likes" >= $3' in query
-        assert params == (1, "popular", 10)
+        assert (
+            'UPDATE "metric_records" SET "views" = ("views" + $1), '
+            '"title" = $2, "updated_at" = $3'
+        ) in query
+        assert 'WHERE "likes" >= $4' in query
+        assert params[0] == 1
+        assert params[1] == "popular"
+        assert isinstance(params[2], datetime)
+        assert params[3] == 10
 
     def test_from_record_handles_iterator_keys_and_assigns_annotation_attributes(self):
         class FakeAsyncpgRecord:


### PR DESCRIPTION
## Summary

This PR prepares the `v0.5.54` ORM correctness release.

It expands the write-path consistency work with relation safety fixes, making the release:

`v0.5.54 — ORM Write & Relation Correctness`

## Write-path consistency

- `bulk_create()` now prepares rows before insert.
- `bulk_create()` applies `auto_now` timestamps before insert.
- `bulk_create()` runs field `async_prepare()` hooks.
- `Slug(auto_from=...)` now works through `bulk_create()`.
- Mixed implicit/explicit `auto_now_add` values now preserve explicit later-row values using per-row `DEFAULT`.
- `QuerySet.update()` now has an explicit `updated_at` / `auto_now` policy:
  - regular field updates refresh auto-managed update fields
  - explicit `updated_at` values are respected
  - `update(updated_at=...)` does not override itself
- `bulk_update()` now casts Vector values inside CASE branches with `CAST($n AS vector)`.

## Relation correctness and DDL safety

- Added shared `on_delete` normalization and validation.
- `ForeignKey` and `OneToOne` now accept valid `on_delete` values and normalize common casing/aliases.
- Invalid arbitrary `on_delete` text is rejected before it reaches DDL generation.
- `SET_NULL` / `SET NULL` now requires `nullable=True`.
- Migration relation FieldOps validate `on_delete` before SQL generation.
- `ManyToMany(..., through=...)` now raises a clear error because custom through models are not supported yet.
- Forward FK access contract is documented and test-locked:
  - `post.author` exposes the stored FK id
  - `post.author_id` exposes the DB-column alias
  - use explicit queries or `select_related()` + `get_related()` for related objects

## Tests

Added/updated coverage in:

- `tests/test_manager.py`
- `tests/test_jsonb_vector_features.py`
- `tests/test_v045_orm_expressions.py`
- `tests/test_relations.py`
- `tests/migrations/test_operations.py`
- `tests/test_v02_features.py`

## Validation

- Relation DB group: `81 passed`
- Migration operations/autodetector: `104 passed`
- Write-path regression group: `84 passed`
- Full suite: `7737 passed, 3 skipped`
- `mkdocs build --strict`: passed
- Wheel build: passed, built current `0.5.53` wheel
- `twine check dist/*.whl`: passed
- `git diff --check`: clean

## Notes

Package version remains `0.5.53`.

Remaining ORM correctness work is intentionally out of scope:

- lazy forward FK object loading
- custom through model support
- array item/nested array policy
- vector precision policy
- `FileField` / `ImageField.to_python()` contract
- JSON scalar behavior
- relation features not implemented by the current relation manager APIs